### PR TITLE
Remove the annoying syntax

### DIFF
--- a/demo.c3
+++ b/demo.c3
@@ -39,7 +39,7 @@ function[@Len] to_str: (allocator: Allocator&, val: u8[@Len]) -> iovec = {
     let mem: u8[@Len]& = &allocator:allocate<u8[@Len]>();
 
     let i: isize = 0;
-    while (i < @Len) {
+    while i < @Len {
         mem[i] = val[i];
         i = i + 1;
     }
@@ -59,13 +59,13 @@ function[@Len, T] printf_impl: (allocator: Allocator&,
                                        val: T
                                       ) -> int = {
     let format_j : isize = format_i;
-    while (format_j < @Len) {
+    while format_j < @Len {
         // 35 is # in ASCII.
-        if (format[format_j] == __builtin_bitcast<u8>(__builtin_narrow<i8>(35))) {
+        if format[format_j] == __builtin_bitcast<u8>(__builtin_narrow<i8>(35){
             // FIXME memory leak.
             let mem: u8[@Len]& = &allocator:allocate<u8[@Len]>();
             let i: isize = format_i;
-            while (i < format_j) {
+            while i < format_j {
                 mem[i] = format[i];
                 i = i + 1;
             }
@@ -81,7 +81,7 @@ function[@Len, T] printf_impl: (allocator: Allocator&,
 
     let mem: u8[@Len]& = &allocator:allocate<u8[@Len]>();
     let i: isize = format_i;
-    while (i < format_j) {
+    while i < format_j {
         mem[i] = format[i];
         i = i + 1;
     }
@@ -98,13 +98,13 @@ function[@Len, T, Ys...] printf_impl: (allocator: Allocator&,
                                        val: T,
                                        next_vals: Ys...) -> int = {
     let format_j : isize = format_i;
-    while (format_j < @Len) {
+    while format_j < @Len {
         // 35 is # in ASCII.
-        if (format[format_j] == __builtin_bitcast<u8>(__builtin_narrow<i8>(35))) {
+        if format[format_j] == __builtin_bitcast<u8>(__builtin_narrow<i8>(35){
             // FIXME memory leak.
             let mem: u8[@Len]& = &allocator:allocate<u8[@Len]>();
             let i: isize = format_i;
-            while (i < format_j) {
+            while i < format_j {
                 mem[i] = format[i];
                 i = i + 1;
             }
@@ -120,7 +120,7 @@ function[@Len, T, Ys...] printf_impl: (allocator: Allocator&,
 
     let mem: u8[@Len]& = &allocator:allocate<u8[@Len]>();
     let i: isize = format_i;
-    while (i < format_j) {
+    while i < format_j {
         mem[i] = format[i];
         i = i + 1;
     }

--- a/demo.c3
+++ b/demo.c3
@@ -6,12 +6,12 @@
 function[T] pack_len: (curr: T) -> int = {
     // Base case
     return 1;
-};
+}
 
 function[T, Ys...] pack_len: (curr: T, next: Ys...) -> int = {
     // Very Haskell
     return pack_len(next...) + 1;
-};
+}
 
 function to_str: (allocator: Allocator&, val: int) -> iovec = {
     // FIXME should be const.
@@ -32,7 +32,7 @@ function to_str: (allocator: Allocator&, val: int) -> iovec = {
 
     // TODO numbers > 10 and < 0.
     return iov;
-};
+}
 
 function[@Len] to_str: (allocator: Allocator&, val: u8[@Len]) -> iovec = {
     // FIXME we leak memory here.
@@ -45,11 +45,11 @@ function[@Len] to_str: (allocator: Allocator&, val: u8[@Len]) -> iovec = {
     }
 
     return {&mem, @Len};
-};
+}
 
 function[T] printf_single: (allocator: Allocator&, iov: iovec[&], i: isize, val: T) -> void = {
     iov[i] = to_str(&allocator, val);
-};
+}
 
 function[@Len, T] printf_impl: (allocator: Allocator&,
                                        format: u8[@Len]&,
@@ -88,7 +88,7 @@ function[@Len, T] printf_impl: (allocator: Allocator&,
     iov[iov_i] = {&mem, format_j - format_i};
 
     return 1;
-};
+}
 
 function[@Len, T, Ys...] printf_impl: (allocator: Allocator&,
                                        format: u8[@Len]&,
@@ -127,7 +127,7 @@ function[@Len, T, Ys...] printf_impl: (allocator: Allocator&,
     iov[iov_i] = {&mem, format_j - format_i};
 
     return 1;
-};
+}
 
 function[@Len, Ts...] printf: (format: u8[@Len]&, vals: Ts...) -> void = {
     let allocator: Allocator = initialize_allocator();
@@ -138,11 +138,11 @@ function[@Len, Ts...] printf: (format: u8[@Len]&, vals: Ts...) -> void = {
     let fixme: iovec[&] = &iov;
     const len: int = printf_impl(&allocator, &format, 0, &fixme, 0, vals...);
     sys_writev(1, &fixme, len);
-};
+}
 
 function main : () -> int = {
     // printf("one # #\n", "two", "three");
     printf("a: #, b: #, c: #\n", 1, 2, 3);
 
     return 0;
-};
+}

--- a/grammar.lark
+++ b/grammar.lark
@@ -175,9 +175,9 @@ const_declaration: "const" IDENTIFIER ":" type "=" expression
 // Control flow
 //
 
-if_statement: "if" "(" expression ")" scope ["else" scope]
-while_statement: "while" "(" expression ")" scope
-for_statement: "for" "(" IDENTIFIER "in" expression ")" scope
+if_statement: "if" expression scope ["else" scope]
+while_statement: "while" expression scope
+for_statement: "for" IDENTIFIER "in" expression scope
 // This needs a higher priority, otherwise `return -1` is parsed as an
 // operator_use with a variable called `return`.
 return_statement.1: "return" expression?

--- a/grammar.lark
+++ b/grammar.lark
@@ -258,4 +258,4 @@ _top_level_program_feature: const_declaration
                           | specialized_typedef
                           | variable_declaration
 
-program: (_top_level_program_feature ";")*
+program: (_top_level_program_feature)*

--- a/std/arithmetic.c3
+++ b/std/arithmetic.c3
@@ -1,120 +1,120 @@
-@require_once "assignments.c3";
-@require_once "logical.c3";
-@require_once "type_traits.c3";
+@require_once "assignments.c3"
+@require_once "logical.c3"
+@require_once "type_traits.c3"
 
-typedef [U, V] CommonArithmeticType: TypeIf<U, Both<IsIntegral<U>, IsIntegral<V>>>;
-typedef CommonArithmeticType<i8, i16> : i16;
-typedef CommonArithmeticType<i8, i32> : i32;
-typedef CommonArithmeticType<i8, i64> : i64;
-typedef CommonArithmeticType<i8, i128> : i128;
-typedef CommonArithmeticType<i16, i32> : i32;
-typedef CommonArithmeticType<i16, i64> : i64;
-typedef CommonArithmeticType<i16, i128> : i128;
-typedef CommonArithmeticType<i32, i64> : i64;
-typedef CommonArithmeticType<i32, i128> : i128;
-typedef CommonArithmeticType<i64, i128> : i128;
+typedef [U, V] CommonArithmeticType: TypeIf<U, Both<IsIntegral<U>, IsIntegral<V>>>
+typedef CommonArithmeticType<i8, i16> : i16
+typedef CommonArithmeticType<i8, i32> : i32
+typedef CommonArithmeticType<i8, i64> : i64
+typedef CommonArithmeticType<i8, i128> : i128
+typedef CommonArithmeticType<i16, i32> : i32
+typedef CommonArithmeticType<i16, i64> : i64
+typedef CommonArithmeticType<i16, i128> : i128
+typedef CommonArithmeticType<i32, i64> : i64
+typedef CommonArithmeticType<i32, i128> : i128
+typedef CommonArithmeticType<i64, i128> : i128
 
-typedef [U, V] ArithmeticCompareResult : TypeIf<bool, Both<IsIntegral<U>, IsIntegral<V>>>;
+typedef [U, V] ArithmeticCompareResult : TypeIf<bool, Both<IsIntegral<U>, IsIntegral<V>>>
 
-typedef HasTrivialAssignments<i8> : TrueType;
-typedef HasTrivialAssignments<i16> : TrueType;
-typedef HasTrivialAssignments<i32> : TrueType;
-typedef HasTrivialAssignments<i64> : TrueType;
-typedef HasTrivialAssignments<i128> : TrueType;
+typedef HasTrivialAssignments<i8> : TrueType
+typedef HasTrivialAssignments<i16> : TrueType
+typedef HasTrivialAssignments<i32> : TrueType
+typedef HasTrivialAssignments<i64> : TrueType
+typedef HasTrivialAssignments<i128> : TrueType
 
-@operator [T] + : (value: T) -> TypeIf<T, IsIntegral<T>> = { return value; };
+@operator [T] + : (value: T) -> TypeIf<T, IsIntegral<T>> = { return value; }
 
 @operator [T] - : (value: T) -> TypeIf<T, IsIntegral<T>> = {
     return __builtin_minus(value);
-};
+}
 
 @operator [U, V] + : (lhs: U, rhs : V) -> CommonArithmeticType<U, V> = {
     let lhs_widen: CommonArithmeticType<U, V> = lhs;
     let rhs_widen: CommonArithmeticType<U, V> = rhs;
     return __builtin_add(lhs_widen, rhs_widen);
-};
+}
 
 @operator [U, V] - : (lhs: U, rhs : V) -> CommonArithmeticType<U, V> = {
     let lhs_widen: CommonArithmeticType<U, V> = lhs;
     let rhs_widen: CommonArithmeticType<U, V> = rhs;
     return __builtin_subtract(lhs_widen, rhs_widen);
-};
+}
 
 @operator [U, V] * : (lhs: U, rhs : V) -> CommonArithmeticType<U, V> = {
     let lhs_widen: CommonArithmeticType<U, V> = lhs;
     let rhs_widen: CommonArithmeticType<U, V> = rhs;
     return __builtin_multiply(lhs_widen, rhs_widen);
-};
+}
 
 @operator [U, V] / : (lhs: U, rhs : V) -> CommonArithmeticType<U, V> = {
     let lhs_widen: CommonArithmeticType<U, V> = lhs;
     let rhs_widen: CommonArithmeticType<U, V> = rhs;
     return __builtin_divide(lhs_widen, rhs_widen);
-};
+}
 
 @operator [U, V] % : (lhs: U, rhs : V) -> CommonArithmeticType<U, V> = {
     let lhs_widen: CommonArithmeticType<U, V> = lhs;
     let rhs_widen: CommonArithmeticType<U, V> = rhs;
     return __builtin_mod(lhs_widen, rhs_widen);
-};
+}
 
 @operator [U, V] == : (lhs: U, rhs: V) -> ArithmeticCompareResult<U, V> = {
     let lhs_widen: CommonArithmeticType<U, V> = lhs;
     let rhs_widen: CommonArithmeticType<U, V> = rhs;
     return __builtin_is_equal(lhs_widen, rhs_widen);
-};
+}
 
 @operator [U, V] != : (lhs: U, rhs: V) -> ArithmeticCompareResult<U, V> = {
     return !(lhs == rhs);
-};
+}
 
 @operator [U, V] < : (lhs: U, rhs: V) -> ArithmeticCompareResult<U, V> = {
     let lhs_widen: CommonArithmeticType<U, V> = lhs;
     let rhs_widen: CommonArithmeticType<U, V> = rhs;
     return __builtin_is_less_than(lhs_widen, rhs_widen);
-};
+}
 
 @operator [U, V] > : (lhs: U, rhs: V) -> ArithmeticCompareResult<U, V> = {
     let lhs_widen: CommonArithmeticType<U, V> = lhs;
     let rhs_widen: CommonArithmeticType<U, V> = rhs;
     return __builtin_is_greater_than(lhs_widen, rhs_widen);
-};
+}
 
 // TODO: remove unnecessary widening by allowing partial specialization
 function [T] Narrow : (value : i128) -> TypeIf<T, IsIntegral<T>> = {
     return __builtin_narrow<T>(value);
-};
+}
 
 @operator [U, V] <= : (lhs: U, rhs: V) -> ArithmeticCompareResult<U, V> = {
     return !(lhs > rhs);
-};
+}
 
 @operator [U, V] >= : (lhs: U, rhs: V) -> ArithmeticCompareResult<U, V> = {
     return !(lhs < rhs);
-};
+}
 
-typedef[T] HasSpaceship : FalseType;
+typedef[T] HasSpaceship : FalseType
 
 @operator [T] == : (lhs: T, rhs: T) -> TypeIf<bool, HasSpaceship<T>> = {
     return (lhs <=> rhs) == 0;
-};
+}
 
 @operator [T] != : (lhs: T, rhs: T) -> TypeIf<bool, HasSpaceship<T>> = {
     return (lhs <=> rhs) != 0;
-};
+}
 
 @operator [T] < : (lhs: T, rhs: T) -> TypeIf<bool, HasSpaceship<T>> = {
     return (lhs <=> rhs) < 0;
-};
+}
 
 @operator [T] > : (lhs: T, rhs: T) -> TypeIf<bool, HasSpaceship<T>> = {
     return (lhs <=> rhs) > 0;
-};
+}
 
 @operator [T] <= : (lhs: T, rhs: T) -> TypeIf<bool, HasSpaceship<T>> = {
     return (lhs <=> rhs) <= 0;
-};
+}
 
 @operator [T] >= : (lhs: T, rhs: T) -> TypeIf<bool, HasSpaceship<T>> = {
     return (lhs <=> rhs) >= 0;
-};
+}

--- a/std/assert.c3
+++ b/std/assert.c3
@@ -1,8 +1,8 @@
-@require_once "syscalls.c3";
+@require_once "syscalls.c3"
 
 function runtime_assert : (condition : bool) -> void = {
     if (!condition) {
         sys_write(/* stderr */ 2, "Assertion Failed!", 17);
         sys_exit(1);
     }
-};
+}

--- a/std/assert.c3
+++ b/std/assert.c3
@@ -1,7 +1,7 @@
 @require_once "syscalls.c3"
 
 function runtime_assert : (condition : bool) -> void = {
-    if (!condition) {
+    if !condition {
         sys_write(/* stderr */ 2, "Assertion Failed!", 17);
         sys_exit(1);
     }

--- a/std/assignments.c3
+++ b/std/assignments.c3
@@ -1,48 +1,48 @@
-@require_once "type_traits.c3";
+@require_once "type_traits.c3"
 
 // Automatic arithmetic assignments
 @assignment [U, V] += : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs + rhs;
-};
+}
 
 @assignment [U, V] -= : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs - rhs;
-};
+}
 
 @assignment [U, V] *= : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs * rhs;
-};
+}
 
 @assignment [U, V] /= : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs / rhs;
-};
+}
 
 @assignment [U, V] @= : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs @ rhs;
-};
+}
 
 @assignment [U, V] %= : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs % rhs;
-};
+}
 
 
 // Automatic logical assignments
 @assignment [U, V] |= : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs | rhs;
-};
+}
 
 @assignment [U, V] <<= : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs << rhs;
-};
+}
 
 @assignment [U, V] >>= : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs >> rhs;
-};
+}
 
 @assignment [U, V] ^= : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs ^ rhs;
