### PR TITLE
Basic support for `@constructor`

### DIFF
--- a/codegen/builtin_types.py
+++ b/codegen/builtin_types.py
@@ -268,6 +268,10 @@ class StructDefinition(TypeDefinition):
 
         return this_size
 
+    @cached_property
+    def is_struct(self) -> bool:
+        return True
+
     def __repr__(self) -> str:
         return f"StructDefinition({', '.join(map(repr, self._members))})"
 

--- a/codegen/builtin_types.py
+++ b/codegen/builtin_types.py
@@ -282,7 +282,7 @@ class StructDefinition(TypeDefinition):
         return self._uuid == other._uuid
 
     def __hash__(self) -> int:
-        return self._uuid.__hash__()
+        return hash(self._uuid)
 
 
 class ArrayDefinition(TypeDefinition):

--- a/codegen/builtin_types.py
+++ b/codegen/builtin_types.py
@@ -281,6 +281,9 @@ class StructDefinition(TypeDefinition):
             return False
         return self._uuid == other._uuid
 
+    def __hash__(self) -> int:
+        return self._uuid.__hash__()
+
 
 class ArrayDefinition(TypeDefinition):
     UNKNOWN_DIMENSION = 0

--- a/codegen/constructors/simple/main.c3
+++ b/codegen/constructors/simple/main.c3
@@ -1,0 +1,22 @@
+typedef my_struct : { a: int, b: int };
+
+@constructor : (this: my_struct&) -> () = {
+    this.a = 1;
+    this.b = 2;
+};
+
+@constructor : (this: my_struct&, a_: int) -> () = {
+    this.a = a_;
+    this.b = 2;
+};
+
+@constructor : (this: my_struct&, a_: int, b_: int) -> () = {
+    this.a = a_;
+    this.b = b_;
+};
+
+function main : () -> int = {
+    let s : my_struct = {}; // Should call the default constructor.
+    let s : my_struct = { 4 };
+    let s : my_struct = { 4, 5 };
+};

--- a/codegen/constructors/simple/test.json
+++ b/codegen/constructors/simple/test.json
@@ -1,0 +1,22 @@
+{
+    "compile": {
+        "command": [
+            "python",
+            "../../../driver.py",
+            "main.c3",
+            "-o",
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 0
+        }
+    },
+    "runtime": {
+        "command": [
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 0
+        }
+    }
+}

--- a/codegen/expressions.py
+++ b/codegen/expressions.py
@@ -47,8 +47,12 @@ class ConstantExpression(TypedExpression):
 
 
 class VariableReference(TypedExpression):
-    def __init__(self, variable: Variable) -> None:
-        super().__init__(variable.type.to_unborrowed_ref())
+    def __init__(self, variable: Variable, borrow: bool) -> None:
+        var_type = variable.type.to_unborrowed_ref()
+        if borrow:
+            var_type = var_type.to_borrowed_ref()
+
+        super().__init__(var_type)
 
         self.variable = variable
 

--- a/codegen/interfaces.py
+++ b/codegen/interfaces.py
@@ -43,6 +43,10 @@ class TypeDefinition(ABC):
     def is_void(self) -> bool:
         return False
 
+    @cached_property
+    def is_struct(self) -> bool:
+        return False
+
     @abstractmethod
     def __repr__(self) -> str:
         pass
@@ -111,6 +115,10 @@ class Type:
     @property
     def is_void(self) -> bool:
         return self.definition.is_void
+
+    @property
+    def is_struct(self) -> bool:
+        return self.definition.is_struct
 
     @property
     def generic_annotation(self) -> str:

--- a/codegen/translation_unit.py
+++ b/codegen/translation_unit.py
@@ -160,12 +160,10 @@ class FunctionSymbolTable:
             return tuple(sum(pair) for pair in zip(lhs, rhs))
 
         for function in candidate_functions:
-            per_arg = list(
-                map(
-                    get_implicit_conversion_cost,
-                    fn_args,
-                    function.get_signature().arguments,
-                )
+            per_arg = map(
+                get_implicit_conversion_cost,
+                fn_args,
+                function.get_signature().arguments,
             )
 
             costs = reduce(tuple_add, per_arg, (0, 0))

--- a/codegen/user_facing_errors.py
+++ b/codegen/user_facing_errors.py
@@ -53,12 +53,12 @@ class OverloadResolutionError(GrapheneError):
 
         # TODO need a better way to indent these.
         if available_overloads:
-            msg.append("   Available overloads:")
+            msg.append("    Available overloads:")
 
             for overload in available_overloads:
                 msg.append("     - " + overload)
         else:
-            msg.append("   No overloads available")
+            msg.append("    No overloads available")
 
         super().__init__(str.join("\n", msg))
 

--- a/codegen/user_facing_errors.py
+++ b/codegen/user_facing_errors.py
@@ -217,3 +217,8 @@ class InvalidMainReturnType(GrapheneError):
             f"Error: type '{actual_type}' is not a valid return type for"
             " function 'main'; expected 'int'"
         )
