### PR TITLE
Switch to the Earley parser

### DIFF
--- a/grammar.lark
+++ b/grammar.lark
@@ -65,7 +65,7 @@ specialized_typedef: "typedef" IDENTIFIER generic_specialization ":" type
 // Non-operator expresssions
 //
 
-BOOL_CONSTANT.1: "true" | "false"
+BOOL_CONSTANT: "true" | "false"
 UNSIGNED_HEX_CONSTANT: "0x" HEXDIGIT+
 
 _inner_list_without_names: _expression ("," _expression)*
@@ -108,11 +108,11 @@ _non_operator_expression: "(" expression ")"
 // We just match python's order of operation
 // https://docs.python.org/3/reference/expressions.html#operator-precedence
 COMPARE_TOKEN: "<" | ">" | "==" | ">=" | "<=" | "!=" | "<=>"
-SHIFT_TOKEN.1: "<<" | ">>"
+SHIFT_TOKEN: "<<" | ">>"
 ADD_SUB_TOKEN: "+" | "-"
 MULT_DIV_TOKEN: "*" | "@" | "/" | "//" | "%"
 UNARY_OPERATOR_TOKEN: "!" | "-" | "+"
-POWER_TOKEN.1: "**"
+POWER_TOKEN: "**"
 
 // TODO: add support for arbitrary operators
 // Alternatively we can prevent user defined operators not in this list
@@ -167,7 +167,9 @@ const_declaration: "const" IDENTIFIER ":" type "=" expression
 
 if_statement: "if" "(" expression ")" scope ["else" scope]
 while_statement: "while" "(" expression ")" scope
-return_statement: "return" expression?
+// This needs a higher priority, otherwise `return -1` is parsed as an
+// operator_use with a variable called `return`.
+return_statement.1: "return" expression?
 
 
 //

--- a/parser.py
+++ b/parser.py
@@ -1137,7 +1137,11 @@ def generate_ir_from_source(
 ) -> str:
     grammar_path = Path(__file__).parent / "grammar.lark"
     lark = Lark.open(
-        str(grammar_path), parser="lalr", start="program", propagate_positions=True
+        str(grammar_path),
+        parser="earley",
+        ambiguity="resolve",
+        start="program",
+        propagate_positions=True,
     )
 
     program = cg.Program()

--- a/tests/v2/operator_parsing.c3
+++ b/tests/v2/operator_parsing.c3
@@ -1,0 +1,73 @@
+foreign puts : (str: u8[&]) -> int;
+
+@operator - : (val: int) -> int = {
+    // unary_operator: highest precedence.
+    puts("-");
+    return 0;
+};
+
+@operator ** : (rhs: int, lhs: int) -> int = {
+    // power.
+    puts("**");
+    return 0;
+};
+
+@operator * : (rhs: int, lhs: int) -> int = {
+    // mult_div.
+    puts("*");
+    return 0;
+};
+
+@operator + : (rhs: int, lhs: int) -> int = {
+    // add_sub.
+    puts("+");
+    return 0;
+};
+
+@operator >> : (rhs: int, lhs: int) -> int = {
+    // bit_shift.
+    puts(">>");
+    return 0;
+};
+
+@operator & : (rhs: int, lhs: int) -> int = {
+    // bitwise_and.
+    puts("&");
+    return 0;
+};
+
+@operator ^ : (rhs: int, lhs: int) -> int = {
+    // bitwise_xor.
+    puts("^");
+    return 0;
+};
+
+@operator | : (rhs: int, lhs: int) -> int = {
+    // bitwise_or.
+    puts("|");
+    return 0;
+};
+
+@operator == : (rhs: int, lhs: int) -> bool = {
+    // comparison_op.
+    puts("==");
+    return false;
+};
+
+function main : () -> int = {
+    const a: int = 0;
+    const r: bool = -a**5 * 2 >> 3 + 2 ^ 1 | 1 & 0 == 0;
+    return 0;
+};
+
+/// @COMPILE --use-crt
+/// @RUN; EXPECT OUT
+/// -
+/// **
+/// *
+/// +
+/// >>
+/// ^
+/// &
+/// |
+/// ==

--- a/tests/v2/regressions/ambiguous_parsing.c3
+++ b/tests/v2/regressions/ambiguous_parsing.c3
@@ -1,0 +1,30 @@
+typedef [T] A : { a : T };
+typedef [T] B : { b : T };
+
+function [T] foo : () -> T = {
+    return {{2}};
+};
+
+@operator - : (value : int) -> int = {
+    return value;
+};
+
+@operator < : (a : int, b: int) -> bool = {
+    return true;
+};
+
+function main : () -> int = {
+    let val : A<B<int>> = foo<A<B<int>>>();
+
+    if (0 < 1) {
+        return -val.a.b;
+    } else {
+        return 1;
+    }
+
+    // FIXME https://github.com/DaveDuck321/GrapheneLang/issues/72
+    return 0;
+};
+
+/// @COMPILE
+/// @RUN; EXPECT 2


### PR DESCRIPTION
Running the entire test suite now takes 40% longer, as parsing is now O(n^3) instead of O(n).

The Earley parser uses rule priorities to resolve ambiguities instead of token priorities, so small changes to the grammar were necessary. 

Fixes #64.