-};
+}
 
 @assignment [U, V] &= : (lhs : U&, rhs : V) -> TypeIf<void, HasTrivialAssignments<U>> = {
     lhs = lhs & rhs;
-};
+}

--- a/std/io.c3
+++ b/std/io.c3
@@ -18,7 +18,7 @@ function[@Len] puts : (str: u8[@Len]&) -> int = {
 
     const ret : isize = sys_writev(/* stdout */ 1, &iov, 2);
 
-    if (ret != -1) {
+    if ret != -1 {
         // Upon successful completion, puts() shall return a non-negative
         // number.
         return 0;

--- a/std/io.c3
+++ b/std/io.c3
@@ -1,12 +1,12 @@
-@require_once "arithmetic.c3";
-@require_once "syscalls.c3";
-@require_once "sys/uio.c3";
+@require_once "arithmetic.c3"
+@require_once "syscalls.c3"
+@require_once "sys/uio.c3"
 
 function EOF : () -> int = {
     // EOF - end-of-file return value
     // An integer constant expression with type int and a negative value.
     return -1;
-};
+}
 
 function[@Len] puts : (str: u8[@Len]&) -> int = {
     // puts - put a string on standard output
@@ -28,4 +28,4 @@ function[@Len] puts : (str: u8[@Len]&) -> int = {
     // TODO: shall set an error indicator for the stream,
     // TODO: and errno shall be set to indicate the error.
     return EOF();
-};
+}

--- a/std/logical.c3
+++ b/std/logical.c3
@@ -10,7 +10,7 @@ typedef HasTrivialAssignments<u64> : TrueType
 typedef HasTrivialAssignments<u128> : TrueType
 
 @operator ! : (value : bool) -> bool = {
-    if (value) {
+    if value {
         return false;
     }
     return true;

--- a/std/logical.c3
+++ b/std/logical.c3
@@ -1,51 +1,51 @@
-@require_once "assignments.c3";
-@require_once "type_traits.c3";
-@require_once "util.c3";
+@require_once "assignments.c3"
+@require_once "type_traits.c3"
+@require_once "util.c3"
 
-typedef HasTrivialAssignments<bool> : TrueType;
-typedef HasTrivialAssignments<u8> : TrueType;
-typedef HasTrivialAssignments<u16> : TrueType;
-typedef HasTrivialAssignments<u32> : TrueType;
-typedef HasTrivialAssignments<u64> : TrueType;
-typedef HasTrivialAssignments<u128> : TrueType;
+typedef HasTrivialAssignments<bool> : TrueType
+typedef HasTrivialAssignments<u8> : TrueType
+typedef HasTrivialAssignments<u16> : TrueType
+typedef HasTrivialAssignments<u32> : TrueType
+typedef HasTrivialAssignments<u64> : TrueType
+typedef HasTrivialAssignments<u128> : TrueType
 
 @operator ! : (value : bool) -> bool = {
     if (value) {
         return false;
     }
     return true;
-};
+}
 
 @operator [T] ~ : (value: T) -> TypeIf<T, IsLogical<T>> = {
     return __builtin_bitwise_not(value);
-};
+}
 
 @operator [T] | : (lhs : T, rhs : T) -> TypeIf<T, IsLogical<T>> = {
     return __builtin_bitwise_or(lhs, rhs);
-};
+}
 
 @operator [T] & : (lhs : T, rhs : T) -> TypeIf<T, IsLogical<T>> = {
     return __builtin_bitwise_and(lhs, rhs);
-};
+}
 
 @operator [T] ^ : (lhs : T, rhs : T) -> TypeIf<T, IsLogical<T>> = {
     return __builtin_bitwise_xor(lhs, rhs);
-};
+}
 
 @operator [L, A] << : (value: L, shift_amount: A) -> TypeIf<L, Both<IsLogical<L>, IsIntegral<A>>> = {
     let ushift : L = as_logical(shift_amount);
     return __builtin_shift_left(value, ushift);
-};
+}
 
 @operator [L, A] >> : (value: L, shift_amount: A) -> TypeIf<L, Both<IsLogical<T>, IsIntegral<A>>> = {
     let ushift : L = as_logical(shift_amount);
     return __builtin_shift_right(value, ushift);
-};
+}
 
 @operator [T] == : (lhs: T, rhs: T) -> TypeIf<bool, IsLogical<T>> = {
     return __builtin_is_equal(lhs, rhs);
-};
+}
 
 @operator [T] != : (lhs: T, rhs: T) -> TypeIf<bool, IsLogical<T>> = {
     return !(lhs == rhs);
-};
+}

--- a/std/memory.c3
+++ b/std/memory.c3
@@ -1,36 +1,36 @@
-@require_once "arithmetic.c3";
-@require_once "assert.c3";
-@require_once "logical.c3";
-@require_once "syscalls.c3";
-@require_once "util.c3";
-@require_once "wrappers.c3";
+@require_once "arithmetic.c3"
+@require_once "assert.c3"
+@require_once "logical.c3"
+@require_once "syscalls.c3"
+@require_once "util.c3"
+@require_once "wrappers.c3"
 
 function allocate_page_and_return_address : (length : isize) -> iptr = {
     let prot : u32 = SYS_PROT_READ() | SYS_PROT_WRITE();
     let flags : u32 = SYS_MAP_PRIVATE() | SYS_MAP_ANONYMOUS();
 
     return sys_mmap(0, length, prot, flags, -1, 0);
-};
+}
 
 function deallocate_page : (addr: iptr, length : isize) -> void = {
     sys_munmap(addr, length);
-};
+}
 
 function PAGE_SIZE : () -> isize = {
     return 4096;  // TODO: this should be a compile time constant
-};
+}
 
 typedef AllocatorNode : {
     integrity_check : u64,
     next_node : iptr, // TODO use: Optional<Ptr<AllocatorNode>> (recursive type)
-};
+}
 
 typedef Allocator : {
     // TODO: parameterize `8` as a generic argument
     bin_count: isize,
     integrity_checks : u64[8],
     bins : Optional<Ptr<AllocatorNode>>[8],
-};
+}
 
 function get_allocator_bin_index : (size_required : isize) -> isize = {
     let bin_index : int = 0;
@@ -43,12 +43,12 @@ function get_allocator_bin_index : (size_required : isize) -> isize = {
     }
 
     return bin_index;
-};
+}
 
 function get_block_size_from_bin_index : (bin : isize) -> isize = {
     let bin0_size: u64 = as_logical(sizeof<AllocatorNode>());
     return as_arithmetic(bin0_size << bin);
-};
+}
 
 function allocate_impl : (allocator : Allocator&, requested_size : isize) -> isize = {
     let bin_index : isize = get_allocator_bin_index(requested_size);
@@ -61,19 +61,19 @@ function allocate_impl : (allocator : Allocator&, requested_size : isize) -> isi
         // Otherwise we actually do it ourselves
         return allocate_from_bin_and_return_address(&allocator, bin_index);
     }
-};
+}
 
 
 function [T] allocate : (allocator : Allocator&) -> T& = {
     return &addr_to_ref<T>(allocator:allocate_impl(sizeof<T>()));
-};
+}
 
 function [T] allocate_span : (allocator : Allocator&, length: isize) -> Span<T> = {
     return {
         data : &addr_to_heap_array<T>(allocator:allocate_impl(sizeof<T>() * length)),
         length : length,
     };
-};
+}
 
 
 function deallocate_impl : (allocator : Allocator&, memory_address: isize, size : isize) -> void = {
@@ -83,15 +83,15 @@ function deallocate_impl : (allocator : Allocator&, memory_address: isize, size 
     } else {
         deallocate_to_bin(&allocator, bin_index, memory_address);
     }
-};
+}
 
 function [T] deallocate : (allocator : Allocator&, ref : T&) -> void = {
     allocator:deallocate_impl(__builtin_ptr_to_int(&ref), sizeof<T>());
-};
+}
 
 function [T] deallocate_span : (allocator : Allocator&, span : Span<T>) -> void = {
     allocator:deallocate_impl(__builtin_ptr_to_int(&span.data), sizeof<T>() * span.length);
-};
+}
 
 function deallocate_to_bin : (allocator : Allocator&, bin : isize, addr : iptr) -> void = {
     let integrity_check : u64 = allocator.integrity_checks[bin];
@@ -109,7 +109,7 @@ function deallocate_to_bin : (allocator : Allocator&, bin : isize, addr : iptr) 
         new_node.next_node = 0;
     }
     allocator.bins[bin]:store<Ptr<AllocatorNode>>({&new_node});
-};
+}
 
 function allocate_from_bin_and_return_address : (allocator : Allocator&, bin : isize) -> iptr = {
     // No bins available, lets allocate more memory
@@ -158,7 +158,7 @@ function allocate_from_bin_and_return_address : (allocator : Allocator&, bin : i
 
     // FIXME: we generate invalid code without this return
     return 0;
-};
+}
 
 function initialize_allocator : () -> Allocator = {
     // TODO: should actually check that the bin is a power of 2 bytes
@@ -182,4 +182,4 @@ function initialize_allocator : () -> Allocator = {
         i += 1;
     }
     return allocator;
-};
+}