+
+
+class EmptyConstructorError(GrapheneError):
+    def __init__(self) -> None:
+        super().__init__("Error: a constructor must have at least one argument")

--- a/codegen/user_facing_errors.py
+++ b/codegen/user_facing_errors.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Literal
+from typing import Iterable, Literal, Optional
 
 from lark import Token
 
@@ -222,3 +222,23 @@ class InvalidMainReturnType(GrapheneError):
 class EmptyConstructorError(GrapheneError):
     def __init__(self) -> None:
         super().__init__("Error: a constructor must have at least one argument")
+
+
+class ConstructorInvalidThisType(GrapheneError):
+    def __init__(self, actual_type: str, suggested_type: Optional[str] = None) -> None:
+        msg = (
+            "Error: a constructor's first argument must be a reference to a "
+            f"struct, not '{actual_type}'"
+        )
+
+        if suggested_type:
+            msg += f". Did you mean '{suggested_type}'?"
+
+        super().__init__(msg)
+
+
+class ConstructorInvalidReturnType(GrapheneError):
+    def __init__(self, actual_type: str) -> None:
+        super().__init__(
+            f"Error: a constructor's return type must be 'void', not '{actual_type}'"
+        )

--- a/parser.py
+++ b/parser.py
@@ -656,7 +656,7 @@ def initialize_struct_variable(
 ) -> list[cg.Generatable]:
     generatables: list[cg.Generatable] = []
 
-    if not isinstance(var_type.definition, cg.StructDefinition):
+    if not isinstance(var_type.definition, cg.StructDefinition) or var_type.is_pointer:
         raise InvalidInitializerListAssignment(
             var_type.get_user_facing_name(False), rhs.user_facing_name
         )

--- a/parser.py
+++ b/parser.py
@@ -674,11 +674,11 @@ def initialize_struct_variable(
         ]
     )
 
+    var_ref = cg.VariableReference(var)
+    generatables.append(var_ref)
+
     for name, expr in zip(names, rhs.exprs):
         generatables.extend(expr.subexpressions)
-
-        var_ref = cg.VariableReference(var)
-        generatables.append(var_ref)
 
         struct_access = cg.StructMemberAccess(var_ref, name)
         generatables.append(struct_access)

--- a/tests/constructors/correct_overload_resolution/main.c3
+++ b/tests/constructors/correct_overload_resolution/main.c3
@@ -1,0 +1,20 @@
+typedef my_struct : { a: int, b: int };
+
+@constructor : (this: my_struct&) -> void = {
+    this.a = 0;
+    this.b = 0;
+};
+
+@constructor : (this: my_struct&, a_: int) -> void = {
+    this.a = a_;
+    this.b = 3;
+};
+
+@operator + : (a: int, b: int) -> int = {
+    return __builtin_add(a, b);
+};
+
+function main : () -> int = {
+    const s : my_struct = { 2 };
+    return s.a + s.b;
+};

--- a/tests/constructors/correct_overload_resolution/test.json
+++ b/tests/constructors/correct_overload_resolution/test.json
@@ -1,0 +1,22 @@
+{
+    "compile": {
+        "command": [
+            "python",
+            "../../../driver.py",
+            "main.c3",
+            "-o",
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 0
+        }
+    },
+    "runtime": {
+        "command": [
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 5
+        }
+    }
+}

--- a/tests/constructors/empty_constructor/main.c3
+++ b/tests/constructors/empty_constructor/main.c3
@@ -1,0 +1,1 @@
+@constructor : () -> void = {};

--- a/tests/constructors/empty_constructor/test.json
+++ b/tests/constructors/empty_constructor/test.json
@@ -1,0 +1,18 @@
+{
+    "compile": {
+        "command": [
+            "python",
+            "../../../driver.py",
+            "main.c3",
+            "-o",
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 1,
+            "stderr": [
+                "File '*/main.c3', line 1, in '@constructor signature'",
+                "Error: a constructor must have at least one argument"
+            ]
+        }
+    }
+}

--- a/tests/constructors/init_list_invalid/main.c3
+++ b/tests/constructors/init_list_invalid/main.c3
@@ -1,0 +1,12 @@
+typedef my_struct : { a: int, b: int };
+
+@constructor : (this: my_struct&) -> void = {};
+
+@operator + : (a: int, b: int) -> int = {
+    return __builtin_add(a, b);
+};
+
+function main : () -> int = {
+    const s : my_struct = { 1, 2 };
+    return s.a + s.b;
+};

