### PR TITLE
Add target config file and parser

### DIFF
--- a/codegen/builtin_types.py
+++ b/codegen/builtin_types.py
@@ -411,14 +411,7 @@ class StackArrayDefinition(TypeDefinition):
 
     @property
     def alignment(self) -> int:
-        # An array uses the same alignment as its elements, except that a local
-        # or global array variable of length at least 16 bytes or a C99
-        # variable-length array variable always has alignment of at least 16
-        # bytes. [docs/abi.pdf, Section 3.1.2]
-        # TODO move to target.py.
-        return (
-            self.member.alignment if self.size < 16 else max(self.member.alignment, 16)
-        )
+        return get_abi().compute_stack_array_alignment(self.size, self.member.alignment)
 
 
 class HeapArrayDefinition(TypeDefinition):

--- a/codegen/builtin_types.py
+++ b/codegen/builtin_types.py
@@ -4,6 +4,8 @@ from functools import cached_property, reduce
 from operator import mul
 from typing import Callable, Optional
 
+from target import get_abi
+
 from .interfaces import SpecializationItem, Type, TypeDefinition, format_specialization
 from .user_facing_errors import (
     ArrayDimensionError,
@@ -347,38 +349,14 @@ class StructDefinition(TypeDefinition):
 
     @property
     def size(self) -> int:
-        # Return the size of the struct as set by the System V AMD64 ABI.
-        # [docs/abi.pdf, Section 3.1.2]
-        #   TODO: we should manually set the `datalayout` string to match this
-
-        def compute_padding(curr_size: int, align_to: int) -> int:
-            # Simplifies to this, using the properties of remainders.
-            return -curr_size % align_to
-
-        # Each member is assigned to the lowest available offset with the
-        # appropriate alignment.
-        this_size = 0
-        for _, member_type in self.members:
-            # Add padding to ensure each member is aligned
-            this_size += compute_padding(this_size, member_type.alignment)
-
-            # Append member to the struct
-            this_size += member_type.size
-
-        # The size of any object is always a multiple of the object‘s alignment.
-        this_size += compute_padding(this_size, self.alignment)
-
-        return this_size
+        member_sizes = [member.size for _, member in self.members]
+        member_aligns = [member.alignment for _, member in self.members]
+        return get_abi().compute_struct_size(member_sizes, member_aligns)
 
     @property
     def alignment(self) -> int:
-        # Structures and unions assume the alignment of their most strictly
-        # aligned component. [docs/abi.pdf, Section 3.1.2]
-        return (
-            max(member_type.alignment for _, member_type in self.members)
-            if self.members
-            else 1
-        )
+        member_aligns = [member.alignment for _, member in self.members]
+        return get_abi().compute_struct_alignment(member_aligns)
 
     def get_member_by_name(self, target_name: str) -> tuple[int, Type]:
         for index, (member_name, member_type) in enumerate(self.members):
@@ -437,6 +415,7 @@ class StackArrayDefinition(TypeDefinition):
         # or global array variable of length at least 16 bytes or a C99
         # variable-length array variable always has alignment of at least 16
         # bytes. [docs/abi.pdf, Section 3.1.2]
+        # TODO move to target.py.
         return (
             self.member.alignment if self.size < 16 else max(self.member.alignment, 16)
         )

--- a/codegen/builtin_types.py
+++ b/codegen/builtin_types.py
@@ -4,7 +4,7 @@ from functools import cached_property, reduce
 from operator import mul
 from typing import Callable, Optional
 
-from target import get_abi, get_ptr_type_info
+from target import get_abi, get_int_type_info, get_ptr_type_info
 
 from .interfaces import SpecializationItem, Type, TypeDefinition, format_specialization
 from .user_facing_errors import (
@@ -265,12 +265,16 @@ class GenericIntType(PrimitiveType):
 
 class IntType(GenericIntType):
     def __init__(self) -> None:
-        super().__init__("int", 32, True)
+        super().__init__("int", get_int_type_info().size.in_bits, True)
 
 
 class UIntType(GenericIntType):
     def __init__(self) -> None:
-        super().__init__("u32", 32, False)
+        super().__init__(
+            f"u{get_int_type_info().size.in_bits}",
+            get_int_type_info().size.in_bits,
+            False,
+        )
 
 
 class SizeType(GenericIntType):

--- a/codegen/builtin_types.py
+++ b/codegen/builtin_types.py
@@ -4,7 +4,7 @@ from functools import cached_property, reduce
 from operator import mul
 from typing import Callable, Optional
 
-from target import get_abi
+from target import get_abi, get_ptr_type_info
 
 from .interfaces import SpecializationItem, Type, TypeDefinition, format_specialization
 from .user_facing_errors import (
@@ -275,12 +275,12 @@ class UIntType(GenericIntType):
 
 class SizeType(GenericIntType):
     def __init__(self) -> None:
-        super().__init__("isize", 64, True)
+        super().__init__("isize", get_ptr_type_info().size.in_bits, True)
 
 
 class IPtrType(GenericIntType):
     def __init__(self) -> None:
-        super().__init__("iptr", 64, True)
+        super().__init__("iptr", get_ptr_type_info().size.in_bits, True)
 
 
 class BoolDefinition(PrimitiveDefinition):

--- a/codegen/interfaces.py
+++ b/codegen/interfaces.py
@@ -3,6 +3,8 @@ from copy import copy
 from dataclasses import dataclass
 from typing import Any, Iterable, Iterator, Optional
 
+from target import get_llvm_type_info
+
 
 class TypeDefinition(ABC):
     def graphene_literal_to_ir_constant(self, value: str) -> str:
@@ -83,13 +85,13 @@ class Type(ABC):
     @property
     def size(self) -> int:
         if self.is_reference:
-            return 8  # TODO: respect the datalayout string
+            return get_llvm_type_info("ptr").size
         return self.definition.size
 
     @property
     def alignment(self) -> int:
         if self.is_reference:
-            return 8  # TODO: respect the datalayout string
+            return get_llvm_type_info("ptr").align
         return self.definition.alignment
 
     def convert_to_value_type(self) -> "Type":

--- a/codegen/interfaces.py
+++ b/codegen/interfaces.py
@@ -85,13 +85,13 @@ class Type(ABC):
     @property
     def size(self) -> int:
         if self.is_reference:
-            return get_llvm_type_info("ptr").size
+            return get_llvm_type_info("ptr").size.in_bytes
         return self.definition.size
 
     @property
     def alignment(self) -> int:
         if self.is_reference:
-            return get_llvm_type_info("ptr").align
+            return get_llvm_type_info("ptr").align.in_bytes
         return self.definition.alignment
 
     def convert_to_value_type(self) -> "Type":

--- a/codegen/translation_unit.py
+++ b/codegen/translation_unit.py
@@ -3,6 +3,8 @@ from functools import cached_property
 from itertools import count
 from typing import Callable, Iterable, Optional
 
+import target
+
 from .builtin_callables import get_builtin_callables
 from .builtin_types import (
     AnonymousType,
@@ -427,10 +429,11 @@ class Program:
     def add_static_variable(self, var: StaticVariable) -> None:
         self._static_variables.append(var)
 
-    def generate_ir(self, target="x86_64-pc-linux-gnu") -> list[str]:
+    def generate_ir(self) -> list[str]:
         lines: list[str] = []
 
-        lines.append(f'target triple = "{target}"')
+        lines.append(f'target datalayout = "{target.get_datalayout()}"')
+        lines.append(f'target triple = "{target.get_target_triple()}"')
 
         lines.append("")
         var_reg_gen = count(0)

--- a/driver.py
+++ b/driver.py
@@ -5,7 +5,7 @@ from os import getenv
 from pathlib import Path
 
 from graphene_parser import generate_ir_from_source
-from target import get_target_triple, set_target
+from target import get_target_triple, load_target_config
 
 
 def extract_include_paths(args: list[str]) -> tuple[list[Path], list[str]]:
@@ -80,7 +80,7 @@ def main() -> None:
             llvm_output = args.output
 
     # Compile to ir
-    set_target(args.target)
+    load_target_config(args.target)
     ir = generate_ir_from_source(args.input[0], include_path, args.debug_compiler)
 
     if will_emit_llvm:

--- a/driver.py
+++ b/driver.py
@@ -5,6 +5,7 @@ from os import getenv
 from pathlib import Path
 
 from graphene_parser import generate_ir_from_source
+from target import get_target_triple, set_target
 
 
 def extract_include_paths(args: list[str]) -> tuple[list[Path], list[str]]:
@@ -51,6 +52,8 @@ def main() -> None:
     parser.add_argument("--debug-compiler", action="store_true")
     parser.add_argument("--nostdlib", action="store_true")
     parser.add_argument("--use-crt", action="store_true")
+    # TODO target the host by default.
+    parser.add_argument("--target", required=False, type=str, default="x86_64_linux")
     args = parser.parse_args(sys_args)
 
     will_emit_llvm: bool = args.emit_llvm or args.emit_everything
@@ -77,6 +80,7 @@ def main() -> None:
             llvm_output = args.output
 
     # Compile to ir
+    set_target(args.target)
     ir = generate_ir_from_source(args.input[0], include_path, args.debug_compiler)
 
     if will_emit_llvm:
@@ -89,14 +93,16 @@ def main() -> None:
     # Use clang to finish compile
 
     if will_emit_optimized_llvm:
-        # TODO: the llvm optimization pipeline is run twice if we also want a binary
+        # TODO: the llvm optimization pipeline is run twice if we also want a
+        # binary
         subprocess.run(
             [
                 getenv("GRAPHENE_CLANG_CMD", "clang"),
-                "-Wno-override-module",
                 "-S",
                 "-emit-llvm",
                 f"-O{opt_level}",
+                "-target",
+                get_target_triple(),
                 "-o",
                 optimized_llvm_output,
                 "-xir",  # Only STDIN is IR, so this should be last.
@@ -121,8 +127,9 @@ def main() -> None:
         subprocess.run(
             [
                 getenv("GRAPHENE_CLANG_CMD", "clang"),
-                "-Wno-override-module",  # Don't complain about the target triple.
                 f"-O{opt_level}",
+                "-target",
+                get_target_triple(),
                 "-o",
                 binary_output,
                 *extra_flags,

--- a/target.py
+++ b/target.py
@@ -131,6 +131,7 @@ class TargetConfig:
     endianness: Endianess
     mangling: ManglingStyle
     stack_align: Size
+    int_type: TypeInfo
     llvm_target_triple: str
     llvm_types: dict[str, TypeInfo]
 
@@ -243,6 +244,10 @@ def get_llvm_type_info(llvm_type_name: str) -> TypeInfo:
 
 def get_ptr_type_info() -> TypeInfo:
     return get_llvm_type_info("ptr")
+
+
+def get_int_type_info() -> TypeInfo:
+    return _get_config().int_type
 
 
 def get_abi() -> ABI:

--- a/target.py
+++ b/target.py
@@ -24,7 +24,7 @@ class ManglingStyle(Enum):
     @property
     def llvm_datalayout_spec(self) -> str:
         if self == self.ELF:
-            return "e"
+            return "m:e"
         raise NotImplementedError()
 
     @property
@@ -70,19 +70,67 @@ def set_target(target: str) -> None:
     _target = target
 
     def parse_type_info(object: dict[str, Any]) -> TypeInfo | dict[str, Any]:
+        # Pack into TypeInfo.
         if "size" in object and "align" in object:
             return TypeInfo(object["size"], object["align"])
+
+        # Endianness enum.
         if "endianness" in object:
             object["endianness"] = Endianess.from_str(object["endianness"])
+
+        # ManglingStyle enum.
         if "mangling" in object:
             object["mangling"] = ManglingStyle.from_str(object["mangling"])
+
         return object
 
     config_path = (TARGETS_DIR / target).with_suffix(".json")
     with open(config_path) as config_file:
         config_data = json.load(config_file, object_hook=parse_type_info)
 
+    # The __init__ function checks that all specified fields are in the
+    # dictionary and that no additional fields are present. This should catch
+    # most mistakes/bugs in the config files and is much simpler than a formal
+    # schema.
     _target_config = TargetConfig(**config_data)
 
 
+def _get_config() -> TargetConfig:
+    # NOTE the dataclass shouldn't be part of the public API.
+    global _target_config
+
+    assert _target_config is not None
+    return _target_config
+
+
+def get_datalayout() -> str:
+    config = _get_config()
+    specs: list[str] = []
+
+    # Endianness.
+    specs.append(config.endianness.llvm_datalayout_spec)
+
+    # Mangling style.
+    specs.append(config.mangling.llvm_datalayout_spec)
+
+    # Pointer type.
+    specs.append(f"p:{config.llvm_types['ptr'].size}:{config.llvm_types['ptr'].align}")
+
+    # Other types.
+    specs.extend(
+        f"{type_name}:{type_info.align}"
+        for type_name, type_info in config.llvm_types.items()
+        if type_name != "ptr"
+    )
+
+    # Native integer widths.
+    specs.append("n" + str.join(":", map(str, config.arch_native_widths)))
+
+    # Alignment of the stack.
+    specs.append(f"S{config.stack_align}")
+
+    return str.join("-", specs)
+
+
 set_target("x86_64_linux")
+print(get_datalayout())

--- a/target.py
+++ b/target.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from sys import exit as sys_exit
+from sys import stderr
 from typing import Any, Optional
 
 
@@ -180,7 +181,7 @@ def load_target_config(target: str) -> None:
 
     if not config_path.is_file():
         # TODO we should be throwing exceptions and catching them in the driver.
-        print(f"Could not find a configuration file for target '{target}'")
+        print(f"Could not find a configuration file for target '{target}'", file=stderr)
         sys_exit(1)
 
     with open(config_path) as config_file:

--- a/target.py
+++ b/target.py
@@ -47,6 +47,9 @@ class ABI(Enum):
     def compute_struct_size(
         self, member_sizes: list[int], member_aligns: list[int]
     ) -> int:
+        if self != self.SystemV_AMD64:
+            raise NotImplementedError
+
         # Return the size of the struct as set by the System V AMD64 ABI.
         # [docs/abi.pdf, Section 3.1.2]
 
@@ -81,9 +84,22 @@ class ABI(Enum):
         return struct_size
 
     def compute_struct_alignment(self, member_aligns: list[int]) -> int:
+        if self != self.SystemV_AMD64:
+            raise NotImplementedError
+
         # Structures and unions assume the alignment of their most strictly
         # aligned component. [docs/abi.pdf, Section 3.1.2]
         return max(member_aligns) if member_aligns else 1
+
+    def compute_stack_array_alignment(self, array_size: int, member_align: int) -> int:
+        if self != self.SystemV_AMD64:
+            raise NotImplementedError
+
+        # An array uses the same alignment as its elements, except that a local
+        # or global array variable of length at least 16 bytes or a C99
+        # variable-length array variable always has alignment of at least 16
+        # bytes. [docs/abi.pdf, Section 3.1.2]
+        return member_align if array_size < 16 else max(member_align, 16)
 
     @classmethod
     def from_str(cls, string: str) -> "ABI":

--- a/target.py
+++ b/target.py
@@ -116,7 +116,7 @@ _target: Optional[str] = None
 _target_config: Optional[TargetConfig] = None
 
 
-def set_target(target: str) -> None:
+def load_target_config(target: str) -> None:
     global _target, _target_config
 
     _target = target

--- a/target.py
+++ b/target.py
@@ -51,7 +51,16 @@ class ABI(Enum):
         # [docs/abi.pdf, Section 3.1.2]
 
         def compute_padding(curr_size: int, align_to: int) -> int:
-            # Simplifies to this, using the properties of remainders.
+            # First, compute the number of bytes needed to pad the struct to
+            # the next `align_to` boundary:
+            # padding = align_to - (curr_size % align_to)
+            #
+            # Then, take the modulus again so that we don't add unnecessary
+            # padding if the next member is already aligned:
+            # return padding % align_to
+            #
+            # Using the properties of remainders, the above procedure simplifies
+            # to:
             return -curr_size % align_to
 
         # Each member is assigned to the lowest available offset with the

--- a/target.py
+++ b/target.py
@@ -1,0 +1,88 @@
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+
+class Endianess(Enum):
+    Big = 0
+    Little = 1
+
+    @property
+    def llvm_datalayout_spec(self) -> str:
+        return "E" if self == self.Big else "e"
+
+    @classmethod
+    def from_str(cls, string: str) -> "Endianess":
+        return cls.Big if string == "big" else cls.Little
+
+
+class ManglingStyle(Enum):
+    ELF = 0
+
+    @property
+    def llvm_datalayout_spec(self) -> str:
+        if self == self.ELF:
+            return "e"
+        raise NotImplementedError()
+
+    @property
+    def private_symbol_prefix(self) -> str:
+        if self == self.ELF:
+            return ".L"
+        raise NotImplementedError()
+
+    @classmethod
+    def from_str(cls, string: str) -> "ManglingStyle":
+        if string == "elf":
+            return cls.ELF
+        raise NotImplementedError()
+
+
+@dataclass
+class TypeInfo:
+    size: int
+    align: int
+
+
+@dataclass(kw_only=True)
+class TargetConfig:
+    arch: str
+    arch_native_widths: list[int]
+    env: str
+    endianness: Endianess
+    mangling: ManglingStyle
+    stack_align: int
+    llvm_target_triple: str
+    llvm_types: dict[str, TypeInfo]
+
+
+TARGETS_DIR = Path(__file__).parent / "targets"
+
+_target: Optional[str] = None
+_target_config: Optional[TargetConfig] = None
+
+
+def set_target(target: str) -> None:
+    global _target, _target_config
+
+    _target = target
+
+    def parse_type_info(object: dict[str, Any]) -> TypeInfo | dict[str, Any]:
+        if "size" in object and "align" in object:
+            return TypeInfo(object["size"], object["align"])
+        if "endianness" in object:
+            object["endianness"] = Endianess.from_str(object["endianness"])
+        if "mangling" in object:
+            object["mangling"] = ManglingStyle.from_str(object["mangling"])
+        return object
+
+    config_path = (TARGETS_DIR / target).with_suffix(".json")
+    with open(config_path) as config_file:
+        config_data = json.load(config_file, object_hook=parse_type_info)
+
+    _target_config = TargetConfig(**config_data)
+
+
+set_target("x86_64_linux")

--- a/target.py
+++ b/target.py
@@ -2,6 +2,7 @@ import json
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from sys import exit as sys_exit
 from typing import Any, Optional
 
 
@@ -85,6 +86,12 @@ def set_target(target: str) -> None:
         return object
 
     config_path = (TARGETS_DIR / target).with_suffix(".json")
+
+    if not config_path.is_file():
+        # TODO we should be throwing exceptions and catching them in the driver.
+        print(f"Could not find a configuration file for target '{target}'")
+        sys_exit(1)
+
     with open(config_path) as config_file:
         config_data = json.load(config_file, object_hook=parse_type_info)
 

--- a/target.py
+++ b/target.py
@@ -132,5 +132,5 @@ def get_datalayout() -> str:
     return str.join("-", specs)
 
 
-set_target("x86_64_linux")
-print(get_datalayout())
+def get_target_triple() -> str:
+    return _get_config().llvm_target_triple

--- a/target.py
+++ b/target.py
@@ -241,5 +241,9 @@ def get_llvm_type_info(llvm_type_name: str) -> TypeInfo:
     return _get_config().llvm_types[llvm_type_name]
 
 
+def get_ptr_type_info() -> TypeInfo:
+    return get_llvm_type_info("ptr")
+
+
 def get_abi() -> ABI:
     return _get_config().abi

--- a/target.py
+++ b/target.py
@@ -141,3 +141,7 @@ def get_datalayout() -> str:
 
 def get_target_triple() -> str:
     return _get_config().llvm_target_triple
+
+
+def get_llvm_type_info(llvm_type_name: str) -> TypeInfo:
+    return _get_config().llvm_types[llvm_type_name]

--- a/targets/x86_64_linux.json
+++ b/targets/x86_64_linux.json
@@ -10,6 +10,10 @@
     "endianness": "little",
     "mangling": "elf",
     "stack_align": 16,
+    "int_type": {
+        "size": 4,
+        "align": 4
+    },
     "llvm_target_triple": "x86_64-unknown-linux-gnu",
     "llvm_types": {
         "ptr": {

--- a/targets/x86_64_linux.json
+++ b/targets/x86_64_linux.json
@@ -1,40 +1,40 @@
 {
     "arch": "x86_64",
     "arch_native_widths": [
-        8,
-        16,
-        32,
-        64
+        1,
+        2,
+        4,
+        8
     ],
     "abi": "SystemV_AMD64",
     "endianness": "little",
     "mangling": "elf",
-    "stack_align": 128,
+    "stack_align": 16,
     "llvm_target_triple": "x86_64-unknown-linux-gnu",
     "llvm_types": {
         "ptr": {
-            "size": 64,
-            "align": 64
+            "size": 8,
+            "align": 8
         },
         "i1": {
-            "size": 8,
-            "align": 8
+            "size": 1,
+            "align": 1
         },
         "i8": {
-            "size": 8,
-            "align": 8
+            "size": 1,
+            "align": 1
         },
         "i16": {
-            "size": 16,
-            "align": 16
+            "size": 2,
+            "align": 2
         },
         "i32": {
-            "size": 32,
-            "align": 32
+            "size": 4,
+            "align": 4
         },
         "i64": {
-            "size": 64,
-            "align": 64
+            "size": 8,
+            "align": 8
         }
     }
 }

--- a/targets/x86_64_linux.json
+++ b/targets/x86_64_linux.json
@@ -6,7 +6,7 @@
         32,
         64
     ],
-    "env": "linux",
+    "abi": "SystemV_AMD64",
     "endianness": "little",
     "mangling": "elf",
     "stack_align": 128,

--- a/targets/x86_64_linux.json
+++ b/targets/x86_64_linux.json
@@ -1,0 +1,40 @@
+{
+    "arch": "x86_64",
+    "arch_native_widths": [
+        8,
+        16,
+        32,
+        64
+    ],
+    "env": "linux",
+    "endianness": "little",
+    "mangling": "elf",
+    "stack_align": 128,
+    "llvm_target_triple": "x86_64-unknown-linux-gnu",
+    "llvm_types": {
+        "ptr": {
+            "size": 64,
+            "align": 64
+        },
+        "i1": {
+            "size": 8,
+            "align": 8
+        },
+        "i8": {
+            "size": 8,
+            "align": 8
+        },
+        "i16": {
+            "size": 16,
+            "align": 16
+        },
+        "i32": {
+            "size": 32,
+            "align": 32
+        },
+        "i64": {
+            "size": 64,
+            "align": 64
+        }
+    }
+}


### PR DESCRIPTION
Not yet ready but I'd like your thoughts on this. The config file contains pretty much the bare minimum to generate the data layout string, so we might need to add more information in the future.

I went for a singleton cause I suspect many files in `codegen/` would need access to this information. If that's not the case then I'd rather refactor it as a class.