--- a/std/memory.c3
+++ b/std/memory.c3
@@ -36,7 +36,7 @@ function get_allocator_bin_index : (size_required : isize) -> isize = {
     let bin_index : int = 0;
     let size_over_current_bin : isize = size_required / sizeof<AllocatorNode>();
 
-    while (size_over_current_bin != 0) {
+    while size_over_current_bin != 0 {
         bin_index += 1;
         // TODO: maybe we should have signed bitshift... but also LLVM can defo optimize the division
         size_over_current_bin = size_over_current_bin / 2;
@@ -54,7 +54,7 @@ function allocate_impl : (allocator : Allocator&, requested_size : isize) -> isi
     let bin_index : isize = get_allocator_bin_index(requested_size);
 
     let memory_address : iptr;
-    if (bin_index >= allocator.bin_count) {
+    if bin_index >= allocator.bin_count {
         // We just pass large allocations straight to the kernel
         return allocate_page_and_return_address(requested_size);
     } else {
@@ -78,7 +78,7 @@ function [T] allocate_span : (allocator : Allocator&, length: isize) -> Span<T> 
 
 function deallocate_impl : (allocator : Allocator&, memory_address: isize, size : isize) -> void = {
     let bin_index : isize = get_allocator_bin_index(size);
-    if (bin_index >= allocator.bin_count) {
+    if bin_index >= allocator.bin_count {
         deallocate_page(memory_address, size);
     } else {
         deallocate_to_bin(&allocator, bin_index, memory_address);
@@ -99,7 +99,7 @@ function deallocate_to_bin : (allocator : Allocator&, bin : isize, addr : iptr) 
     let new_node : AllocatorNode& = &addr_to_ref<AllocatorNode>(addr);
     new_node.integrity_check = integrity_check;
 
-    if (allocator.bins[bin]:has_value<Ptr<AllocatorNode>>()) {
+    if allocator.bins[bin]:has_value<Ptr<AllocatorNode>>() {
         let next_node_ptr : Ptr<AllocatorNode> = allocator.bins[bin]:data<Ptr<AllocatorNode>>();
         let next_node : AllocatorNode& = &next_node_ptr:data<AllocatorNode>();
         runtime_assert(next_node.integrity_check == integrity_check);
@@ -113,7 +113,7 @@ function deallocate_to_bin : (allocator : Allocator&, bin : isize, addr : iptr) 
 
 function allocate_from_bin_and_return_address : (allocator : Allocator&, bin : isize) -> iptr = {
     // No bins available, lets allocate more memory
-    if (bin == allocator.bin_count) {
+    if bin == allocator.bin_count {
         runtime_assert(get_block_size_from_bin_index(bin) == PAGE_SIZE());
         return allocate_page_and_return_address(PAGE_SIZE());
     }
@@ -122,14 +122,14 @@ function allocate_from_bin_and_return_address : (allocator : Allocator&, bin : i
     let integrity_check : u64 = allocator.integrity_checks[bin];
 
     // TODO: need template arguments deduction for function calls (especially the UFCS)
-    if (allocator.bins[bin]:has_value<Ptr<AllocatorNode>>()) {
+    if allocator.bins[bin]:has_value<Ptr<AllocatorNode>>() {
         let node_to_pop_ptr : Ptr<AllocatorNode> = allocator.bins[bin]:data<Ptr<AllocatorNode>>();
         let node_to_pop : AllocatorNode& = &node_to_pop_ptr:data<AllocatorNode>();
 
         runtime_assert(node_to_pop.integrity_check == integrity_check);
 
         // TODO: we should eventually just copy the optional without the branch
-        if (node_to_pop.next_node != 0) {
+        if node_to_pop.next_node != 0 {
             let next_node_but_fixme_address : iptr = node_to_pop.next_node;
             let next_node : Ptr<AllocatorNode>& = &addr_to_ref<Ptr<AllocatorNode>>(next_node_but_fixme_address);
 
@@ -171,7 +171,7 @@ function initialize_allocator : () -> Allocator = {
     let i : int = 0;
 
     // TODO: use i < allocator.bins:len() (fails since it cannot dedude arg types)
-    while (i < allocator.bin_count) {
+    while i < allocator.bin_count {
         // TODO: use a true random number
         // TODO: allow 64 bit constants
         allocator.integrity_checks[i] = 0xd2f4bd5b;

--- a/std/sys/uio.c3
+++ b/std/sys/uio.c3
@@ -4,4 +4,4 @@
 typedef iovec : {
     iov_base : u8[&], // Base address of a memory region for input or output.
     iov_len  : isize  // The size of the memory pointed to by iov_base.
-};
+}

--- a/std/syscalls.c3
+++ b/std/syscalls.c3
@@ -1,56 +1,57 @@
-@require_once "util.c3";
-@require_once "sys/uio.c3";
+@require_once "util.c3"
+@require_once "sys/uio.c3"
 
-foreign _syscall_0 : (syscall_number: i64) -> i64;
-foreign _syscall_1 : (a: i64, syscall_number: i64) -> i64;
-foreign _syscall_2 : (a: i64, b: i64, syscall_number: i64) -> i64;
-foreign _syscall_3 : (a: i64, b: i64, c: i64, syscall_number: i64) -> i64;
-foreign _syscall_6 : (a: i64, b: i64, c: i64, d: i64, e: i64, f: i64, syscall_number: i64) -> i64;
+
+foreign _syscall_0 : (syscall_number: i64) -> i64
+foreign _syscall_1 : (a: i64, syscall_number: i64) -> i64
+foreign _syscall_2 : (a: i64, b: i64, syscall_number: i64) -> i64
+foreign _syscall_3 : (a: i64, b: i64, c: i64, syscall_number: i64) -> i64
+foreign _syscall_6 : (a: i64, b: i64, c: i64, d: i64, e: i64, f: i64, syscall_number: i64) -> i64
 
 function sys_write : (fd: int, buffer: u8[&], count: isize) -> isize = {
     const buffer_addr : iptr = __builtin_ptr_to_int(buffer);
 
     return _syscall_3(fd, buffer_addr, count, /* write */ 1);
-};
+}
 
 function sys_writev : (fd: int, iov: iovec[&], iovcnt: int) -> isize = {
     const iov_addr : iptr = __builtin_ptr_to_int(iov);
 
     return _syscall_3(fd, iov_addr, iovcnt, /* writev */ 20);
-};
+}
 
 function sys_fork : () -> i64 = {
     return _syscall_0(/* fork */ 57);
-};
+}
 
 // TODO: support enums (or similar)
 function SYS_PROT_READ : () -> u32 = {
     // https://sites.uclouvain.be/SystInfo/usr/include/bits/mman.h.html
     return 0x01;
-};
+}
 function SYS_PROT_WRITE : () -> u32 = {
     // https://sites.uclouvain.be/SystInfo/usr/include/bits/mman.h.html
     return 0x02;
-};
+}
 
 function SYS_MAP_PRIVATE : () -> u32 = {
     // https://sites.uclouvain.be/SystInfo/usr/include/bits/mman.h.html
     return 0x02;
-};
+}
 
 function SYS_MAP_ANONYMOUS : () -> u32 = {
     // https://sites.uclouvain.be/SystInfo/usr/include/bits/mman.h.html
     return 0x20;
-};
+}
 
 function sys_mmap : (addr: isize, length : isize, prot: u32, flags: u32, fd: i32, offset: isize) -> iptr = {
     return _syscall_6(addr, length, as_arithmetic(prot), as_arithmetic(flags), fd, offset, 9);
-};
+}
 
 function sys_munmap : (addr: isize, length : isize) -> void = {
     _syscall_2(addr, length, 11);
-};
+}
 
 function sys_exit : (code : int) -> void = {
     _syscall_1(code, 60);
-};
+}

--- a/std/type_traits.c3
+++ b/std/type_traits.c3
@@ -1,37 +1,37 @@
-typedef TrueType : {};
-typedef FalseType : {};
-typedef EnableIf<TrueType> : {};
+typedef TrueType : {}
+typedef FalseType : {}
+typedef EnableIf<TrueType> : {}
 
-typedef Both<TrueType,  TrueType>  : TrueType;
-typedef Both<TrueType,  FalseType> : FalseType;
-typedef Both<FalseType, TrueType>  : FalseType;
-typedef Both<FalseType, FalseType> : FalseType;
+typedef Both<TrueType,  TrueType>  : TrueType
+typedef Both<TrueType,  FalseType> : FalseType
+typedef Both<FalseType, TrueType>  : FalseType
+typedef Both<FalseType, FalseType> : FalseType
 
-typedef Either<TrueType,  TrueType>  : TrueType;
-typedef Either<TrueType,  FalseType> : TrueType;
-typedef Either<FalseType, TrueType>  : TrueType;
-typedef Either<FalseType, FalseType> : FalseType;
+typedef Either<TrueType,  TrueType>  : TrueType
+typedef Either<TrueType,  FalseType> : TrueType
+typedef Either<FalseType, TrueType>  : TrueType
+typedef Either<FalseType, FalseType> : FalseType
 
-typedef Not<TrueType> : FalseType;
-typedef Not<FalseType> : TrueType;
+typedef Not<TrueType> : FalseType
+typedef Not<FalseType> : TrueType
 
-typedef[U, V] SelectFirst : U;
-typedef[Type, Condition] TypeIf : SelectFirst<Type, EnableIf<Condition>>;
+typedef[U, V] SelectFirst : U
+typedef[Type, Condition] TypeIf : SelectFirst<Type, EnableIf<Condition>>
 
 // Groupings for the builtin types
-typedef[T] IsIntegral : FalseType;
-typedef IsIntegral<i8> : TrueType;
-typedef IsIntegral<i16> : TrueType;
-typedef IsIntegral<i32> : TrueType;
-typedef IsIntegral<i64> : TrueType;
-typedef IsIntegral<i128> : TrueType;
+typedef[T] IsIntegral : FalseType
+typedef IsIntegral<i8> : TrueType
+typedef IsIntegral<i16> : TrueType
+typedef IsIntegral<i32> : TrueType
+typedef IsIntegral<i64> : TrueType
+typedef IsIntegral<i128> : TrueType
 
-typedef[T] IsLogical : FalseType;
-typedef IsLogical<bool> : TrueType;
-typedef IsLogical<u8> : TrueType;
-typedef IsLogical<u16> : TrueType;
-typedef IsLogical<u32> : TrueType;
-typedef IsLogical<u64> : TrueType;
-typedef IsLogical<u128> : TrueType;
+typedef[T] IsLogical : FalseType
+typedef IsLogical<bool> : TrueType
+typedef IsLogical<u8> : TrueType
+typedef IsLogical<u16> : TrueType
+typedef IsLogical<u32> : TrueType
+typedef IsLogical<u64> : TrueType
+typedef IsLogical<u128> : TrueType
 
-typedef[T] HasTrivialAssignments : FalseType;
+typedef[T] HasTrivialAssignments : FalseType

--- a/std/unistd.c3
+++ b/std/unistd.c3
@@ -1,8 +1,8 @@
-@require_once "std/syscalls.c3";
-@require_once "std/util.c3";
+@require_once "std/syscalls.c3"
+@require_once "std/util.c3"
 
-typedef pid_t : int;
+typedef pid_t : int
 
 function fork : () -> pid_t = {
     return Narrow<pid_t>(sys_fork());
-};
+}

--- a/std/util.c3
+++ b/std/util.c3
@@ -1,10 +1,10 @@
 function [T] sizeof : () -> isize = {
     return __builtin_sizeof<T>();
-};
+}
 
 function [T] alignof : () -> isize = {
     return __builtin_alignof<T>();
-};
+}
 
 function [T] addr_to_ref : (bad_address : i32) -> T& = {
     // NOTE: this overload ensures that we are called with an i64 (with no implict conversions)
@@ -13,30 +13,30 @@ function [T] addr_to_ref : (bad_address : i32) -> T& = {
     // TODO: this should be a static assert/ error
     runtime_assert(false);
     return &__builtin_int_to_ptr<T&>(0);
-};
+}
 
 function [T] addr_to_ref : (address : iptr) -> T& = {
     return &__builtin_int_to_ptr<T&>(address);
-};
+}
 
 function [T] addr_to_heap_array : (bad_address : i32) -> T[&] = {
     // TODO: this should be a static assert/ error
     runtime_assert(false);
     return &__builtin_int_to_ptr<T[&]>(bad_address);
-};
+}
 
 function [T] addr_to_heap_array : (address : iptr) -> T[&] = {
     return &__builtin_int_to_ptr<T[&]>(address);
-};
+}
 
-function as_arithmetic : (value : u8)   -> i8   = { return __builtin_bitcast<i8>(value); };
-function as_arithmetic : (value : u16)  -> i16  = { return __builtin_bitcast<i16>(value); };
-function as_arithmetic : (value : u32)  -> i32  = { return __builtin_bitcast<i32>(value); };
-function as_arithmetic : (value : u64)  -> i64  = { return __builtin_bitcast<i64>(value); };
-function as_arithmetic : (value : u128) -> i128 = { return __builtin_bitcast<i128>(value); };
+function as_arithmetic : (value : u8)   -> i8   = { return __builtin_bitcast<i8>(value); }
+function as_arithmetic : (value : u16)  -> i16  = { return __builtin_bitcast<i16>(value); }
+function as_arithmetic : (value : u32)  -> i32  = { return __builtin_bitcast<i32>(value); }
+function as_arithmetic : (value : u64)  -> i64  = { return __builtin_bitcast<i64>(value); }
+function as_arithmetic : (value : u128) -> i128 = { return __builtin_bitcast<i128>(value); }
 
-function as_logical : (value : i8)   -> u8   = { return __builtin_bitcast<u8>(value); };
-function as_logical : (value : i16)  -> u16  = { return __builtin_bitcast<u16>(value); };
-function as_logical : (value : i32)  -> u32  = { return __builtin_bitcast<u32>(value); };
-function as_logical : (value : i64)  -> u64  = { return __builtin_bitcast<u64>(value); };
-function as_logical : (value : i128) -> u128 = { return __builtin_bitcast<u128>(value); };
+function as_logical : (value : i8)   -> u8   = { return __builtin_bitcast<u8>(value); }
+function as_logical : (value : i16)  -> u16  = { return __builtin_bitcast<u16>(value); }
+function as_logical : (value : i32)  -> u32  = { return __builtin_bitcast<u32>(value); }
+function as_logical : (value : i64)  -> u64  = { return __builtin_bitcast<u64>(value); }
+function as_logical : (value : i128) -> u128 = { return __builtin_bitcast<u128>(value); }

--- a/std/vector.c3
+++ b/std/vector.c3
@@ -22,7 +22,7 @@ function [T] make_vector : (allocator : Allocator&) -> Vector<T> = {
 }
 
 function [T] push_back : (self : Vector<T>&, data : T) -> void = {
-    if (self.length == self.memory.length) {
+    if self.length == self.memory.length{
         // Grow the vector
         let new_capacity : isize = 2 * self.memory.length;
         let new_memory : Span<T> = self.allocator:allocate_span<T>(new_capacity);
@@ -30,7 +30,7 @@ function [T] push_back : (self : Vector<T>&, data : T) -> void = {
         // Copy the old data
         // TODO: use a memcpy/ for loop
         let index : isize = 0;
-        while (index < self.length) {
+        while index < self.length {
             new_memory.data[index] = self.memory.data[index];
             index += 1;
         }

--- a/std/vector.c3
+++ b/std/vector.c3
@@ -1,15 +1,15 @@
-@require_once "arithmetic.c3";
-@require_once "assert.c3";
-@require_once "memory.c3";
-@require_once "wrappers.c3";
+@require_once "arithmetic.c3"
+@require_once "assert.c3"
+@require_once "memory.c3"
+@require_once "wrappers.c3"
 
 typedef [T] Vector : {
     allocator : Allocator&,
     memory : Span<T>,
     length : isize,
-};
+}
 
-function DEFAULT_VECTOR_CAPACITY : () -> isize = { return 8; };
+function DEFAULT_VECTOR_CAPACITY : () -> isize = { return 8; }
 
 function [T] make_vector : (allocator : Allocator&) -> Vector<T> = {
     /* TODO: It'd be kinda nice to NOT allocate by default
@@ -19,7 +19,7 @@ function [T] make_vector : (allocator : Allocator&) -> Vector<T> = {
         memory : allocator:allocate_span<T>(DEFAULT_VECTOR_CAPACITY()),
         length : 0,
     };
-};
+}
 
 function [T] push_back : (self : Vector<T>&, data : T) -> void = {
     if (self.length == self.memory.length) {
@@ -41,48 +41,48 @@ function [T] push_back : (self : Vector<T>&, data : T) -> void = {
     self.memory.data[self.length] = data;
 
     self.length += 1;
-};
+}
 
 function [T] pop_back : (self : Vector<T>&) -> T = {
     runtime_assert(self.length > 0);
 
     self.length -= 1;
     return self.memory.data[self.length];
-};
+}
 
 function [T] get : (self : Vector<T>&, index : isize) -> T = {
     runtime_assert(index >= 0);
     runtime_assert(index < self.length); // TODO: && in previous line
     return self.memory.data[index];
-};
+}
 
 function [T] set : (self : Vector<T>&, index : isize, data : T) -> void = {
     runtime_assert(index >= 0);
     runtime_assert(index < self.length);  // TODO: && in previous line
     self.memory.data[index] = data;
-};
+}
 
 function [T] length : (self : Vector<T>&) -> isize = {
     return self.length;
-};
+}
 
 function [T] capacity : (self : Vector<T>&) -> isize = {
     return self.memory.length;
-};
+}
 
 function [T] clear : (self : Vector<T>&) -> void = {
     // TODO: destructor support (if we add destructors)
     self.length = 0;
-};
+}
 
 function [T] deallocate : (self : Vector<T>&) -> void = {
     // TODO: this aught to be a destructor
     self.allocator:deallocate_span(self.memory);
-};
+}
 
 function [T] data : (self : Vector<T>&) -> Span<T> = {
     return {
         data : &self.memory.data,
         length : self.length,
     };
-};
+}

--- a/std/wrappers.c3
+++ b/std/wrappers.c3
@@ -1,40 +1,40 @@
-typedef [T] Ptr : { _data : T& };
+typedef [T] Ptr : { _data : T& }
 
 function [T] data : (self : Ptr<T>&) -> T& = {
     return &self._data;
-};
+}
 
-typedef [T] Optional : { _value : T, _has_value : bool};
+typedef [T] Optional : { _value : T, _has_value : bool}
 
 function [T] store : (self : Optional<T>&, value : T) -> void = {
     self._value = value;
     self._has_value = true;
-};
+}
 
 function [T] erase : (self : Optional<T>&) -> void = {
     self._has_value = false;
-};
+}
 
 // TODO: this should be a constructor
 function [T] make_optional : () -> Optional<T> = {
     let result : Optional<T>;
     result._has_value = false;
     return result;
-};
+}
 
 function [T] make_optional : (value : T) -> Optional<T> = {
     return {_value : value, _has_value : true};
-};
+}
 
 function [T] data : (self : Optional<T>&) -> T& = {
     return &self._value;
-};
+}
 
 function [T] has_value : (self : Optional<T>&) -> bool = {
     return self._has_value;
-};
+}
 
 typedef [T] Span : {
     data : T[&],
     length : isize,
-};
+}

--- a/tests/arrays/alignment.c3
+++ b/tests/arrays/alignment.c3
@@ -7,7 +7,7 @@ function main : () -> int = {
     let large : int[4];
 
     return 0;
-};
+}
 
 /// @COMPILE
 /// @GREP_IR [3 x i32], align 4

--- a/tests/arrays/array_assignments.c3
+++ b/tests/arrays/array_assignments.c3
@@ -1,8 +1,8 @@
-typedef MyArray : int[3];
+typedef MyArray : int[3]
 
 @operator + : (lhs : int, rhs: int) -> int = {
     return __builtin_add(lhs, rhs);
-};
+}
 
 function main : () -> int = {
     let array : MyArray;
@@ -14,7 +14,7 @@ function main : () -> int = {
     c = 7;  // Sets `array[1]` to 7
     array[2] = 9;
     return array[0] + array[1] + array[2];
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 22

--- a/tests/arrays/array_expression.c3
+++ b/tests/arrays/array_expression.c3
@@ -1,13 +1,13 @@
 function[T] generic_fn : () -> void = {
 
-};
+}
 
 function main : () -> int = {
     let array : int[6];
     array[1] = 1;
     generic_fn<int[6]>();
     return array[1];
-};
+}
 
 
 /// @COMPILE

--- a/tests/arrays/bad_dimensions.c3
+++ b/tests/arrays/bad_dimensions.c3
@@ -1,8 +1,8 @@
-typedef A : int[6, 0];
+typedef A : int[6, 0]
 
 function main: () -> int = {
     return a(0, 0);
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 1, in 'typedef'

--- a/tests/arrays/correct_initialization.c3
+++ b/tests/arrays/correct_initialization.c3
@@ -2,7 +2,7 @@ function main : () -> int = {
     const array : int[4] = { 0, 0, 1, 2 };
 
     return array[3];
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 2

--- a/tests/arrays/heap_array_access.c3
+++ b/tests/arrays/heap_array_access.c3
@@ -2,7 +2,7 @@ function main : () -> int = {
     const str : u8[&] = "ABCD";
 
     return __builtin_bitcast<i8>(str[2]);
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 67

--- a/tests/arrays/initialization_with_wrong_length.c3
+++ b/tests/arrays/initialization_with_wrong_length.c3
@@ -2,7 +2,7 @@ function main : () -> int = {
     const array : int[4] = { 0, 0, 1 };
 
     return array[3];
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> int'

--- a/tests/arrays/initialization_with_wrong_type.c3
+++ b/tests/arrays/initialization_with_wrong_type.c3
@@ -2,7 +2,7 @@ function main : () -> int = {
     const array : int[4] = { 0, 0, 1, "hello!" };
 
     return array[3];
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> int'

--- a/tests/arrays/late_initialization.c3
+++ b/tests/arrays/late_initialization.c3
@@ -4,7 +4,7 @@ function main : () -> int = {
     array = { 0, 0, 1, 2 };
 
     return array[3];
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 2

--- a/tests/arrays/md_heap_array.c3
+++ b/tests/arrays/md_heap_array.c3
@@ -9,16 +9,16 @@ function main : () -> int = {
     heap_array[1, 0, 1] = 1;
     heap_array[1, 1, 1] = 1;
 
-    if (heap_array[0, 0, 1] != 1) {
+    if heap_array[0, 0, 1] != 1{
         return 1;
     }
-    if (heap_array[0, 1, 1] != 1) {
+    if heap_array[0, 1, 1] != 1{
         return 1;
     }
-    if (heap_array[1, 0, 1] != 1) {
+    if heap_array[1, 0, 1] != 1{
         return 1;
     }
-    if (heap_array[1, 1, 1] != 1) {
+    if heap_array[1, 1, 1] != 1{
         return 1;
     }
 

--- a/tests/arrays/md_heap_array.c3
+++ b/tests/arrays/md_heap_array.c3
@@ -1,4 +1,4 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
 function main : () -> int = {
     let stack_array : i32[2, 2, 2];
@@ -23,7 +23,7 @@ function main : () -> int = {
     }
 
     return 0;
-};
+}
 
 /// @COMPILE
 /// @GREP_IR getelementptr inbounds [2 x [2 x i32]]

--- a/tests/assignments/assignment_plus_equals.c3
+++ b/tests/assignments/assignment_plus_equals.c3
@@ -1,12 +1,12 @@
 @assignment += : (lhs : int&, rhs: int) -> void = {
     lhs = __builtin_add(lhs, rhs);
-};
+}
 
 function main : () -> int = {
     let a : int = 0;
     a += 7;
     return a;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 7

--- a/tests/builtin_callables/alignof.c3
+++ b/tests/builtin_callables/alignof.c3
@@ -4,7 +4,7 @@ typedef MyArray1 : i32[5]
 typedef MyArray2 : i8[5]
 
 @operator != : (lhs : isize, rhs : isize) -> bool = {
-    if (__builtin_is_equal(lhs, rhs)) {
+    if __builtin_is_equal(lhs, rhs){
         return false;
     }
     return true;
@@ -15,29 +15,29 @@ function main: () -> int = {
     let align : isize = 0;
 
     align = __builtin_alignof<i16>();
-    if (align != 2) {
+    if align != 2{
         return 1;
     }
 
     align = __builtin_alignof<MyStruct1>();
-    if (align != 4) {
+    if align != 4{
         return 1;
     }
 
     align = __builtin_alignof<MyStruct2>();
-    if (align != 4) {
+    if align != 4{
         return 1;
     }
 
     align = __builtin_alignof<MyArray1>();
     // Arrays of length at least 16 bytes have an alignment of at least 16
     // bytes.
-    if (align != 16) {
+    if align != 16{
         return 1;
     }
 
     align = __builtin_alignof<MyArray2>();
-    if (align != 1) {
+    if align != 1{
         return 1;
     }
 

--- a/tests/builtin_callables/alignof.c3
+++ b/tests/builtin_callables/alignof.c3
@@ -1,14 +1,14 @@
-typedef MyStruct1 : {a : i32, b : i8, c : i16, d : i8};
-typedef MyStruct2 : {a : i8, b : i16, c : i8, d : i32};
-typedef MyArray1 : i32[5];
-typedef MyArray2 : i8[5];
+typedef MyStruct1 : {a : i32, b : i8, c : i16, d : i8}
+typedef MyStruct2 : {a : i8, b : i16, c : i8, d : i32}
+typedef MyArray1 : i32[5]
+typedef MyArray2 : i8[5]
 
 @operator != : (lhs : isize, rhs : isize) -> bool = {
     if (__builtin_is_equal(lhs, rhs)) {
         return false;
     }
     return true;
-};
+}
 
 function main: () -> int = {
     // TODO: we get an uninitialized variable warning without the =0
@@ -42,7 +42,7 @@ function main: () -> int = {
     }
 
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/builtin_callables/arithmetic.c3
+++ b/tests/builtin_callables/arithmetic.c3
@@ -3,7 +3,7 @@
 }
 
 @operator != : (lhs: int, rhs: int) -> bool = {
-    if (lhs == rhs) {
+    if lhs == rhs{
         return false;
     }
     return true;
@@ -56,66 +56,66 @@
 foreign puts : (str: u8[&]) -> int
 
 function main : () -> int = {
-    if (1 + 1 != 3) {
+    if 1 + 1 != 3{
         puts("sanity check\0");
     }
 
     // All of the following check for obvious errors
-    if (2 != 2) {
+    if 2 != 2{
         return 1;
     }
-    if (1 > 2) {
+    if 1 > 2{
         return 1;
     }
-    if (-1 > 2) {
-        return 1;
-    }
-
-    if (2 < 1) {
-        return 1;
-    }
-    if (2 < -1) {
+    if -1 > 2{
         return 1;
     }
 
-    if (1 + 1 != 2) {
+    if 2 < 1{
         return 1;
     }
-    if (-1 + 1 != 0) {
-        return 1;
-    }
-
-    if (3*4 != 12) {
-        return 1;
-    }
-    if (3*-4 != -12) {
+    if 2 < -1{
         return 1;
     }
 
-    if (10 / 4 != 2) {
+    if 1 + 1 != 2{
         return 1;
     }
-    if (-10 / 4 != -2) {
-        return 1;
-    }
-
-    if (9 >> 1 != 4) {
-        return 1;
-    }
-    if (-2 >> 1 != -1) {
-        return 1;
-    }
-    if (9 << 1 != 18) {
+    if -1 + 1 != 0{
         return 1;
     }
 
-    if (5 & 4 != 4) {
+    if 3*4 != 12{
         return 1;
     }
-    if (5 | 4 != 5) {
+    if 3*-4 != -12{
         return 1;
     }
-    if (5 ^ 4 != 1) {
+
+    if 10 / 4 != 2{
+        return 1;
+    }
+    if -10 / 4 != -2{
+        return 1;
+    }
+
+    if 9 >> 1 != 4{
+        return 1;
+    }
+    if -2 >> 1 != -1{
+        return 1;
+    }
+    if 9 << 1 != 18{
+        return 1;
+    }
+
+    if 5 & 4 != 4{
+        return 1;
+    }
+    if 5 | 4 != 5{
+        return 1;
+    }
+    if 5 ^ 4 != 1{
         return 1;
     }
     return 0;

--- a/tests/builtin_callables/arithmetic.c3
+++ b/tests/builtin_callables/arithmetic.c3
@@ -1,59 +1,59 @@
 @operator == : (lhs: int, rhs: int) -> bool = {
     return __builtin_is_equal(lhs, rhs);
-};
+}
 
 @operator != : (lhs: int, rhs: int) -> bool = {
     if (lhs == rhs) {
         return false;
     }
     return true;
-};
+}
 
 @operator < : (lhs: int, rhs: int) -> bool = {
     return __builtin_is_less_than(lhs, rhs);
-};
+}
 
 @operator > : (lhs: int, rhs: int) -> bool = {
     return __builtin_is_greater_than(lhs, rhs);
-};
+}
 
 @operator * : (lhs: int, rhs: int) -> int = {
     return __builtin_multiply(lhs, rhs);
-};
+}
 
 @operator / : (lhs: int, rhs: int) -> int = {
     return __builtin_divide(lhs, rhs);
-};
+}
 
 @operator - : (lhs: int, rhs: int) -> int = {
     return __builtin_subtract(lhs, rhs);
-};
+}
 
 @operator + : (lhs: int, rhs: int) -> int = {
     return __builtin_add(lhs, rhs);
-};
+}
 
 @operator >> : (lhs: int, rhs: int) -> int = {
     return __builtin_shift_right(lhs, rhs);
-};
+}
 
 @operator << : (lhs: int, rhs: int) -> int = {
     return __builtin_shift_left(lhs, rhs);
-};
+}
 
 @operator & : (lhs: int, rhs: int) -> int = {
     return __builtin_bitwise_and(lhs, rhs);
-};
+}
 
 @operator | : (lhs: int, rhs: int) -> int = {
     return __builtin_bitwise_or(lhs, rhs);
-};
+}
 
 @operator ^ : (lhs: int, rhs: int) -> int = {
     return __builtin_bitwise_xor(lhs, rhs);
-};
+}
 
-foreign puts : (str: u8[&]) -> int;
+foreign puts : (str: u8[&]) -> int
 
 function main : () -> int = {
     if (1 + 1 != 3) {
@@ -119,7 +119,7 @@ function main : () -> int = {
         return 1;
     }
     return 0;
-};
+}
 
 /// @COMPILE --use-crt
 /// @RUN; EXPECT OUT

--- a/tests/builtin_callables/narrow.c3
+++ b/tests/builtin_callables/narrow.c3
@@ -3,7 +3,7 @@ function main: () -> int = {
     let b : i8 = __builtin_narrow<i8>(a);
     let c : i8 = __builtin_narrow<i8>(7);
     return __builtin_add(b, c);
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 127

--- a/tests/builtin_callables/sizeof.c3
+++ b/tests/builtin_callables/sizeof.c3
@@ -1,14 +1,14 @@
-typedef MyStruct1 : {a : i32, b : i8, c : i8, d : i16}; // Elements ordered to avoid padding
-typedef MyStruct2 : {a : i8, b : i16, c : i32, d : i8}; // Very poor padding
-typedef MyArray1 : i32[5];
-typedef MyArray2 : i8[5];
+typedef MyStruct1 : {a : i32, b : i8, c : i8, d : i16} // Elements ordered to avoid padding
+typedef MyStruct2 : {a : i8, b : i16, c : i32, d : i8} // Very poor padding
+typedef MyArray1 : i32[5]
+typedef MyArray2 : i8[5]
 
 @operator != : (lhs : isize, rhs : isize) -> bool = {
     if (__builtin_is_equal(lhs, rhs)) {
         return false;
     }
     return true;
-};
+}
 
 function main: () -> int = {
     // TODO: we get an uninitialized variable warning without the =0
@@ -40,7 +40,7 @@ function main: () -> int = {
     }
 
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/builtin_callables/sizeof.c3
+++ b/tests/builtin_callables/sizeof.c3
@@ -4,7 +4,7 @@ typedef MyArray1 : i32[5]
 typedef MyArray2 : i8[5]
 
 @operator != : (lhs : isize, rhs : isize) -> bool = {
-    if (__builtin_is_equal(lhs, rhs)) {
+    if __builtin_is_equal(lhs, rhs){
         return false;
     }
     return true;
@@ -15,27 +15,27 @@ function main: () -> int = {
     let size : isize = 0;
 
     size = __builtin_sizeof<i16>();
-    if (size != 2) {
+    if size != 2{
         return 1;
     }
 
     size = __builtin_sizeof<MyStruct1>();
-    if (size != 8) {
+    if size != 8{
         return 1;
     }
 
     size = __builtin_sizeof<MyStruct2>();
-    if (size != 12) {
+    if size != 12{
         return 1;
     }
 
     size = __builtin_sizeof<MyArray1>();
-    if (size != 20) {
+    if size != 20{
         return 1;
     }
 
     size = __builtin_sizeof<MyArray2>();
-    if (size != 5) {
+    if size != 5{
         return 1;
     }
 

--- a/tests/control_flow/for.c3
+++ b/tests/control_flow/for.c3
@@ -1,20 +1,20 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
-typedef Range : {lower: int, upper: int};
+typedef Range : {lower: int, upper: int}
 
 function range : (lower: int, upper: int) -> Range = {
     return {lower, upper};
-};
+}
 
 @implicit has_next : (range: Range&) -> bool = {
     return range.upper > range.lower;
-};
+}
 
 @implicit get_next : (range: Range&) -> int = {
     let return_value: int = range.lower;
     range.lower += 1;
     return return_value;
-};
+}
 
 function main : () -> int = {
     let sum : int = 0;
@@ -22,7 +22,7 @@ function main : () -> int = {
         sum += i;
     }
     return sum;
-};
+}
 
 
 /// @COMPILE

--- a/tests/control_flow/for.c3
+++ b/tests/control_flow/for.c3
@@ -18,7 +18,7 @@ function range : (lower: int, upper: int) -> Range = {
 
 function main : () -> int = {
     let sum : int = 0;
-    for (i in range(0, 10)) {
+    for i in range(0, 10) {
         sum += i;
     }
     return sum;

--- a/tests/control_flow/if_else.c3
+++ b/tests/control_flow/if_else.c3
@@ -3,13 +3,13 @@
 function main : () -> int = {
     let a : int = 0;
 
-    if (7 == 8) {
+    if 7 == 8{
         return 1;
     } else {
         a = 9;
     }
 
-    if (a == 9) {
+    if a == 9{
         return 0;
     }
     return 1;

--- a/tests/control_flow/if_else.c3
+++ b/tests/control_flow/if_else.c3
@@ -1,4 +1,4 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
 function main : () -> int = {
     let a : int = 0;
@@ -13,7 +13,7 @@ function main : () -> int = {
         return 0;
     }
     return 1;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/control_flow/nested_while_statement.c3
+++ b/tests/control_flow/nested_while_statement.c3
@@ -8,17 +8,17 @@ function main : () -> int = {
     let i : int = 0;
     let sum : int = 0;
 
-    while (is_less_than_20(i)) {
+    while is_less_than_20(i) {
         i = i + 1;
 
         let a : int = 0;
-        while (10 > a) {
+        while 10 > a {
             a = a + 1;
             sum = sum + i;
         }
     }
 
-    if (sum != 2100) {
+    if sum != 2100{
         return 1;
     }
     return 0;

--- a/tests/control_flow/nested_while_statement.c3
+++ b/tests/control_flow/nested_while_statement.c3
@@ -1,8 +1,8 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
 function is_less_than_20 : (arg: int) -> bool = {
     return __builtin_is_less_than(arg, 20);
-};
+}
 
 function main : () -> int = {
     let i : int = 0;
@@ -22,7 +22,7 @@ function main : () -> int = {
         return 1;
     }
     return 0;
-};
+}
 
 
 /// @COMPILE

--- a/tests/control_flow/while_statement.c3
+++ b/tests/control_flow/while_statement.c3
@@ -1,8 +1,8 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
 function is_less_than_20 : (arg: int) -> bool = {
     return __builtin_is_less_than(arg, 20);
-};
+}
 
 function main : () -> int = {
     let i : int = 0;
@@ -13,7 +13,7 @@ function main : () -> int = {
         sum = sum + i;
     }
     return sum;
-};
+}
 
 
 /// @COMPILE

--- a/tests/control_flow/while_statement.c3
+++ b/tests/control_flow/while_statement.c3
@@ -8,7 +8,7 @@ function main : () -> int = {
     let i : int = 0;
     let sum : int = 0;
 
-    while (is_less_than_20(i)) {
+    while is_less_than_20(i) {
         i = i + 1;
         sum = sum + i;
     }

--- a/tests/generic_functions/basic_specialization.c3
+++ b/tests/generic_functions/basic_specialization.c3
@@ -1,24 +1,24 @@
-@require_once "std/io.c3";
+@require_once "std/io.c3"
 
 function normal_overloaded_function : (a : i64) -> int = {
     puts("i64");
     return 0;
-};
+}
 
 function normal_overloaded_function : (a : i32) -> int = {
     puts("i32");
     return 0;
-};
+}
 
 function normal_overloaded_function : (a : i128) -> int = {
     puts("i128");
     return 0;
-};
+}
 
 function[T] generic_fn : () -> int = {
     let a : T = 0;
     return normal_overloaded_function(a);
-};
+}
 
 function main : () -> int = {
     generic_fn<i32>();
@@ -26,7 +26,7 @@ function main : () -> int = {
     generic_fn<i32>();
     generic_fn<i128>();
     return generic_fn<i64>();
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT OUT

--- a/tests/generic_functions/sfinae.c3
+++ b/tests/generic_functions/sfinae.c3
@@ -1,32 +1,32 @@
-typedef TrueType : {};
-typedef FalseType : {};
-typedef EnableIf<TrueType> : int;
+typedef TrueType : {}
+typedef FalseType : {}
+typedef EnableIf<TrueType> : int
 
-typedef Not<TrueType> : FalseType;
-typedef Not<FalseType> : TrueType;
+typedef Not<TrueType> : FalseType
+typedef Not<FalseType> : TrueType
 
-typedef[T] IsLargeIntegral : FalseType;
-typedef IsLargeIntegral<i32> : TrueType;
-typedef IsLargeIntegral<i64> : TrueType;
-typedef IsLargeIntegral<i128> : TrueType;
+typedef[T] IsLargeIntegral : FalseType
+typedef IsLargeIntegral<i32> : TrueType
+typedef IsLargeIntegral<i64> : TrueType
+typedef IsLargeIntegral<i128> : TrueType
 
-foreign puts : (str : u8[&]) -> int;
+foreign puts : (str : u8[&]) -> int
 
 function[T] generic_fn : () -> EnableIf<IsLargeIntegral<T>> = {
     puts("Large integral type\0");
     return 0;
-};
+}
 
 function[T] generic_fn : () -> EnableIf<Not<IsLargeIntegral<T>>> = {
     puts("Small integral type\0");
     return 0;
-};
+}
 
 function main : () -> int = {
     generic_fn<i8>();
     generic_fn<i32>();
     return 0;
-};
+}
 
 /// @COMPILE --use-crt
 /// @RUN; EXPECT OUT

--- a/tests/generic_functions/sfinae_ambiguous.c3
+++ b/tests/generic_functions/sfinae_ambiguous.c3
@@ -1,22 +1,22 @@
-typedef TrueType : {};
-typedef FalseType : {};
-typedef EnableIf<TrueType> : int;
+typedef TrueType : {}
+typedef FalseType : {}
+typedef EnableIf<TrueType> : int
 
-typedef isI32<i32> : TrueType;
+typedef isI32<i32> : TrueType
 
 function[T] generic_fn : () -> EnableIf<isI32<T>> = {
     return 0;
-};
+}
 
 function[T] generic_fn : () -> int = {
     return 0;
-};
+}
 
 
 function main : () -> int = {
     generic_fn<i32>();
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 17, in 'function main: () -> int'

--- a/tests/generic_functions/sfinae_implicit.c3
+++ b/tests/generic_functions/sfinae_implicit.c3
@@ -1,26 +1,26 @@
-typedef TrueType : {};
-typedef FalseType : {};
-typedef EnableIf<TrueType> : int;
+typedef TrueType : {}
+typedef FalseType : {}
+typedef EnableIf<TrueType> : int
 
-typedef Not<TrueType> : FalseType;
-typedef Not<FalseType> : TrueType;
+typedef Not<TrueType> : FalseType
+typedef Not<FalseType> : TrueType
 
-typedef[T] IsLargeIntegral : FalseType;
-typedef IsLargeIntegral<i32> : TrueType;
-typedef IsLargeIntegral<i64> : TrueType;
-typedef IsLargeIntegral<i128> : TrueType;
+typedef[T] IsLargeIntegral : FalseType
+typedef IsLargeIntegral<i32> : TrueType
+typedef IsLargeIntegral<i64> : TrueType
+typedef IsLargeIntegral<i128> : TrueType
 
-foreign puts : (str : u8[&]) -> int;
+foreign puts : (str : u8[&]) -> int
 
 function[T] generic_fn : (a : T) -> EnableIf<IsLargeIntegral<T>> = {
     puts("Large integral type\0");
     return 0;
-};
+}
 
 function[T] generic_fn : (a : T) -> EnableIf<Not<IsLargeIntegral<T>>> = {
     puts("Small integral type\0");
     return 0;
-};
+}
 
 function main : () -> int = {
     let small : i8 = __builtin_narrow<i8>(0);
@@ -29,7 +29,7 @@ function main : () -> int = {
     generic_fn(small);
     generic_fn(big);
     return 0;
-};
+}
 
 /// @COMPILE --use-crt
 /// @RUN; EXPECT OUT

--- a/tests/generic_functions/substitution_failure_inline.c3
+++ b/tests/generic_functions/substitution_failure_inline.c3
@@ -1,15 +1,15 @@
-typedef TrueType : {};
-typedef FalseType : {};
-typedef EnableIf<TrueType> : int;
+typedef TrueType : {}
+typedef FalseType : {}
+typedef EnableIf<TrueType> : int
 
-typedef[T] IsI32 : FalseType;
-typedef IsI32<i32> : TrueType;
+typedef[T] IsI32 : FalseType
+typedef IsI32<i32> : TrueType
 
 
 function main : () -> int = {
     let a : EnableIf<IsI32<i8>> = 0;
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 10, in 'function main: () -> int'

--- a/tests/generic_functions/substitution_impossible.c3
+++ b/tests/generic_functions/substitution_impossible.c3
@@ -1,15 +1,15 @@
-typedef TrueType : {};
-typedef FalseType : {};
-typedef EnableIf<TrueType> : int;
+typedef TrueType : {}
+typedef FalseType : {}
+typedef EnableIf<TrueType> : int
 
 function[T] generic_fn : () -> EnableIf<Typo<T>> = {
     return 0;
-};
+}
 
 function main : () -> int = {
     generic_fn<i8>();
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 10, in 'function main: () -> int'

--- a/tests/generic_types/basic_usage.c3
+++ b/tests/generic_types/basic_usage.c3
@@ -1,10 +1,10 @@
-typedef[T, U, V] my_struct : {a: T, b: U, c: V};
+typedef[T, U, V] my_struct : {a: T, b: U, c: V}
 
 function main: () -> int = {
     let s : my_struct<i32, i16, i8>;
 
     return 0;
-};
+}
 
 /// @COMPILE
 /// @GREP_IR %type.__T_my_struct__S__T_i32__T_i16__T_i8 = type {i32, i16, i8}

--- a/tests/generic_types/duplicate_generic_parameters.c3
+++ b/tests/generic_types/duplicate_generic_parameters.c3
@@ -1,9 +1,9 @@
-typedef[T, T] my_struct : {a: T, b: T};
+typedef[T, T] my_struct : {a: T, b: T}
 
 function main: () -> int = {
     // Linker fails without a main().
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 1, in 'typedef my_struct : ...'

--- a/tests/generic_types/duplicate_type_specialization.c3
+++ b/tests/generic_types/duplicate_type_specialization.c3
@@ -1,7 +1,7 @@
-typedef[T] MyType : bool;
-typedef MyType<int> : int;
-typedef MyType<u8> : bool;
-typedef MyType<u8> : int;
+typedef[T] MyType : bool
+typedef MyType<int> : int
+typedef MyType<u8> : bool
+typedef MyType<u8> : int
 
 /// @COMPILE; EXPECT ERR
 /// File *.c3', line 4, in 'typedef'

--- a/tests/generic_types/nested_generic_annotations.c3
+++ b/tests/generic_types/nested_generic_annotations.c3
@@ -1,12 +1,12 @@
 // Error: generic 'T' has a generic annotation (generic types may not have
 // additional generic annotations)
-typedef[T, U] struct_t: {a: T<U>};
+typedef[T, U] struct_t: {a: T<U>}
 
 function main: () -> int = {
     let s: struct_t<int, int>; // unused typedef's are not parsed
 
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 3, in 'typedef'

--- a/tests/generic_types/specializations.c3
+++ b/tests/generic_types/specializations.c3
@@ -18,12 +18,12 @@ function to_value : (_: FalseType) -> bool = {
 
 function main : () -> int = {
     let result1 : IsIntegral<u16> = {};
-    if (to_value(result1)) {
+    if to_value(result1){
         puts("u16 is integral\0");
     }
 
     let result2 : IsIntegral<u8[&]> = {};
-    if (to_value(result2)) {
+    if to_value(result2){
         // Should not run
         puts("u8[&] is integral\0");
     }

--- a/tests/generic_types/specializations.c3
+++ b/tests/generic_types/specializations.c3
@@ -1,20 +1,20 @@
-typedef TrueType : {};
-typedef FalseType : {};
+typedef TrueType : {}
+typedef FalseType : {}
 
-typedef[T] IsIntegral : FalseType;
-typedef IsIntegral<int> : TrueType;
-typedef IsIntegral<u8> : TrueType;
-typedef IsIntegral<u16> : TrueType;
+typedef[T] IsIntegral : FalseType
+typedef IsIntegral<int> : TrueType
+typedef IsIntegral<u8> : TrueType
+typedef IsIntegral<u16> : TrueType
 
-foreign puts : (str : u8[&]) -> int;
+foreign puts : (str : u8[&]) -> int
 
 function to_value : (_: TrueType) -> bool = {
     return true;
-};
+}
 
 function to_value : (_: FalseType) -> bool = {
     return false;
-};
+}
 
 function main : () -> int = {
     let result1 : IsIntegral<u16> = {};
@@ -28,7 +28,7 @@ function main : () -> int = {
         puts("u8[&] is integral\0");
     }
     return 0;
-};
+}
 
 /// @COMPILE --use-crt
 /// @RUN; EXPECT OUT

--- a/tests/main_return_type/invalid.c3
+++ b/tests/main_return_type/invalid.c3
@@ -1,8 +1,8 @@
-typedef my_int : i64;
+typedef my_int : i64
 
 function main : () -> my_int = {
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 3, in 'function signature'

--- a/tests/main_return_type/valid.c3
+++ b/tests/main_return_type/valid.c3
@@ -1,7 +1,7 @@
-typedef my_int : i32;
+typedef my_int : i32
 
 function main : () -> my_int = {
     return 0;
-};
+}
 
 /// @COMPILE

--- a/tests/misc/ambiguous_function_call.c3
+++ b/tests/misc/ambiguous_function_call.c3
@@ -1,9 +1,9 @@
-function a : (x: i32, y: i64) -> int = { return 0; };
-function a : (x: i64, y: i32) -> int = { return 1; };
+function a : (x: i32, y: i64) -> int = { return 0; }
+function a : (x: i64, y: i32) -> int = { return 1; }
 
 function main: () -> int = {
     return a(0, 0);
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 5, in 'function main: () -> int'

--- a/tests/misc/fork.c3
+++ b/tests/misc/fork.c3
@@ -5,7 +5,7 @@
 function main : () -> int = {
     const pid : pid_t = fork();
 
-    if (pid != 0) {
+    if pid != 0{
         puts<6>("Parent");
     } else {
         puts<5>("Child");

--- a/tests/misc/fork.c3
+++ b/tests/misc/fork.c3
@@ -1,6 +1,6 @@
-@require_once "std/arithmetic.c3";
-@require_once "std/io.c3";
-@require_once "std/unistd.c3";
+@require_once "std/arithmetic.c3"
+@require_once "std/io.c3"
+@require_once "std/unistd.c3"
 
 function main : () -> int = {
     const pid : pid_t = fork();
@@ -12,7 +12,7 @@ function main : () -> int = {
     }
 
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT OUT

--- a/tests/misc/function_without_return.c3
+++ b/tests/misc/function_without_return.c3
@@ -2,7 +2,7 @@ function without_return : (a : bool) -> int = {
     if (a) {
         return 7;
     }
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 5, in 'function without_return: (bool) -> int'

--- a/tests/misc/function_without_return.c3
+++ b/tests/misc/function_without_return.c3
@@ -1,5 +1,5 @@
 function without_return : (a : bool) -> int = {
-    if (a) {
+    if a{
         return 7;
     }
 }

--- a/tests/misc/generic_type_with_int_parameter.c3
+++ b/tests/misc/generic_type_with_int_parameter.c3
@@ -1,6 +1,6 @@
-@require_once "std/io.c3";
+@require_once "std/io.c3"
 
-typedef[@Len] string : u8[@Len];
+typedef[@Len] string : u8[@Len]
 
 function main: () -> int = {
     // XXX we truncate array types.
@@ -9,7 +9,7 @@ function main: () -> int = {
     puts<2>(&const str);
 
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT OUT

--- a/tests/misc/manual_iterators.c3
+++ b/tests/misc/manual_iterators.c3
@@ -1,15 +1,15 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
-typedef MyType : {val : int};
+typedef MyType : {val : int}
 
 @implicit has_next : (a : MyType&) -> bool = {
     return true;
-};
+}
 
 @implicit get_next : (a : MyType&) -> int = {
     a.val += 1;
     return a.val;
-};
+}
 
 function main : () -> int = {
     let a : MyType = {0};
@@ -22,7 +22,7 @@ function main : () -> int = {
         return 0;
     }
     return a.val;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 4

--- a/tests/misc/manual_iterators.c3
+++ b/tests/misc/manual_iterators.c3
@@ -18,7 +18,7 @@ function main : () -> int = {
     __builtin_get_next(&a);
     __builtin_get_next(&a);
 
-    if (!__builtin_has_next(&a)) {
+    if !__builtin_has_next(&a){
         return 0;
     }
     return a.val;

--- a/tests/misc/operator_parsing.c3
+++ b/tests/misc/operator_parsing.c3
@@ -1,64 +1,64 @@
-foreign puts : (str: u8[&]) -> int;
+foreign puts : (str: u8[&]) -> int
 
 @operator - : (val: int) -> int = {
     // unary_operator: highest precedence.
     puts("-\0");
     return 0;
-};
+}
 
 @operator ** : (rhs: int, lhs: int) -> int = {
     // power.
     puts("**\0");
     return 0;
-};
+}
 
 @operator * : (rhs: int, lhs: int) -> int = {
     // mult_div.
     puts("*\0");
     return 0;
-};
+}
 
 @operator + : (rhs: int, lhs: int) -> int = {
     // add_sub.
     puts("+\0");
     return 0;
-};
+}
 
 @operator >> : (rhs: int, lhs: int) -> int = {
     // bit_shift.
     puts(">>\0");
     return 0;
-};
+}
 
 @operator & : (rhs: int, lhs: int) -> int = {
     // bitwise_and.
     puts("&\0");
     return 0;
-};
+}
 
 @operator ^ : (rhs: int, lhs: int) -> int = {
     // bitwise_xor.
     puts("^\0");
     return 0;
-};
+}
 
 @operator | : (rhs: int, lhs: int) -> int = {
     // bitwise_or.
     puts("|\0");
     return 0;
-};
+}
 
 @operator == : (rhs: int, lhs: int) -> bool = {
     // comparison_op.
     puts("==\0");
     return false;
-};
+}
 
 function main : () -> int = {
     const a: int = 0;
     const r: bool = -a**5 * 2 >> 3 + 2 ^ 1 | 1 & 0 == 0;
     return 0;
-};
+}
 
 /// @COMPILE --use-crt
 /// @RUN; EXPECT OUT

--- a/tests/misc/order_of_operations.c3
+++ b/tests/misc/order_of_operations.c3
@@ -1,29 +1,29 @@
-foreign puts : (str: u8[&]) -> int;
+foreign puts : (str: u8[&]) -> int
 
 @operator + : (rhs: int, lhs: int) -> int = {
     puts("+\0");
     return 0;
-};
+}
 
 @operator * : (rhs: int, lhs: int) -> int = {
     puts("*\0");
     return 0;
-};
+}
 
 @operator | : (rhs: int, lhs: int) -> bool = {
     puts("|\0");
     return false;
-};
+}
 
 @operator ** : (rhs: int, lhs: int) -> int = {
     puts("**\0");
     return 0;
-};
+}
 
 @operator == : (rhs: int, lhs: int) -> bool = {
     puts("==\0");
     return false;
-};
+}
 
 function main : () -> int = {
     const a: int = 1 + 2 * 3;
@@ -32,7 +32,7 @@ function main : () -> int = {
     const d: int = 1 * 2 ** 8 * 3;
     const e: bool = 1 * 2 == 8 * 3;
     return 0;
-};
+}
 
 /// @COMPILE --use-crt
 /// @RUN; EXPECT OUT

--- a/tests/misc/overload_resolution_does_not_dereference.c3
+++ b/tests/misc/overload_resolution_does_not_dereference.c3
@@ -1,7 +1,7 @@
-@require_once "std/io.c3";
+@require_once "std/io.c3"
 
-function f: (x: int, y: int) -> int = { puts("val"); return 0; };
-function f: (x: int&, y: i64) -> int = { puts("ref"); return 0; };
+function f: (x: int, y: int) -> int = { puts("val"); return 0; }
+function f: (x: int&, y: i64) -> int = { puts("ref"); return 0; }
 
 function main: () -> int = {
     let x: int = 4;
@@ -11,7 +11,7 @@ function main: () -> int = {
     f(&x, y);
 
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT OUT

--- a/tests/misc/process_args.c3
+++ b/tests/misc/process_args.c3
@@ -5,7 +5,7 @@ function strlen : (cstr: u8[&]) -> isize = {
     let len : isize = 0;
     const null : u8[1]& = "\0";
 
-    while (cstr[len] != null[0]) {
+    while cstr[len] != null[0] {
         len = len + 1;
     }
 
@@ -15,7 +15,7 @@ function strlen : (cstr: u8[&]) -> isize = {
 function main : (argc: int, argv: u8[&][&]) -> int = {
     let i : int = 0;
 
-    while (i < argc) {
+    while i < argc {
         sys_write(/* stdout */ 1, &argv[i], strlen(&argv[i]));
         sys_write(/* stdout */ 1, "\n", 1);
         i = i + 1;

--- a/tests/misc/process_args.c3
+++ b/tests/misc/process_args.c3
@@ -1,5 +1,5 @@
-@require_once "std/arithmetic.c3";
-@require_once "std/syscalls.c3";
+@require_once "std/arithmetic.c3"
+@require_once "std/syscalls.c3"
 
 function strlen : (cstr: u8[&]) -> isize = {
     let len : isize = 0;
@@ -10,7 +10,7 @@ function strlen : (cstr: u8[&]) -> isize = {
     }
 
     return len;
-};
+}
 
 function main : (argc: int, argv: u8[&][&]) -> int = {
     let i : int = 0;
@@ -22,7 +22,7 @@ function main : (argc: int, argv: u8[&][&]) -> int = {
     }
 
     return argc;
-};
+}
 
 /// @COMPILE
 /// @RUN a bb ccc; EXPECT 4; EXPECT OUT

--- a/tests/misc/recursive_types.c3
+++ b/tests/misc/recursive_types.c3
@@ -1,26 +1,26 @@
-typedef[T] Ptr : {data: T&};
+typedef[T] Ptr : {data: T&}
 typedef[T] LinkedListNode1 : {
     next: Ptr<LinkedListNode1<T>>,
     data: T
-};
+}
 
-typedef[T] Wrapper : {data: T};
+typedef[T] Wrapper : {data: T}
 typedef[T] LinkedListNode2 : {
     next: Wrapper<LinkedListNode2<T>>&,
     data: T
-};
+}
 
 typedef[T] LinkedListNode3 : {
     next: Wrapper<LinkedListNode3<T>&>,
     data: T
-};
+}
 
 function main : () -> int = {
     let a : LinkedListNode1<int>;
     let b : LinkedListNode2<int>;
     let c : LinkedListNode3<int>;
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/misc/recursive_types_unresolvable.c3
+++ b/tests/misc/recursive_types_unresolvable.c3
@@ -1,14 +1,14 @@
-typedef[T] Ptr : {data: T};
+typedef[T] Ptr : {data: T}
 
 typedef[T] LinkedListNode : {
     next: Ptr<LinkedListNode<T>>,
     data: T
-};
+}
 
 function main : () -> int = {
     let a : LinkedListNode<int>;
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 9, in 'function main: () -> int'

--- a/tests/misc/reference_borrowing.c3
+++ b/tests/misc/reference_borrowing.c3
@@ -1,12 +1,12 @@
 function func : (var : int&) -> i32 = {
     return var;
-};
+}
 
 function main: () -> int = {
     let a: int = 7;
     let b: int& = &a;
     return func(&b);
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 7

--- a/tests/misc/reference_nesting.c3
+++ b/tests/misc/reference_nesting.c3
@@ -1,13 +1,13 @@
-typedef int_ref : int&;
+typedef int_ref : int&
 
-function d : (var : int_ref&) -> int = { return var; };
+function d : (var : int_ref&) -> int = { return var; }
 
 function main: () -> int = {
     let a: int = 2;
     let b: int& = &a;
     let c: int_ref& = &b;
     return d(&c);
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*/reference_nesting.c3', line 3, in 'function signature'

--- a/tests/misc/reference_overloading.c3
+++ b/tests/misc/reference_overloading.c3
@@ -1,16 +1,16 @@
-@require_once "std/io.c3";
+@require_once "std/io.c3"
 
-typedef MyStruct : {a : int};
+typedef MyStruct : {a : int}
 
 function fn : (a: int) -> int = {
     puts("val");
     return 0;
-};
+}
 
 function fn : (a: int&) -> int = {
     puts("ref");
     return 0;
-};
+}
 
 function main: () -> int = {
     let x: int = 0;
@@ -21,7 +21,7 @@ function main: () -> int = {
     fn(&my_struct.a);
     fn(my_struct.a);
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT OUT

--- a/tests/misc/simple_typedef.c3
+++ b/tests/misc/simple_typedef.c3
@@ -1,13 +1,13 @@
-typedef my_new_type : int;
-typedef my_new_type_2 : my_new_type;
+typedef my_new_type : int
+typedef my_new_type_2 : my_new_type
 
 function b : (input : my_new_type_2) -> int = {
     return __builtin_add(2, input);
-};
+}
 
 function main: () -> int = {
     return b(6);
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 8

--- a/tests/misc/string_constants.c3
+++ b/tests/misc/string_constants.c3
@@ -1,4 +1,4 @@
-foreign puts: (str: u8[&]) -> int;
+foreign puts: (str: u8[&]) -> int
 
 function main: () -> int = {
     // There are two characters between the β and the γ:
@@ -6,7 +6,7 @@ function main: () -> int = {
     // - https://unicode-table.com/en/2000/ (0xe28080 in utf-8)
     puts("άβ­ γ");
     return 0;
-};
+}
 
 /// @COMPILE --use-crt
 /// @GREP_IR [11 x i8] c"άβ\c2\ad\e2\80\80γ"

--- a/tests/misc/subexpression_ordering.c3
+++ b/tests/misc/subexpression_ordering.c3
@@ -1,25 +1,25 @@
-foreign puts : (str: u8[&]) -> int;
+foreign puts : (str: u8[&]) -> int
 
 function a : () -> int = {
     puts("a\0");
     return 1;
-};
+}
 
 function b : (b: int) -> int = {
     puts("b\0");
     return 7;
-};
+}
 
 function c : () -> int = {
     puts("c\0");
     return 1;
-};
+}
 
 function main: () -> int = {
     b(c());
     c();
     return a();
-};
+}
 
 /// @COMPILE --use-crt
 /// @RUN; EXPECT 1; EXPECT OUT