--- a/tests/constructors/init_list_invalid/test.json
+++ b/tests/constructors/init_list_invalid/test.json
@@ -1,0 +1,20 @@
+{
+    "compile": {
+        "command": [
+            "python",
+            "../../../driver.py",
+            "main.c3",
+            "-o",
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 1,
+            "stderr": [
+                "File '*/main.c3', line 10, in 'function main: () -> int'",
+                "Error: overload resolution for function call '@constructor(my_struct& (borrowed), int, int)' failed",
+                "Available overloads:",
+                "- function @constructor: (my_struct&) -> void"
+            ]
+        }
+    }
+}

--- a/tests/constructors/init_list_valid/main.c3
+++ b/tests/constructors/init_list_valid/main.c3
@@ -1,0 +1,10 @@
+typedef my_struct : { a: int, b: int };
+
+@operator + : (a: int, b: int) -> int = {
+    return __builtin_add(a, b);
+};
+
+function main : () -> int = {
+    const s : my_struct = { 1, 2 };
+    return s.a + s.b;
+};

--- a/tests/constructors/init_list_valid/test.json
+++ b/tests/constructors/init_list_valid/test.json
@@ -1,0 +1,14 @@
+{
+    "compile": {
+        "command": [
+            "python",
+            "../../../driver.py",
+            "main.c3",
+            "-o",
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 0
+        }
+    }
+}

--- a/tests/constructors/non_void_return_type/main.c3
+++ b/tests/constructors/non_void_return_type/main.c3
@@ -1,0 +1,3 @@
+typedef my_struct : {};
+
+@constructor : (this: my_struct&) -> int = {};

--- a/tests/constructors/non_void_return_type/test.json
+++ b/tests/constructors/non_void_return_type/test.json
@@ -1,0 +1,18 @@
+{
+    "compile": {
+        "command": [
+            "python",
+            "../../../driver.py",
+            "main.c3",
+            "-o",
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 1,
+            "stderr": [
+                "File '*/main.c3', line 3, in '@constructor signature'",
+                "Error: a constructor's return type must be 'void', not 'int'"
+            ]
+        }
+    }
+}

--- a/tests/constructors/this_by_value/main.c3
+++ b/tests/constructors/this_by_value/main.c3
@@ -1,0 +1,3 @@
+typedef my_struct : {};
+
+@constructor : (this: my_struct) -> void = {};

--- a/tests/constructors/this_by_value/test.json
+++ b/tests/constructors/this_by_value/test.json
@@ -1,0 +1,18 @@
+{
+    "compile": {
+        "command": [
+            "python",
+            "../../../driver.py",
+            "main.c3",
+            "-o",
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 1,
+            "stderr": [
+                "File '*/main.c3', line 3, in '@constructor signature'",
+                "Error: a constructor's first argument must be a reference to a struct, not 'my_struct'. Did you mean 'my_struct&'?"
+            ]
+        }
+    }
+}

--- a/tests/constructors/this_double_ref/main.c3
+++ b/tests/constructors/this_double_ref/main.c3
@@ -1,0 +1,3 @@
+typedef my_struct : {};
+
+@constructor : (this: my_struct&&) -> void = {};

--- a/tests/constructors/this_double_ref/test.json
+++ b/tests/constructors/this_double_ref/test.json
@@ -1,0 +1,18 @@
+{
+    "compile": {
+        "command": [
+            "python",
+            "../../../driver.py",
+            "main.c3",
+            "-o",
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 1,
+            "stderr": [
+                "File '*/main.c3', line 3, in '@constructor signature'",
+                "Error: a constructor's first argument must be a reference to a struct, not 'my_struct&&'. Did you mean 'my_struct&'?"
+            ]
+        }
+    }
+}

--- a/tests/constructors/this_non_struct/main.c3
+++ b/tests/constructors/this_non_struct/main.c3
@@ -1,0 +1,1 @@
+@constructor : (this: int&) -> void = {};

--- a/tests/constructors/this_non_struct/test.json
+++ b/tests/constructors/this_non_struct/test.json
@@ -1,0 +1,18 @@
+{
+    "compile": {
+        "command": [
+            "python",
+            "../../../driver.py",
+            "main.c3",
+            "-o",
+            "./out/a.out"
+        ],
+        "output": {
+            "status": 1,
+            "stderr": [
+                "File '*/main.c3', line 1, in '@constructor signature'",
+                "Error: a constructor's first argument must be a reference to a struct, not 'int&'"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
We still need `this = { ... }` support.
If any constructors are defined for the struct you are trying to initialize, you can no longer use the initializer list syntax.