--- a/tests/misc/syntax_error_inline.c3
+++ b/tests/misc/syntax_error_inline.c3
@@ -2,7 +2,7 @@ function main : () -> int = {
     // TODO: test caret position
     let hello int = 0;
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 3

--- a/tests/misc/syntax_error_overlineline.c3
+++ b/tests/misc/syntax_error_overlineline.c3
@@ -1,11 +1,11 @@
 function main : () -> int = {
     // TODO: test caret position
     return 0
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 4
 /// return 0
-/// };
+/// }
 /// ^
 /// Error: invalid syntax, unexpected symbol

--- a/tests/misc/ufcs_call.c3
+++ b/tests/misc/ufcs_call.c3
@@ -1,16 +1,16 @@
 @operator +: (a: int, b: int) -> int = {
     return __builtin_add(a, b);
-};
+}
 
 function add: (this: int&, that: int) -> int& = {
     this = this + that;
     return &this;
-};
+}
 
 function main: () -> int = {
     let x: int = 2;
     return x:add(-1):add(3);
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 4

--- a/tests/misc/unary_operators.c3
+++ b/tests/misc/unary_operators.c3
@@ -1,18 +1,18 @@
-foreign puts : (str: u8[&]) -> int;
+foreign puts : (str: u8[&]) -> int
 
 function a : () -> int = {
     puts("a\0");
     return 1;
-};
+}
 
 @operator - : (rhs: int) -> int = {
     puts("-\0");
     return __builtin_add(rhs, 6);
-};
+}
 
 function main: () -> int = {
     return -a();
-};
+}
 
 /// @COMPILE --use-crt
 /// @RUN; EXPECT 7; EXPECT OUT

--- a/tests/misc/undeclared_variable.c3
+++ b/tests/misc/undeclared_variable.c3
@@ -1,6 +1,6 @@
 function main: () -> int = {
     return x;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> int'

--- a/tests/misc/uninitialized_variable_usage.c3
+++ b/tests/misc/uninitialized_variable_usage.c3
@@ -1,7 +1,7 @@
 function main: () -> int = {
     let x: int;
     return x;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 3, in 'function main: () -> int'

--- a/tests/misc/variable_assignments.c3
+++ b/tests/misc/variable_assignments.c3
@@ -1,6 +1,6 @@
 @operator + : (lhs : int, rhs: int) -> int = {
     return __builtin_add(lhs, rhs);
-};
+}
 
 function main : () -> int = {
     let x : int = 1;
@@ -10,7 +10,7 @@ function main : () -> int = {
     x = 3;
     b = 4;  // Sets `a` to 4
     return a + x + b;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 11

--- a/tests/modules/ambiguous_imports/_import.c3
+++ b/tests/modules/ambiguous_imports/_import.c3
@@ -1,3 +1,3 @@
 function test : () -> int = {
     return 6;
-};
+}

--- a/tests/modules/ambiguous_imports/ambiguous_imports.c3
+++ b/tests/modules/ambiguous_imports/ambiguous_imports.c3
@@ -1,8 +1,8 @@
-@require_once "_import.c3";
+@require_once "_import.c3"
 
 function main : () -> int = {
     return test();
-};
+}
 
 /// @COMPILE -Iincluded; EXPECT ERR
 /// File '*.c3', line 1, in '@require_once "_import.c3"'

--- a/tests/modules/ambiguous_imports/included/_import.c3
+++ b/tests/modules/ambiguous_imports/included/_import.c3
@@ -1,3 +1,3 @@
 function test : () -> int = {
     return 1;
-};
+}

--- a/tests/modules/circular_imports.c3
+++ b/tests/modules/circular_imports.c3
@@ -1,4 +1,4 @@
-@require_once "circular_imports.c3";
+@require_once "circular_imports.c3"
 
 /// @COMPILE; EXPECT ERR
 /// File '*/circular_imports.c3', line 1, in '@require_once "circular_imports.c3"'

--- a/tests/modules/correct_usage/correct_usage.c3
+++ b/tests/modules/correct_usage/correct_usage.c3
@@ -1,13 +1,13 @@
-@require_once "subdir/_thing.c3";
-@require_once "_stuff.c3";
-@require_once "_stuff.c3";
-@require_once "_stuff.c3";
+@require_once "subdir/_thing.c3"
+@require_once "_stuff.c3"
+@require_once "_stuff.c3"
+@require_once "_stuff.c3"
 
 function main : () -> int = {
     let a : SubDirStruct;
 
     return __builtin_add(do_thing(), do_stuff());
-};
+}
 
 /// @COMPILE -Iincluded
 /// @RUN; EXPECT 9

--- a/tests/modules/correct_usage/included/_stuff.c3
+++ b/tests/modules/correct_usage/included/_stuff.c3
@@ -1,3 +1,3 @@
 function do_stuff : () -> int = {
     return 6;
-};
+}

--- a/tests/modules/correct_usage/subdir/_other_thing.c3
+++ b/tests/modules/correct_usage/subdir/_other_thing.c3
@@ -1,3 +1,3 @@
 function do_other_thing : () -> int = {
     return 2;
-};
+}

--- a/tests/modules/correct_usage/subdir/_thing.c3
+++ b/tests/modules/correct_usage/subdir/_thing.c3
@@ -1,7 +1,7 @@
-@require_once "_other_thing.c3";
+@require_once "_other_thing.c3"
 
-typedef SubDirStruct : {item : int};
+typedef SubDirStruct : {item : int}
 
 function do_thing : () -> int = {
     return __builtin_add(do_other_thing(), 1);
-};
+}

--- a/tests/parameter_packs/lookup_error.c3
+++ b/tests/parameter_packs/lookup_error.c3
@@ -1,14 +1,14 @@
 function[Ts...] inner: (args: Ts...) -> int = {
     return 0;
-};
+}
 
 function[T, Ys...] outer: (curr: T, next: Ys...) -> int = {
     return inner(undefined...);
-};
+}
 
 function main : () -> int = {
     return outer(1, 2, 3);
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 6, in 'function outer<int, int, int>: (int, int, int) -> int'

--- a/tests/parameter_packs/nested_scopes.c3
+++ b/tests/parameter_packs/nested_scopes.c3
@@ -3,7 +3,7 @@ function[Ts...] inner: (args: Ts...) -> int = {
 }
 
 function[T, Ys...] outer: (curr: T, next: Ys...) -> int = {
-    if (true) {
+    if true{
         return inner(next...);
     } else {
         return 1;

--- a/tests/parameter_packs/nested_scopes.c3
+++ b/tests/parameter_packs/nested_scopes.c3
@@ -1,6 +1,6 @@
 function[Ts...] inner: (args: Ts...) -> int = {
     return 0;
-};
+}
 
 function[T, Ys...] outer: (curr: T, next: Ys...) -> int = {
     if (true) {
@@ -8,11 +8,11 @@ function[T, Ys...] outer: (curr: T, next: Ys...) -> int = {
     } else {
         return 1;
     }
-};
+}
 
 function main : () -> int = {
     return outer(1, 2, 3);
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/parameter_packs/pack_length.c3
+++ b/tests/parameter_packs/pack_length.c3
@@ -1,22 +1,22 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
-typedef S : {};
-typedef T : {};
+typedef S : {}
+typedef T : {}
 
 function[T] pack_len: (curr: T) -> int = {
     return 1;
-};
+}
 
 function[T, Ys...] pack_len: (curr: T, next: Ys...) -> int = {
     return pack_len(next...) + 1;
-};
+}
 
 function main : () -> int = {
     const s : S = {};
     const t : T = {};
 
     return pack_len(1, 2, 3, s, t);
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 5

--- a/tests/references/function_return.c3
+++ b/tests/references/function_return.c3
@@ -1,8 +1,8 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
 function test_fn : (arg : int&) -> int& = {
     return &arg;
-};
+}
 
 function main : () -> int = {
     let a : int = 0;
@@ -14,7 +14,7 @@ function main : () -> int = {
     test_fn(&b) = 9;
 
     return a + b;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 19

--- a/tests/references/function_return_bad_ref.c3
+++ b/tests/references/function_return_bad_ref.c3
@@ -1,6 +1,6 @@
 function test_fn : (arg : int&) -> int& = {
     return arg;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function test_fn: (int&) -> int&'

--- a/tests/references/function_return_bad_ref_stack.c3
+++ b/tests/references/function_return_bad_ref_stack.c3
@@ -1,7 +1,7 @@
 function test_fn : (arg : int) -> int& = {
     // This should not give an error message that recommends a borrow since arg would be out-of-scope.
     return arg;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 3, in 'function test_fn: (int) -> int&'

--- a/tests/references/function_return_without_borrow.c3
+++ b/tests/references/function_return_without_borrow.c3
@@ -1,6 +1,6 @@
 function test_fn : (arg : int&) -> int& = {
     return &arg;
-};
+}
 
 function main : () -> int = {
     let a : int = 0;
@@ -9,7 +9,7 @@ function main : () -> int = {
     a_ref = 10;
 
     return a;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 7, in 'function main: () -> int'

--- a/tests/regressions/alias_pattern_matching.c3
+++ b/tests/regressions/alias_pattern_matching.c3
@@ -1,6 +1,6 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
-function[T] foo: (i: isize, j: T) -> void = {};
+function[T] foo: (i: isize, j: T) -> void = {}
 
 function main : () -> int = {
     const i: isize = 2;
@@ -9,6 +9,6 @@ function main : () -> int = {
     foo(i + 1, 0);
 
     return 0;
-};
+}
 
 /// @COMPILE

--- a/tests/regressions/ambiguous_parsing.c3
+++ b/tests/regressions/ambiguous_parsing.c3
@@ -16,7 +16,7 @@ function [T] foo : () -> T = {
 function main : () -> int = {
     let val : A<B<int>> = foo<A<B<int>>>();
 
-    if (0 < 1) {
+    if 0 < 1{
         return -val.a.b;
     } else {
         return 1;

--- a/tests/regressions/ambiguous_parsing.c3
+++ b/tests/regressions/ambiguous_parsing.c3
@@ -1,17 +1,17 @@
-typedef [T] A : { a : T };
-typedef [T] B : { b : T };
+typedef [T] A : { a : T }
+typedef [T] B : { b : T }
 
 function [T] foo : () -> T = {
     return {{2}};
-};
+}
 
 @operator - : (value : int) -> int = {
     return value;
-};
+}
 
 @operator < : (a : int, b: int) -> bool = {
     return true;
-};
+}
 
 function main : () -> int = {
     let val : A<B<int>> = foo<A<B<int>>>();
@@ -24,7 +24,7 @@ function main : () -> int = {
 
     // FIXME https://github.com/DaveDuck321/GrapheneLang/issues/72
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 2

--- a/tests/regressions/array_type_mangling.c3
+++ b/tests/regressions/array_type_mangling.c3
@@ -1,11 +1,11 @@
 function foo : (a : int[2, 3]) -> int = {
     return 0;
-};
+}
 
 function main : () -> int = {
     // FIXME call foo() once we support array constants.
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/regressions/builtin_redefinition.c3
+++ b/tests/regressions/builtin_redefinition.c3
@@ -1,4 +1,4 @@
-typedef int : i8;
+typedef int : i8
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 1, in 'typedef'

--- a/tests/regressions/equivalent_types.c3
+++ b/tests/regressions/equivalent_types.c3
@@ -1,17 +1,17 @@
-typedef A : { x : int };
-typedef B : A;
+typedef A : { x : int }
+typedef B : A
 
 function foo : () -> B = {
     let a : A = {1};
     return a;
-};
+}
 
 function main : () -> int = {
     // This would erroneously cause a codegen error, even though our typesystem worked
     // `error: value doesn't match function result type '%type.__T_B = type { i32 }'`
     let a : A = foo();
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 0

--- a/tests/regressions/forwarding_numeric_generic_parameter.c3
+++ b/tests/regressions/forwarding_numeric_generic_parameter.c3
@@ -1,12 +1,12 @@
-typedef[@Len] S : int[@Len];
-typedef[@Len] T1 : S<@Len>;
+typedef[@Len] S : int[@Len]
+typedef[@Len] T1 : S<@Len>
 
 
 function main : () -> int = {
     let a : T1<10>;
     a[8] = 6;
     return a[8];
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 6

--- a/tests/regressions/lli_crt.c3
+++ b/tests/regressions/lli_crt.c3
@@ -1,11 +1,11 @@
-foreign gnu_get_libc_version : () -> u8[&];
+foreign gnu_get_libc_version : () -> u8[&]
 
-foreign puts : (str: u8[&]) -> int;
+foreign puts : (str: u8[&]) -> int
 
 function main : () -> int = {
     puts(&gnu_get_libc_version());
     return 0;
-};
+}
 
 /// @COMPILE --use-crt
 /// @RUN; EXPECT OUT

--- a/tests/regressions/overload_by_number_of_arguments.c3
+++ b/tests/regressions/overload_by_number_of_arguments.c3
@@ -1,19 +1,19 @@
-@require_once "std/io.c3";
+@require_once "std/io.c3"
 
 function [T] fn : () -> void = {
     puts<6>("No arg");
-};
+}
 
 function [T] fn : (arg : int&) -> void = {
     puts<3>("arg");
-};
+}
 
 function main : () -> int = {
     let a : int = 0;
     fn<int>();
     fn<int>(&a);
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT OUT

--- a/tests/regressions/pattern_match_heap_array.c3
+++ b/tests/regressions/pattern_match_heap_array.c3
@@ -1,10 +1,10 @@
-@require_once "std/io.c3";
+@require_once "std/io.c3"
 
 function main : () -> int = {
     const str: u8[&] = "abc";
     puts(&const str);
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 5, in 'function main: () -> int'

--- a/tests/regressions/pattern_matching.c3
+++ b/tests/regressions/pattern_matching.c3
@@ -1,11 +1,11 @@
 function [T] foo : (a : T, b : isize) -> void = {
 
-};
+}
 
 function main : () -> int = {
     foo(10, 10);
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/regressions/recursive_specialized_function.c3
+++ b/tests/regressions/recursive_specialized_function.c3
@@ -1,7 +1,7 @@
 @require_once "std/arithmetic.c3"
 
 function [T] recursive: (i: int) -> int = {
-    if (i > 0) {
+    if i > 0{
         recursive<T>(i - 1);
     }
 

--- a/tests/regressions/recursive_specialized_function.c3
+++ b/tests/regressions/recursive_specialized_function.c3
@@ -1,4 +1,4 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
 function [T] recursive: (i: int) -> int = {
     if (i > 0) {
@@ -6,11 +6,11 @@ function [T] recursive: (i: int) -> int = {
     }
 
     return 0;
-};
+}
 
 function main : () -> int = {
     return recursive<int>(2);
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 0

--- a/tests/regressions/return_from_both_if_branches.c3
+++ b/tests/regressions/return_from_both_if_branches.c3
@@ -1,5 +1,5 @@
 function foo : () -> void = {
-    if (true) {
+    if true{
         return;
     } else {
         return;

--- a/tests/regressions/return_from_both_if_branches.c3
+++ b/tests/regressions/return_from_both_if_branches.c3
@@ -4,12 +4,12 @@ function foo : () -> void = {
     } else {
         return;
     }
-};
+}
 
 function main : () -> int = {
     foo();
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/regressions/return_from_both_if_branches_unreachable.c3
+++ b/tests/regressions/return_from_both_if_branches_unreachable.c3
@@ -5,12 +5,12 @@ function foo : () -> void = {
         return;
     }
     return;
-};
+}
 
 function main : () -> int = {
     foo();
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/regressions/return_from_both_if_branches_unreachable.c3
+++ b/tests/regressions/return_from_both_if_branches_unreachable.c3
@@ -1,5 +1,5 @@
 function foo : () -> void = {
-    if (true) {
+    if true{
         return;
     } else {
         return;

--- a/tests/regressions/std_redefinition.c3
+++ b/tests/regressions/std_redefinition.c3
@@ -1,6 +1,6 @@
-@require_once "std/type_traits.c3";
+@require_once "std/type_traits.c3"
 
-typedef EnableIf<TrueType>: {};
+typedef EnableIf<TrueType>: {}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 3, in 'typedef'

--- a/tests/stdlib/arithmetic_addition.c3
+++ b/tests/stdlib/arithmetic_addition.c3
@@ -1,11 +1,11 @@
-@require_once "std/arithmetic.c3";
-@require_once "std/type_traits.c3";
+@require_once "std/arithmetic.c3"
+@require_once "std/type_traits.c3"
 
-typedef isI128<i128> : TrueType;
+typedef isI128<i128> : TrueType
 
 function[T] assertIsI128 : (arg: T) -> TypeIf<i128, isI128<T>> = {
     return arg;
-};
+}
 
 function main : () -> int = {
     let a : i8 = __builtin_narrow<i8>(1);
@@ -16,7 +16,7 @@ function main : () -> int = {
 
     let sum : i128 = assertIsI128(a + b + d + e + c);
     return __builtin_narrow<i32>(sum);
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 31

--- a/tests/stdlib/arithmetic_assignments.c3
+++ b/tests/stdlib/arithmetic_assignments.c3
@@ -1,4 +1,4 @@
-@require_once "std/arithmetic.c3";
+@require_once "std/arithmetic.c3"
 
 
 function main : () -> int = {
@@ -10,7 +10,7 @@ function main : () -> int = {
     a *= 9;
     a -= 1;
     return a;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 71

--- a/tests/stdlib/logical_operations.c3
+++ b/tests/stdlib/logical_operations.c3
@@ -5,24 +5,24 @@ function main : () -> int = {
     let a : bool = true;
     let b : bool = false;
 
-    if (a & b != false) {
+    if a & b != false{
         return 1;
     }
-    if (a | b != true) {
+    if a | b != true{
         return 1;
     }
-    if (a ^ b != true) {
+    if a ^ b != true{
         return 1;
     }
 
     b = true;
-    if (a & b != true) {
+    if a & b != true{
         return 1;
     }
-    if (a | b != true) {
+    if a | b != true{
         return 1;
     }
-    if (a ^ b != false) {
+    if a ^ b != false{
         return 1;
     }
     return 0;

--- a/tests/stdlib/logical_operations.c3
+++ b/tests/stdlib/logical_operations.c3
@@ -1,5 +1,5 @@
-@require_once "std/logical.c3";
-@require_once "std/type_traits.c3";
+@require_once "std/logical.c3"
+@require_once "std/type_traits.c3"
 
 function main : () -> int = {
     let a : bool = true;
@@ -26,7 +26,7 @@ function main : () -> int = {
         return 1;
     }
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/stdlib/malloc.c3
+++ b/tests/stdlib/malloc.c3
@@ -16,7 +16,7 @@ function main : () -> int = {
 
     // Allocate int array
     let i: int = 0;
-    while (i < 1028) {
+    while i < 1028 {
         let allocated : int& = &allocator:allocate<int>();
         allocated_memory[i] = {&allocated};
         allocated = i;
@@ -25,8 +25,8 @@ function main : () -> int = {
 
     // Check int array contains valid data
     i = 0;
-    while (i < 1028) {
-        if (allocated_memory[i]:data() != i) {
+    while i < 1028 {
+        if allocated_memory[i]:data() != i{
             return 1;
         }
         i = i + 1;
@@ -34,14 +34,14 @@ function main : () -> int = {
 
     // Deallocate every other element of int array
     i = 0;
-    while (i < 1028) {
+    while i < 1028 {
         allocator:deallocate(&allocated_memory[i]:data());
         i = i + 2;
     }
 
     // Allocate an unrelated struct array
     i = 0;
-    while (i < 512) {
+    while i < 512 {
         let allocated : MyStruct& = &allocator:allocate<MyStruct>();
         allocated_structs[i] = {&allocated};
         allocated = {-1, -1};
@@ -50,15 +50,15 @@ function main : () -> int = {
 
     // Deallocate the struct array
     i = 0;
-    while (i < 512) {
+    while i < 512 {
         allocator:deallocate(&allocated_structs[i]:data());
         i = i + 1;
     }
 
     // Check the remaining elements of the int array are still valid
     i = 1;
-    while (i < 1028) {
-        if (allocated_memory[i]:data() != i) {
+    while i < 1028 {
+        if allocated_memory[i]:data() != i{
             return 1;
         }
         allocator:deallocate(&allocated_memory[i]:data());

--- a/tests/stdlib/malloc.c3
+++ b/tests/stdlib/malloc.c3
@@ -1,11 +1,11 @@
-@require_once "std/arithmetic.c3";
-@require_once "std/memory.c3";
-@require_once "std/wrappers.c3";
+@require_once "std/arithmetic.c3"
+@require_once "std/memory.c3"
+@require_once "std/wrappers.c3"
 
 typedef MyStruct : {
     a : int,
     b : isize
-};
+}
 
 
 function main : () -> int = {
@@ -66,7 +66,7 @@ function main : () -> int = {
     }
 
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/stdlib/malloc_dynamic.c3
+++ b/tests/stdlib/malloc_dynamic.c3
@@ -1,11 +1,11 @@
-@require_once "std/arithmetic.c3";
-@require_once "std/memory.c3";
-@require_once "std/wrappers.c3";
+@require_once "std/arithmetic.c3"
+@require_once "std/memory.c3"
+@require_once "std/wrappers.c3"
 
 typedef MyStruct : {
     a : int,
     b : isize
-};
+}
 
 
 function main : () -> int = {
@@ -17,7 +17,7 @@ function main : () -> int = {
     allocator:deallocate_span(span_to_deallocate);
 
     return span.data[29];
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 42

--- a/tests/stdlib/unary.c3
+++ b/tests/stdlib/unary.c3
@@ -4,19 +4,19 @@
 
 function main : () -> int = {
     let a : int = 1;
-    if (-a != -1) {
+    if -a != -1{
         return 1;
     }
 
-    if (+a != 1) {
+    if +a != 1{
         return 1;
     }
 
     let b : u32 = 0xFFFF0000;
-    if (b ^ 0xFFFFFFFF != 0xFFFF) {
+    if b ^ 0xFFFFFFFF != 0xFFFF{
         return 1;
     }
-    if (~(b ^ 0xFFFFFFFF) != 0xFFFF0000) {
+    if ~(b ^ 0xFFFFFFFF) != 0xFFFF0000{
         return 1;
     }
 

--- a/tests/stdlib/unary.c3
+++ b/tests/stdlib/unary.c3
@@ -1,6 +1,6 @@
-@require_once "std/arithmetic.c3";
-@require_once "std/logical.c3";
-@require_once "std/util.c3";
+@require_once "std/arithmetic.c3"
+@require_once "std/logical.c3"
+@require_once "std/util.c3"
 
 function main : () -> int = {
     let a : int = 1;
@@ -21,7 +21,7 @@ function main : () -> int = {
     }
 
     return - a + - + - a;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/stdlib/vector.c3
+++ b/tests/stdlib/vector.c3
@@ -13,16 +13,16 @@ function main : () -> int = {
     vec:push_back(4);
     vec:push_back(5);
 
-    if (vec:pop_back() != 5) {
+    if vec:pop_back() != 5{
         return 1;
     }
 
-    if (vec:get(1) != 1) {
+    if vec:get(1) != 1{
         return 1;
     }
 
     vec:set(0, 10);
-    if (vec:get(0) != 10) {
+    if vec:get(0) != 10{
         return 1;
     }
 

--- a/tests/stdlib/vector.c3
+++ b/tests/stdlib/vector.c3
@@ -1,5 +1,5 @@
-@require_once "std/arithmetic.c3";
-@require_once "std/vector.c3";
+@require_once "std/arithmetic.c3"
+@require_once "std/vector.c3"
 
 
 function main : () -> int = {
@@ -28,7 +28,7 @@ function main : () -> int = {
 
     vec:deallocate(); // TODO: RAII
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/structs/assignment.c3
+++ b/tests/structs/assignment.c3
@@ -1,8 +1,8 @@
-typedef MyStruct : {a: int, x: int};
+typedef MyStruct : {a: int, x: int}
 
 @operator + : (lhs : int, rhs: int) -> int = {
     return __builtin_add(lhs, rhs);
-};
+}
 
 function main : () -> int = {
     let struct : MyStruct;
@@ -11,7 +11,7 @@ function main : () -> int = {
     b = 6;  // Sets `struct.a` to 6
     struct.x = 5;  // Sets `struct.x` to 5
     return struct.a + struct.x + 5;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 16

--- a/tests/structs/dereferencing.c3
+++ b/tests/structs/dereferencing.c3
@@ -1,14 +1,14 @@
-typedef MyStruct : {member : int};
+typedef MyStruct : {member : int}
 
-foreign GetStruct : () -> MyStruct;
+foreign GetStruct : () -> MyStruct
 
 function fn_val : () -> MyStruct = {
     return GetStruct();
-};
+}
 
 function fn_ref : (in : MyStruct&) -> MyStruct& = {
     return &in;
-};
+}
 
 
 function main: () -> int = {
@@ -23,6 +23,6 @@ function main: () -> int = {
     let result4 : int = fn_ref(&b).member;
 
     return 0;
-};
+}
 
 /// @COMPILE

--- a/tests/structs/function_ref_return.c3
+++ b/tests/structs/function_ref_return.c3
@@ -1,15 +1,15 @@
-typedef MyStruct : {a: int, x: int};
+typedef MyStruct : {a: int, x: int}
 
 function[T] forward_ref : (arg: T&) -> T& = {
     return &arg;
-};
+}
 
 function main : () -> int = {
     let struct : MyStruct = {42, 10};
     forward_ref<MyStruct>(&struct).x = 11;
 
     return forward_ref<MyStruct>(&struct).x;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 11

--- a/tests/structs/function_value_return.c3
+++ b/tests/structs/function_value_return.c3
@@ -1,13 +1,13 @@
-typedef MyStruct : {a: int, x: int};
+typedef MyStruct : {a: int, x: int}
 
 function make_struct : () -> MyStruct = {
     let ret : MyStruct = {42, 10};
     return ret;
-};
+}
 
 function main : () -> int = {
     return make_struct().x;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 10

--- a/tests/structs/function_value_return_error.c3
+++ b/tests/structs/function_value_return_error.c3
@@ -1,14 +1,14 @@
-typedef MyStruct : {a: int, x: int};
+typedef MyStruct : {a: int, x: int}
 
 function make_struct : () -> MyStruct = {
     let ret : MyStruct = {42, 10};
     return ret;
-};
+}
 
 function main : () -> int = {
     make_struct().x = 10;
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 9, in 'function main: () -> int'

--- a/tests/structs/init_list_assign_to_initializer_list.c3
+++ b/tests/structs/init_list_assign_to_initializer_list.c3
@@ -1,7 +1,7 @@
 function main: () -> i32 = {
     {1, 2} = 7;
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> i32'

--- a/tests/structs/init_list_invalid_assignment_with_names.c3
+++ b/tests/structs/init_list_invalid_assignment_with_names.c3
@@ -2,7 +2,7 @@ function main: () -> int = {
     const not_a_struct : int = {a: 2, b: "str", c: true};
 
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> int'

--- a/tests/structs/init_list_invalid_assignment_without_names.c3
+++ b/tests/structs/init_list_invalid_assignment_without_names.c3
@@ -2,7 +2,7 @@ function main: () -> int = {
     const not_a_struct : int = {2, "str", true};
 
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> int'

--- a/tests/structs/init_list_unexpected.c3
+++ b/tests/structs/init_list_unexpected.c3
@@ -3,7 +3,7 @@ function main: () -> i32 = {
         return 1;
     }
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> i32'

--- a/tests/structs/init_list_unexpected.c3
+++ b/tests/structs/init_list_unexpected.c3
@@ -1,5 +1,5 @@
 function main: () -> i32 = {
-    if ({1, 2}) {
+    if {1, 2}{
         return 1;
     }
     return 0;

--- a/tests/structs/init_list_with_missing_name.c3
+++ b/tests/structs/init_list_with_missing_name.c3
@@ -1,10 +1,10 @@
-typedef my_struct: {a: int, b: int};
+typedef my_struct: {a: int, b: int}
 
 function main: () -> int = {
     const s : my_struct = {b: 2};
 
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 4, in 'function main: () -> int'

--- a/tests/structs/init_list_with_names.c3
+++ b/tests/structs/init_list_with_names.c3
@@ -1,9 +1,9 @@
-typedef my_i32 : int;
-typedef[T] my_struct : {a: T, b: my_i32};
+typedef my_i32 : int
+typedef[T] my_struct : {a: T, b: my_i32}
 
 @operator +: (a: i64, b: i64) -> i64 = {
     return __builtin_add(a, b);
-};
+}
 
 function main: () -> int = {
     let x : int = 1;
@@ -16,7 +16,7 @@ function main: () -> int = {
     let s4 : my_struct<i64> = {b: 20, a: 10};
 
     return __builtin_narrow<int>(s1.a + s2.b + s3.b + s4.a);
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 33

--- a/tests/structs/init_list_with_wrong_name.c3
+++ b/tests/structs/init_list_with_wrong_name.c3
@@ -1,10 +1,10 @@
-typedef my_struct: {a: int};
+typedef my_struct: {a: int}
 
 function main: () -> int = {
     const s : my_struct = {b: 2};
 
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 4, in 'function main: () -> int'

--- a/tests/structs/init_list_without_names.c3
+++ b/tests/structs/init_list_without_names.c3
@@ -1,9 +1,9 @@
-typedef my_i32 : int;
-typedef[T] my_struct : {a: T, b: my_i32};
+typedef my_i32 : int
+typedef[T] my_struct : {a: T, b: my_i32}
 
 @operator +: (a: i64, b: i64) -> i64 = {
     return __builtin_add(a, b);
-};
+}
 
 function main: () -> int = {
     let x : int = 1;
@@ -16,7 +16,7 @@ function main: () -> int = {
     let s4 : my_struct<i64> = {10, 20};
 
     return __builtin_narrow<int>(s1.a + s2.b + s3.b + s4.a);
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 33

--- a/tests/structs/initializer_list_assignment.c3
+++ b/tests/structs/initializer_list_assignment.c3
@@ -1,4 +1,4 @@
-typedef MyStruct : {a: int, x: int};
+typedef MyStruct : {a: int, x: int}
 
 function main : () -> int = {
     let struct : MyStruct;
@@ -6,7 +6,7 @@ function main : () -> int = {
     struct = {x: 11, a: 12};
 
     return struct.x;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 11

--- a/tests/structs/initializer_list_function_call.c3
+++ b/tests/structs/initializer_list_function_call.c3
@@ -1,12 +1,12 @@
-typedef MyStruct : {a: int, x: int};
+typedef MyStruct : {a: int, x: int}
 
 function get_x : (struct : MyStruct) -> int = {
     return struct.x;
-};
+}
 
 function main : () -> int = {
     return get_x({11, 12});
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 12

--- a/tests/structs/initializer_list_function_call_named_overload.c3
+++ b/tests/structs/initializer_list_function_call_named_overload.c3
@@ -1,29 +1,29 @@
-@require_once "std/io.c3";
+@require_once "std/io.c3"
 
-typedef MyStruct1 : {a: int, z: int};
-typedef MyStruct2 : {a: int, y: int};
-typedef MyStruct3 : {a: int, x: int};
+typedef MyStruct1 : {a: int, z: int}
+typedef MyStruct2 : {a: int, y: int}
+typedef MyStruct3 : {a: int, x: int}
 
 function get : (struct : MyStruct1) -> int = {
     puts("MyStruct1");
     return struct.z;
-};
+}
 
 function get : (struct : MyStruct2) -> int = {
     puts("MyStruct2");
     return struct.y;
-};
+}
 
 function get : (struct : MyStruct3) -> int = {
     puts("MyStruct3");
     return struct.x;
-};
+}
 
 
 function main : () -> int = {
     get({a : 11, y : 12});
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT OUT

--- a/tests/structs/initializer_list_function_call_no_overloaded.c3
+++ b/tests/structs/initializer_list_function_call_no_overloaded.c3
@@ -1,17 +1,17 @@
-typedef MyStruct1 : {a: int, x: int, b: int};
-typedef MyStruct2 : {a: int, x: int};
+typedef MyStruct1 : {a: int, x: int, b: int}
+typedef MyStruct2 : {a: int, x: int}
 
 function get_x : (struct : MyStruct1) -> int = {
     return struct.x;
-};
+}
 
 function get_x : (struct : MyStruct2) -> int = {
     return struct.x;
-};
+}
 
 function main : () -> int = {
     return get_x({11});
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 13, in 'function main: () -> int'

--- a/tests/structs/initializer_list_function_call_overloaded.c3
+++ b/tests/structs/initializer_list_function_call_overloaded.c3
@@ -1,17 +1,17 @@
-typedef MyStruct1 : {a: int, x: int, b: int};
-typedef MyStruct2 : {a: int, x: int};
+typedef MyStruct1 : {a: int, x: int, b: int}
+typedef MyStruct2 : {a: int, x: int}
 
 function get_x : (struct : MyStruct1) -> int = {
     return struct.x;
-};
+}
 
 function get_x : (struct : MyStruct2) -> int = {
     return struct.x;
-};
+}
 
 function main : () -> int = {
     return get_x({11, 12});
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 12

--- a/tests/structs/initializer_list_function_call_templated.c3
+++ b/tests/structs/initializer_list_function_call_templated.c3
@@ -1,12 +1,12 @@
-typedef MyStruct : {a: int, x: int};
+typedef MyStruct : {a: int, x: int}
 
 function[T] get_x : (struct : T) -> int = {
     return struct.x;
-};
+}
 
 function main : () -> int = {
     return get_x({11, 12});
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 8, in 'function main: () -> int'

--- a/tests/structs/initializer_list_return.c3
+++ b/tests/structs/initializer_list_return.c3
@@ -1,12 +1,12 @@
-typedef MyStruct : {a: int, x: int};
+typedef MyStruct : {a: int, x: int}
 
 function get_struct : () -> MyStruct = {
     return {1, 2};
-};
+}
 
 function main : () -> int = {
     return get_struct().a;
-};
+}
 
 /// @COMPILE
 /// @RUN; EXPECT 1

--- a/tests/structs/member_redeclaration.c3
+++ b/tests/structs/member_redeclaration.c3
@@ -1,12 +1,12 @@
 typedef S : {
     a: i32,
     a: i64  // We should print the correct line number.
-};
+}
 
 function main : () -> int = {
     const s : S = {0, 0};
     return s.a;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 3, in 'struct definition'

--- a/tests/void/arguments.c3
+++ b/tests/void/arguments.c3
@@ -1,4 +1,4 @@
-foreign foo : (x: void) -> void;
+foreign foo : (x: void) -> void
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 1, in 'foreign signature'

--- a/tests/void/functions.c3
+++ b/tests/void/functions.c3
@@ -3,7 +3,7 @@
 }
 
 function foo : (i : int&) -> void = {
-    if (i > 2) {
+    if i > 2{
         return;
     }
 

--- a/tests/void/functions.c3
+++ b/tests/void/functions.c3
@@ -1,6 +1,6 @@
 @operator > : (a : int, b: int) -> bool = {
     return __builtin_is_greater_than(a, b);
-};
+}
 
 function foo : (i : int&) -> void = {
     if (i > 2) {
@@ -10,14 +10,14 @@ function foo : (i : int&) -> void = {
     let x : int;
 
     // We need to add an implicit `ret void` here or LLVM will complain.
-};
+}
 
 function main : () -> int = {
     let i : int = 1;
     foo(&i);
 
     return 0;
-};
+}
 
 /// @COMPILE
 /// @RUN

--- a/tests/void/heap_array.c3
+++ b/tests/void/heap_array.c3
@@ -1,11 +1,11 @@
-typedef my_void : void;
-typedef my_array : my_void[&];
+typedef my_void : void
+typedef my_array : my_void[&]
 
 function main : () -> int = {
     let s : my_struct;
 
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'typedef'

--- a/tests/void/stack_array.c3
+++ b/tests/void/stack_array.c3
@@ -1,11 +1,11 @@
-typedef my_void : void;
-typedef my_array : my_void[6];
+typedef my_void : void
+typedef my_array : my_void[6]
 
 function main : () -> int = {
     let s : my_struct;
 
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'typedef'

--- a/tests/void/structs.c3
+++ b/tests/void/structs.c3
@@ -1,11 +1,11 @@
-typedef my_void : void;
-typedef my_struct : { a: int, b: my_void };
+typedef my_void : void
+typedef my_struct : { a: int, b: my_void }
 
 function main : () -> int = {
     let s : my_struct;
 
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'typedef'

--- a/tests/void/variables.c3
+++ b/tests/void/variables.c3
@@ -2,7 +2,7 @@ function main : () -> int = {
     let x : void;
 
     return 0;
-};
+}
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> int'


### PR DESCRIPTION
We no longer require semicolons after every top-level statement and `if`/ `for`/ `while` no longer require parens around the condition.


I'm a bit unsure about the aesthetic of foreign functions and typedef aliases... but it's unambiguous so let's give it a shot.