### PR TITLE
Refactor type and function resolution

### DIFF
--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -1,4 +1,11 @@
-from .builtin_types import BoolType, IntType, StructDefinition, UIntType, VoidType
+from .builtin_types import (
+    BoolType,
+    FunctionSignature,
+    IntType,
+    StructDefinition,
+    UIntType,
+    VoidType,
+)
 from .expressions import (
     ArrayIndexAccess,
     BorrowExpression,
@@ -20,6 +27,7 @@ from .generatable import (
 )
 from .interfaces import (
     Generatable,
+    GenericArgument,
     GenericMapping,
     Parameter,
     SpecializationItem,
@@ -27,15 +35,15 @@ from .interfaces import (
     TypedExpression,
     Variable,
 )
-from .translation_unit import Function, GenericFunctionParser, Program, Scope
+from .translation_unit import Function, Program, Scope
 from .type_resolution import (
     CompileTimeConstant,
-    GenericArgument,
+    FnDeclaration,
     GenericResolutionImpossible,
-    GenericTypedef,
     GenericValueReference,
     NumericLiteralConstant,
-    SpecializedTypedef,
+    Typedef,
+    UnresolvedFunctionSignature,
     UnresolvedGenericMapping,
     UnresolvedGenericType,
     UnresolvedHeapArrayType,

--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -38,7 +38,7 @@ from .interfaces import (
 from .translation_unit import Function, Program, Scope
 from .type_resolution import (
     CompileTimeConstant,
-    FnDeclaration,
+    FunctionDeclaration,
     GenericResolutionImpossible,
     GenericValueReference,
     NumericLiteralConstant,

--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -45,7 +45,6 @@ from .type_resolution import (
     NumericLiteralConstant,
     Typedef,
     UnresolvedFunctionSignature,
-    UnresolvedGenericMapping,
     UnresolvedGenericType,
     UnresolvedHeapArrayType,
     UnresolvedNamedType,

--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -40,7 +40,6 @@ from .translation_unit import Function, Program, Scope
 from .type_resolution import (
     CompileTimeConstant,
     FunctionDeclaration,
-    GenericResolutionImpossible,
     GenericValueReference,
     NumericLiteralConstant,
     Typedef,

--- a/codegen/builtin_types.py
+++ b/codegen/builtin_types.py
@@ -21,7 +21,8 @@ class PlaceholderDefinition(TypeDefinition):
         super().__init__()
 
     def are_equivalent(self, other: TypeDefinition) -> bool:
-        assert False
+        assert other is self
+        return True
 
     def format_for_output_to_user(self) -> str:
         assert False

--- a/codegen/interfaces.py
+++ b/codegen/interfaces.py
@@ -313,9 +313,20 @@ def format_specialization(specialization: list[SpecializationItem]) -> str:
     return f"<{items}>"
 
 
-def format_arguments(args: list[Type] | list[TypedExpression]) -> str:
+def format_arguments(args: Iterable[Type] | Iterable[TypedExpression]) -> str:
     items = ", ".join(item.format_for_output_to_user() for item in args)
     return f"({items})"
+
+
+def format_generics(args: Iterable[GenericArgument], pack_name: Optional[str]) -> str:
+    formatted_generics = [item.name for item in args]
+    if pack_name is not None:
+        format_generics.append(pack_name)
+
+    if len(formatted_generics) == 0:
+        return ""
+
+    return f" [{str.join(', ', formatted_generics)}]"
 
 
 @dataclass

--- a/codegen/interfaces.py
+++ b/codegen/interfaces.py
@@ -272,7 +272,18 @@ class TypedExpression(Generatable):
 
 
 SpecializationItem = Type | int
-GenericMapping = dict[str, SpecializationItem]
+
+
+@dataclass(frozen=True)
+class GenericArgument:
+    name: str
+    is_value_arg: bool
+
+
+@dataclass
+class GenericMapping:
+    mapping: dict[GenericArgument, SpecializationItem]
+    pack: list[Type]
 
 
 def do_specializations_match(
@@ -300,6 +311,11 @@ def format_specialization(specialization: list[SpecializationItem]) -> str:
         for item in specialization
     )
     return f"<{items}>"
+
+
+def format_arguments(args: list[Type] | list[TypedExpression]) -> str:
+    items = ", ".join(item.format_for_output_to_user() for item in args)
+    return f"({items})"
 
 
 @dataclass

--- a/codegen/translation_unit.py
+++ b/codegen/translation_unit.py
@@ -1,7 +1,6 @@
-from collections import defaultdict
 from functools import cached_property
 from itertools import count
-from typing import Callable, Iterable, Optional
+from typing import Optional
 
 import target
 
@@ -14,47 +13,23 @@ from .builtin_types import (
 )
 from .expressions import FunctionCallExpression, FunctionParameter
 from .generatable import Scope, StackVariable, StaticVariable, VariableAssignment
-from .interfaces import (
-    GenericMapping,
-    Parameter,
-    SpecializationItem,
-    Type,
-    TypedExpression,
-    do_specializations_match,
-)
+from .interfaces import Parameter, SpecializationItem, Type, TypedExpression
 from .strings import encode_string
-from .type_conversions import get_implicit_conversion_cost
-from .type_resolution import (
-    GenericTypedef,
-    NumericLiteralConstant,
-    SpecializedTypedef,
-    TypeSymbolTable,
-    UnresolvedGenericMapping,
-    UnresolvedType,
-)
-from .user_facing_errors import (
-    AmbiguousFunctionCall,
-    OverloadResolutionError,
-    RedefinitionError,
-)
+from .type_resolution import SymbolTable
 
 
 class Function:
     def __init__(
         self,
-        name: str,
-        parameters: list[Parameter],
-        return_type: Type,
-        is_foreign: bool,
-        specialization: list[SpecializationItem],
+        parameter_names: tuple[str],
+        signature: FunctionSignature,
+        parameter_pack_name: Optional[str],
     ) -> None:
-        self._signature = FunctionSignature(
-            name,
-            [var.type for var in parameters],
-            return_type,
-            specialization,
-            is_foreign,
-        )
+        assert not signature.is_foreign
+        if parameter_pack_name is None:
+            assert len(parameter_names) == len(signature.arguments)
+
+        self._signature = signature
 
         self.scope_id_iter = count()
         self.top_level_scope = Scope(self.get_next_scope_id())
@@ -62,17 +37,26 @@ class Function:
         # Implicit stack variable allocation for parameters
         #   TODO: constant parameters (when/ if added to grammar)
         self._parameters: list[FunctionParameter] = []
-        if not self.is_foreign():
-            for param in parameters:
-                fn_param = FunctionParameter(param.type)
-                self._parameters.append(fn_param)
-                self.top_level_scope.add_generatable(fn_param)
+        for param_name, param_type in zip(parameter_names, signature.arguments):
+            self._add_parameter(param_name, param_type)
 
-                fn_param_var = StackVariable(param.name, param.type, False, True)
-                self.top_level_scope.add_variable(fn_param_var)
+        if parameter_pack_name is not None:
+            packed_args = signature.arguments[len(parameter_names) :]
+            self.top_level_scope.add_generic_pack(parameter_pack_name, len(packed_args))
 
-                fn_param_var_assignment = VariableAssignment(fn_param_var, fn_param)
-                self.top_level_scope.add_generatable(fn_param_var_assignment)
+            for i, param_type in enumerate(signature.arguments[len(parameter_names) :]):
+                self._add_parameter(f"{parameter_pack_name}{i}", param_type)
+
+    def _add_parameter(self, param_name: str, param_type: Type):
+        fn_param = FunctionParameter(param_type)
+        self._parameters.append(fn_param)
+        self.top_level_scope.add_generatable(fn_param)
+
+        fn_param_var = StackVariable(param_name, param_type, False, True)
+        self.top_level_scope.add_variable(fn_param_var)
+
+        fn_param_var_assignment = VariableAssignment(fn_param_var, fn_param)
+        self.top_level_scope.add_generatable(fn_param_var_assignment)
 
     def __repr__(self) -> str:
         return f"Function({repr(self._signature)})"
@@ -84,22 +68,16 @@ class Function:
     def get_signature(self) -> FunctionSignature:
         return self._signature
 
+    @property
     def is_foreign(self) -> bool:
-        return self._signature.is_foreign()
+        return self._signature.is_foreign
 
     def get_next_scope_id(self) -> int:
         return next(self.scope_id_iter)
 
-    def generate_declaration(self) -> list[str]:
-        args_ir = [arg.ir_type for arg in self._signature.arguments]
-
-        # XXX nounwind indicates that the function never raises an exception.
-        return [
-            f"declare dso_local {self._signature.return_type.ir_type}"
-            f" @{self.mangled_name}({str.join(', ', args_ir)}) nounwind"
-        ]
-
-    def generate_definition(self) -> list[str]:
+    def generate_ir(self) -> list[str]:
+        # https://llvm.org/docs/LangRef.html#functions
+        assert not self.is_foreign
         if not self.get_signature().return_type.definition.is_void:
             assert self.top_level_scope.is_return_guaranteed()
 
@@ -125,271 +103,22 @@ class Function:
             "}",
         ]
 
-    def generate_ir(self) -> list[str]:
-        # https://llvm.org/docs/LangRef.html#functions
-        if self.is_foreign():
-            assert self.top_level_scope.is_empty()
-            return self.generate_declaration()
-
-        return self.generate_definition()
-
-
-class GenericFunctionParser:
-    def __init__(
-        self,
-        name: str,
-        parse_with_specialization_fn: Callable[
-            [str, list[SpecializationItem]],
-            Optional[Function],
-        ],
-        deduce_specialization_fn: Callable[
-            [str, list[TypedExpression]], Optional[list[SpecializationItem]]
-        ],
-    ) -> None:
-        self.fn_name = name
-        self._parse_with_specialization_fn = parse_with_specialization_fn
-        self._deduce_specialization_fn = deduce_specialization_fn
-
-    def try_parse_with_specialization(
-        self, specialization: list[SpecializationItem]
-    ) -> Optional[Function]:
-        return self._parse_with_specialization_fn(self.fn_name, specialization)
-
-    def try_deduce_specialization(
-        self, args: list[TypedExpression]
-    ) -> Optional[list[SpecializationItem]]:
-        return self._deduce_specialization_fn(self.fn_name, args)
-
-
-class FunctionSymbolTable:
-    def __init__(self) -> None:
-        self.foreign_functions: list[Function] = []
-        self.graphene_functions: list[Function] = []
-
-        self._generic_parsers: dict[str, list[GenericFunctionParser]] = defaultdict(
-            list
-        )
-        self._specialized_functions: dict[str, list[Function]] = defaultdict(list)
-        self._functions: dict[str, list[Function]] = defaultdict(list)
-
-    def add_generic_function(
-        self,
-        fn_name: str,
-        parser: GenericFunctionParser,
-    ) -> None:
-        self._generic_parsers[fn_name].append(parser)
-
-    def add_function(self, fn_to_add: Function) -> None:
-        fn_to_add_signature = fn_to_add.get_signature()
-        matched_functions = self._functions[fn_to_add_signature.name]
-
-        if fn_to_add_signature.is_foreign() and len(matched_functions) > 0:
-            raise RedefinitionError(
-                "non-overloadable foreign function",
-                fn_to_add_signature.user_facing_name,
-            )
-
-        for target in matched_functions:
-            if target.is_foreign():
-                raise RedefinitionError(
-                    "non-overloadable foreign function",
-                    target.get_signature().user_facing_name,
-                )
-
-            if target.get_signature().arguments == fn_to_add_signature.arguments:
-                raise RedefinitionError(
-                    "function", fn_to_add_signature.user_facing_name
-                )
-
-        matched_functions.append(fn_to_add)
-        if fn_to_add.is_foreign():
-            self.foreign_functions.append(fn_to_add)
-        else:
-            self.graphene_functions.append(fn_to_add)
-
-    def generate_functions_with_specialization(
-        self, fn_name: str, fn_specialization: list[SpecializationItem]
-    ) -> list[Function]:
-        # Have we already parsed this function?
-        if fn_name in self._specialized_functions:
-            matching_functions = []
-            for candidate_function in self._specialized_functions[fn_name]:
-                candidate_signature = candidate_function.get_signature()
-                if do_specializations_match(
-                    candidate_signature.specialization, fn_specialization
-                ):
-                    matching_functions.append(candidate_function)
-
-            if matching_functions:
-                return matching_functions
-
-        # We have not parsed this function
-        candidate_parsers = self._generic_parsers[fn_name]
-        if len(candidate_parsers) == 0:
-            raise NotImplementedError()
-
-        matching_functions = []
-        for parser in candidate_parsers:
-            parsed_fn = parser.try_parse_with_specialization(fn_specialization)
-            if parsed_fn is not None:
-                matching_functions.append(parsed_fn)
-
-        for matched_fn in matching_functions:
-            # TODO: we don't actually need to generate all these functions, some might be unused
-            self.graphene_functions.append(matched_fn)
-            self._specialized_functions[fn_name].append(matched_fn)
-
-        return matching_functions
-
-    def lookup_explicitly_specialized_function(
-        self,
-        fn_name: str,
-        fn_specialization: list[SpecializationItem],
-        fn_args: list[TypedExpression],
-    ) -> Function:
-        matching_functions = self.generate_functions_with_specialization(
-            fn_name, fn_specialization
-        )
-        return self.select_function_with_least_cost(
-            fn_name, matching_functions, fn_specialization, fn_args
-        )
-
-    def lookup_function(self, fn_name: str, fn_args: list[TypedExpression]) -> Function:
-        # The normal Graphene functions
-        candidate_functions = [
-            fn
-            for fn in self._functions[fn_name]
-            if len(fn.get_signature().specialization) == 0
-        ]
-
-        # Implicit generic instantiation
-        candidate_specializations: list[list[SpecializationItem]] = []
-
-        def in_candidates(
-            specialization: list[SpecializationItem],
-        ) -> bool:
-            for candidate in candidate_specializations:
-                if do_specializations_match(specialization, candidate):
-                    return True
-
-            return False
-
-        for candidate_generic in self._generic_parsers[fn_name]:
-            fn_specialization = candidate_generic.try_deduce_specialization(fn_args)
-
-            if fn_specialization is not None and not in_candidates(fn_specialization):
-                candidate_specializations.append(fn_specialization)
-                candidate_functions.extend(
-                    self.generate_functions_with_specialization(
-                        fn_name, fn_specialization
-                    )
-                )
-
-        return self.select_function_with_least_cost(
-            fn_name, candidate_functions, [], fn_args
-        )
-
-    def select_function_with_least_cost(
-        self,
-        fn_name: str,
-        candidate_functions: Iterable[Function],
-        fn_specialization: list[SpecializationItem],
-        fn_args: list[TypedExpression],
-    ) -> Function:
-        functions_by_cost: list[tuple[int, Function]] = []
-
-        for function in candidate_functions:
-            total_cost = 0
-            if len(fn_args) != len(function.get_signature().arguments):
-                continue
-
-            for src_type, dest_type in zip(fn_args, function.get_signature().arguments):
-                cost = get_implicit_conversion_cost(src_type, dest_type)
-                if cost is not None:
-                    total_cost += cost
-                else:
-                    total_cost = None
-                    break
-
-            # Conversion might fail for some arguments. In that case, discard
-            # this candidate.
-            if total_cost is not None:
-                functions_by_cost.append((total_cost, function))
-
-        functions_by_cost.sort(key=lambda t: t[0])
-
-        readable_arg_names = ", ".join(
-            arg.format_for_output_to_user() for arg in fn_args
-        )
-        readable_specialization = ", ".join(
-            specialization.format_for_output_to_user()
-            if isinstance(specialization, Type)
-            else str(specialization)
-            for specialization in fn_specialization
-        )
-
-        if not functions_by_cost:
-            raise OverloadResolutionError(
-                fn_name,
-                readable_specialization,
-                readable_arg_names,
-                [
-                    fn.get_signature().user_facing_name
-                    for fn in self._functions[fn_name]
-                ],
-            )
-
-        if len(functions_by_cost) == 1:
-            return functions_by_cost[0][1]
-
-        first, second, *_ = functions_by_cost
-
-        # If there are two or more equally good candidates, then this function
-        # call is ambiguous.
-        if first[0] == second[0]:
-            raise AmbiguousFunctionCall(
-                fn_name,
-                readable_arg_names,
-                first[1].get_signature().user_facing_name,
-                second[1].get_signature().user_facing_name,
-            )
-
-        return first[1]
-
 
 class Program:
     def __init__(self) -> None:
         super().__init__()
         self._builtin_callables = get_builtin_callables()
 
-        self._function_table = FunctionSymbolTable()
-        self._type_table = TypeSymbolTable()
+        self._fn_bodies = []
+        self.symbol_table = SymbolTable()
 
         self._string_cache: dict[str, StaticVariable] = {}
         self._static_variables: list[StaticVariable] = []
 
         self._has_main: bool = False
 
-        self._builtin_type_names: set[str] = set()
         for builtin_type in get_builtin_types():
-            self._type_table.add_resolved_type(builtin_type)
-            self._builtin_type_names.add(builtin_type.name)
-
-    def resolve_type(self, unresolved: UnresolvedType) -> Type:
-        return self._type_table.resolve_type(unresolved)
-
-    def resolve_generic_mapping(
-        self, unresolved: UnresolvedGenericMapping
-    ) -> GenericMapping:
-        resolved: GenericMapping = {}
-        for item_name, item in unresolved.items():
-            if isinstance(item, NumericLiteralConstant):
-                resolved[item_name] = item.value
-            else:
-                assert isinstance(item, UnresolvedType)
-                resolved[item_name] = self._type_table.resolve_type(item)
-
-        return resolved
+            self.symbol_table.add_builtin_type(builtin_type)
 
     def lookup_call_expression(
         self,
@@ -400,29 +129,10 @@ class Program:
         if fn_name in self._builtin_callables:
             return self._builtin_callables[fn_name](fn_specialization, fn_args)
 
-        if len(fn_specialization) != 0:
-            function = self._function_table.lookup_explicitly_specialized_function(
-                fn_name, fn_specialization, fn_args
-            )
-        else:
-            function = self._function_table.lookup_function(fn_name, fn_args)
-
-        return FunctionCallExpression(function.get_signature(), fn_args)
-
-    def add_generic_function(self, fn_name: str, parser: GenericFunctionParser):
-        self._function_table.add_generic_function(fn_name, parser)
-
-    def add_function(self, function: Function) -> None:
-        self._function_table.add_function(function)
-
-    def resolve_all_types(self) -> None:
-        self._type_table.resolve_all_types()
-
-    def add_type_alias(self, typedef: SpecializedTypedef) -> None:
-        self._type_table.add_unresolved_type(typedef)
-
-    def add_generic_type_alias(self, typedef: GenericTypedef) -> None:
-        self._type_table.add_generic_unresolved_type(typedef)
+        signature = self.symbol_table.lookup_function(
+            fn_name, fn_specialization, fn_args
+        )
+        return FunctionCallExpression(signature, fn_args)
 
     def add_static_string(self, string: str) -> StaticVariable:
         if string in self._string_cache:
@@ -441,6 +151,9 @@ class Program:
     def add_static_variable(self, var: StaticVariable) -> None:
         self._static_variables.append(var)
 
+    def add_function_body(self, fn: Function) -> None:
+        self._fn_bodies.append(fn)
+
     def generate_ir(self) -> list[str]:
         lines: list[str] = []
 
@@ -453,15 +166,10 @@ class Program:
             lines.extend(variable.generate_ir(var_reg_gen))
 
         lines.append("")
-        lines.extend(self._type_table.get_ir_for_initialization())
+        lines.extend(self.symbol_table.get_ir_for_initialization())
 
         lines.append("")
-        for func in self._function_table.foreign_functions:
+        for func in self._fn_bodies:
             lines.extend(func.generate_ir())
-
-        lines.append("")
-        for func in self._function_table.graphene_functions:
-            lines.extend(func.generate_ir())
-            lines.append("")
 
         return lines

--- a/codegen/translation_unit.py
+++ b/codegen/translation_unit.py
@@ -166,8 +166,8 @@ class Program:
     def add_static_variable(self, var: StaticVariable) -> None:
         self._static_variables.append(var)
 
-    def add_function_body(self, fn: Function) -> None:
-        self._fn_bodies.append(fn)
+    def add_function_body(self, function: Function) -> None:
+        self._fn_bodies.append(function)
 
     def generate_ir(self) -> list[str]:
         lines: list[str] = []

--- a/codegen/translation_unit.py
+++ b/codegen/translation_unit.py
@@ -48,7 +48,7 @@ class Function:
             packed_args = signature.arguments[len(parameter_names) :]
             self.top_level_scope.add_generic_pack(parameter_pack_name, len(packed_args))
 
-            for i, param_type in enumerate(signature.arguments[len(parameter_names) :]):
+            for i, param_type in enumerate(packed_args):
                 self._add_parameter(f"{parameter_pack_name}{i}", param_type)
 
         # Check the signature

--- a/codegen/type_conversions.py
+++ b/codegen/type_conversions.py
@@ -1,6 +1,8 @@
 from functools import cached_property
 from typing import Iterator, Optional
 
+from codegen.interfaces import Type
+
 from .builtin_types import HeapArrayDefinition, IntegerDefinition, StackArrayDefinition
 from .interfaces import Type, TypedExpression
 from .user_facing_errors import OperandError, TypeCheckerError
@@ -256,10 +258,28 @@ def assert_is_implicitly_convertible(
 
 
 def get_implicit_conversion_cost(
-    src: TypedExpression, dest_type: Type
+    src: Type | TypedExpression, dest_type: Type
 ) -> Optional[int]:
+    class Wrapper(TypedExpression):
+        def __init__(self, expr_type: Type) -> None:
+            super().__init__(expr_type, False, False)
+
+        @property
+        def ir_ref_without_type_annotation(self) -> str:
+            assert False
+
+        def assert_can_read_from(self) -> None:
+            pass
+
+        def assert_can_write_to(self) -> None:
+            pass
+
+        def __repr__(self) -> str:
+            return self.underlying_type.format_for_output_to_user(False)
+
     try:
-        cost, _ = implicit_conversion_impl(src, dest_type)
+        expression = src if isinstance(src, TypedExpression) else Wrapper(src)
+        cost, _ = implicit_conversion_impl(expression, dest_type)
         return cost
     except TypeCheckerError:
         return None

--- a/codegen/type_conversions.py
+++ b/codegen/type_conversions.py
@@ -1,8 +1,6 @@
 from functools import cached_property
 from typing import Iterator, Optional
 
-from codegen.interfaces import Type
-
 from .builtin_types import HeapArrayDefinition, IntegerDefinition, StackArrayDefinition
 from .interfaces import Type, TypedExpression
 from .user_facing_errors import OperandError, TypeCheckerError

--- a/codegen/type_resolution.py
+++ b/codegen/type_resolution.py
@@ -2,27 +2,44 @@ from abc import abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable
+from itertools import groupby
+from typing import Callable, Iterable, Optional
 
 from .builtin_types import (
     AnonymousType,
+    FunctionSignature,
     HeapArrayDefinition,
     NamedType,
+    PrimitiveType,
     StackArrayDefinition,
     StructDefinition,
 )
-from .interfaces import GenericMapping, SpecializationItem, Type, format_specialization
+from .expressions import InitializerList
+from .interfaces import (
+    GenericArgument,
+    GenericMapping,
+    SpecializationItem,
+    Type,
+    TypedExpression,
+    do_specializations_match,
+    format_arguments,
+    format_specialization,
+)
+from .type_conversions import get_implicit_conversion_cost
 from .user_facing_errors import (
+    AmbiguousInitialization,
+    BuiltinSourceLocation,
     DoubleReferenceError,
     ErrorWithLocationInfo,
     FailedLookupError,
-    GenericArgumentCountError,
     GrapheneError,
+    Location,
     NonDeterminableSize,
+    PatternMatchDeductionFailure,
     RedefinitionError,
-    SourceLocation,
     SpecializationFailed,
     SubstitutionFailure,
+    OverloadResolutionError,
 )
 
 
@@ -31,24 +48,25 @@ class GenericResolutionImpossible(ValueError):
 
 
 @dataclass
-class GenericArgument:
-    name: str
-    is_value_arg: bool
+class BaseSymbol:
+    specialization_count: int
 
 
-@dataclass
+def get_cost_at_pattern_match_depth(depth: int) -> int:
+    # TODO: maybe this should be a list for infinite precision?
+    # ATM. only 16 generic deductions/ nested levels are allowed
+    return 16 ** (16 - depth)
+
+
+@dataclass(frozen=True)
 class UnresolvedType:
     @abstractmethod
     def format_for_output_to_user(self) -> str:
         pass
 
     @abstractmethod
-    def get_typedef_dependencies(self) -> list[str]:
-        pass
-
-    @abstractmethod
     def produce_specialized_copy(
-        self, specialization_map: dict[str, SpecializationItem]
+        self, specialization_map: GenericMapping
     ) -> "UnresolvedType":
         pass
 
@@ -57,11 +75,22 @@ class UnresolvedType:
         pass
 
     @abstractmethod
-    def pattern_match(self, target: Type, mapping_out: GenericMapping) -> bool:
+    def get_components_to_match(self) -> set[GenericArgument]:
         pass
 
+    @abstractmethod
+    def pattern_match_impl(
+        self, target: Type, out: GenericMapping, depth: int
+    ) -> Optional[int]:
+        pass
 
-@dataclass
+    def pattern_match(
+        self, target: Type, out: GenericMapping, depth: int
+    ) -> Optional[int]:
+        return self.pattern_match_impl(target, out, depth)
+
+
+@dataclass(frozen=True)
 class CompileTimeConstant:
     @abstractmethod
     def format_for_output_to_user(self) -> str:
@@ -69,7 +98,7 @@ class CompileTimeConstant:
 
     @abstractmethod
     def produce_specialized_copy(
-        self, specialization_map: dict[str, SpecializationItem]
+        self, specialization_map: GenericMapping
     ) -> "CompileTimeConstant":
         pass
 
@@ -78,7 +107,13 @@ class CompileTimeConstant:
         pass
 
     @abstractmethod
-    def pattern_match(self, target: int, mapping_out: GenericMapping) -> bool:
+    def get_components_to_match(self) -> set[GenericArgument]:
+        pass
+
+    @abstractmethod
+    def pattern_match(
+        self, target: int, out: GenericMapping, depth: int
+    ) -> Optional[int]:
         pass
 
 
@@ -86,26 +121,31 @@ UnresolvedSpecializationItem = UnresolvedType | CompileTimeConstant
 UnresolvedGenericMapping = dict[str, UnresolvedSpecializationItem]
 
 
-@dataclass
+@dataclass(frozen=True)
 class NumericLiteralConstant(CompileTimeConstant):
     value: int
 
     def format_for_output_to_user(self) -> str:
         return str(self.value)
 
-    def produce_specialized_copy(
-        self, specialization_map: dict[str, SpecializationItem]
-    ) -> CompileTimeConstant:
+    def produce_specialized_copy(self, _: GenericMapping) -> CompileTimeConstant:
         return NumericLiteralConstant(self.value)
 
     def resolve(self) -> int:
         return self.value
 
-    def pattern_match(self, target: int, mapping_out: GenericMapping) -> bool:
-        return target == self.value
+    def get_components_to_match(self) -> set[GenericArgument]:
+        return set()
+
+    def pattern_match_impl(
+        self, target: int, mapping_out: GenericMapping, depth: int
+    ) -> Optional[int]:
+        if target != self.value:
+            return None
+        return 0
 
 
-@dataclass
+@dataclass(frozen=True)
 class GenericValueReference(CompileTimeConstant):
     argument_name: str
 
@@ -113,12 +153,11 @@ class GenericValueReference(CompileTimeConstant):
         return f"@{self.argument_name}"
 
     def produce_specialized_copy(
-        self, specialization_map: dict[str, SpecializationItem]
+        self, specialization: GenericMapping
     ) -> CompileTimeConstant:
-        # TODO: user facing errors
-        assert self.argument_name in specialization_map
+        assert self.argument_name in specialization.mapping
 
-        specialized_value = specialization_map[self.argument_name]
+        specialized_value = specialization.mapping[self.argument_name]
         if not isinstance(specialized_value, int):
             raise SpecializationFailed(
                 self.format_for_output_to_user(),
@@ -130,41 +169,49 @@ class GenericValueReference(CompileTimeConstant):
     def resolve(self) -> int:
         raise GenericResolutionImpossible("Generic value reference")
 
-    def pattern_match(self, target: int, mapping_out: GenericMapping) -> bool:
-        if self.argument_name in mapping_out:
+    def get_components_to_match(self) -> set[GenericArgument]:
+        return {GenericArgument(self.argument_name, True)}
+
+    def pattern_match_impl(
+        self, target: int, out: GenericMapping, depth: int
+    ) -> Optional[int]:
+        if self.argument_name in out.mapping:
             # TODO: user facing error
-            return mapping_out[self.argument_name] == target
+            if out.mapping[self.argument_name] != target:
+                return None
 
-        mapping_out[self.argument_name] = target
-        return True
+        out.mapping[GenericArgument(self.argument_name, True)] = target
+        return get_cost_at_pattern_match_depth(depth)
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnresolvedTypeWrapper(UnresolvedType):
     resolved_type: Type
 
     def format_for_output_to_user(self) -> str:
         return self.resolved_type.format_for_output_to_user()
 
-    def get_typedef_dependencies(self) -> list[str]:
-        return []
-
-    def produce_specialized_copy(
-        self, _: dict[str, SpecializationItem]
-    ) -> UnresolvedType:
+    def produce_specialized_copy(self, _: GenericMapping) -> UnresolvedType:
         return UnresolvedTypeWrapper(self.resolved_type)
 
     def resolve(self, lookup: Callable[[str, list[SpecializationItem]], Type]) -> Type:
         return self.resolved_type
 
-    def pattern_match(self, target: Type, mapping_out: GenericMapping) -> bool:
-        return self.resolved_type == target
+    def get_components_to_match(self) -> set[GenericArgument]:
+        return set()
+
+    def pattern_match_impl(
+        self, target: Type, out: GenericMapping, depth: int
+    ) -> Optional[int]:
+        if self.resolved_type != target:
+            return None
+        return 0
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnresolvedNamedType(UnresolvedType):
     name: str
-    specialization: list[UnresolvedSpecializationItem]
+    specialization: tuple[UnresolvedSpecializationItem]
 
     def format_for_output_to_user(self) -> str:
         if len(self.specialization) == 0:
@@ -175,24 +222,14 @@ class UnresolvedNamedType(UnresolvedType):
         )
         return f"{self.name}<{specialization_format}>"
 
-    def get_typedef_dependencies(self) -> list[str]:
-        specialization_depends = []
-        for specialization in self.specialization:
-            if isinstance(specialization, UnresolvedType):
-                specialization_depends.extend(specialization.get_typedef_dependencies())
-
-        return [self.name, *specialization_depends]
-
     def produce_specialized_copy(
-        self, specialization_map: dict[str, SpecializationItem]
+        self, specialization: GenericMapping
     ) -> UnresolvedType:
-        result = UnresolvedNamedType(self.name, [])
+        specializations = []
         for item in self.specialization:
-            result.specialization.append(
-                item.produce_specialized_copy(specialization_map)
-            )
+            specializations.append(item.produce_specialized_copy(specialization))
 
-        return result
+        return UnresolvedNamedType(self.name, tuple(specializations))
 
     def resolve(self, lookup: Callable[[str, list[SpecializationItem]], Type]) -> Type:
         resolved_specialization = []
@@ -205,67 +242,84 @@ class UnresolvedNamedType(UnresolvedType):
 
         return lookup(self.name, resolved_specialization)
 
-    def _pattern_match_impl(self, target: Type, mapping_out: GenericMapping) -> bool:
+    def _pattern_match_impl_impl(
+        self, target: Type, mapping_out: GenericMapping, depth: int
+    ) -> Optional[int]:
         if not isinstance(target, NamedType):
-            return False
+            return None
 
         # If our name doesn't match, recurse into the target's alias
         if target.name != self.name:
             if target.alias is None:
-                return False
-            return self.pattern_match(target.alias, mapping_out)
+                return None
+
+            return self.pattern_match(target.alias, mapping_out, depth)
 
         if len(self.specialization) != len(target.specialization):
-            return False
+            return None
 
+        cost = 0
         for this_arg, target_arg in zip(self.specialization, target.specialization):
             if isinstance(this_arg, CompileTimeConstant) != isinstance(target_arg, int):
-                return False
+                return None
 
+            result: Optional[int] = None
             if isinstance(this_arg, CompileTimeConstant):
                 assert isinstance(target_arg, int)
-                if not this_arg.pattern_match(target_arg, mapping_out):
-                    return False
+                result = this_arg.pattern_match(target_arg, mapping_out, depth + 1)
 
             if isinstance(this_arg, UnresolvedType):
                 assert isinstance(target_arg, Type)
-                if not this_arg.pattern_match(target_arg, mapping_out):
-                    return False
+                result = this_arg.pattern_match(target_arg, mapping_out, depth + 1)
 
-        return True
+            if result is None:
+                return None
 
-    def pattern_match(self, target: Type, mapping_out: GenericMapping) -> bool:
+            cost += result
+
+        return cost
+
+    def get_components_to_match(self) -> set[GenericArgument]:
+        return set().union(
+            *(item.get_components_to_match() for item in self.specialization)
+        )
+
+    def pattern_match_impl(
+        self, target: Type, out: GenericMapping, depth: int
+    ) -> Optional[int]:
         curr = target
 
         while curr:
-            curr_mapping = mapping_out.copy()
+            curr_mapping = GenericMapping(out.mapping.copy(), out.pack.copy())
+            result = self._pattern_match_impl_impl(curr, curr_mapping, depth)
 
-            if self._pattern_match_impl(curr, curr_mapping):
-                mapping_out.update(curr_mapping)
-                return True
+            if result is not None:
+                out.mapping.update(curr_mapping.mapping)
+                out.pack = curr_mapping.pack
+                return result
 
             curr = curr.alias if isinstance(curr, NamedType) else None
 
-        return False
+        return None
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnresolvedGenericType(UnresolvedType):
     name: str
+
+    @property
+    def argument(self) -> GenericArgument:
+        return GenericArgument(self.name, False)
 
     def format_for_output_to_user(self) -> str:
         return self.name
 
-    def get_typedef_dependencies(self) -> list[str]:
-        return [self.name]
-
     def produce_specialized_copy(
-        self, specialization_map: dict[str, SpecializationItem]
+        self, specialization: GenericMapping
     ) -> UnresolvedType:
-        # TODO: user facing errors
-        assert self.name in specialization_map
+        assert self.argument in specialization.mapping
 
-        specialized_type = specialization_map[self.name]
+        specialized_type = specialization.mapping[self.argument]
         if not isinstance(specialized_type, Type):
             raise SpecializationFailed(
                 self.format_for_output_to_user(), str(specialized_type)
@@ -276,31 +330,29 @@ class UnresolvedGenericType(UnresolvedType):
     def resolve(self, lookup: Callable[[str, list[SpecializationItem]], Type]) -> Type:
         raise GenericResolutionImpossible("Generic type")
 
-    def pattern_match(self, target: Type, mapping_out: GenericMapping) -> bool:
-        if self.name in mapping_out:
-            # TODO: user facing error
-            return target == mapping_out[self.name]
+    def get_components_to_match(self) -> set[GenericArgument]:
+        return {self.argument}
 
-        mapping_out[self.name] = target
-        return True
+    def pattern_match_impl(
+        self, target: Type, out: GenericMapping, depth: int
+    ) -> Optional[int]:
+        if self.name in out.mapping:
+            if target != out.mapping[self.argument]:
+                return None
+
+        out.mapping[self.argument] = target
+        return get_cost_at_pattern_match_depth(depth)
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnresolvedReferenceType(UnresolvedType):
     value_type: UnresolvedType
 
     def format_for_output_to_user(self) -> str:
         return self.value_type.format_for_output_to_user() + "&"
 
-    def get_typedef_dependencies(self) -> list[UnresolvedType]:
-        return []
-
-    def produce_specialized_copy(
-        self, specialization_map: dict[str, SpecializationItem]
-    ) -> UnresolvedType:
-        return UnresolvedReferenceType(
-            self.value_type.produce_specialized_copy(specialization_map)
-        )
+    def produce_specialized_copy(self, out: GenericMapping) -> UnresolvedType:
+        return UnresolvedReferenceType(self.value_type.produce_specialized_copy(out))
 
     def resolve(self, lookup: Callable[[str, list[SpecializationItem]], Type]) -> Type:
         # TODO: support circular references
@@ -310,18 +362,23 @@ class UnresolvedReferenceType(UnresolvedType):
 
         return resolved_value.convert_to_reference_type()
 
-    def pattern_match(self, target: Type, mapping_out: GenericMapping) -> bool:
+    def get_components_to_match(self) -> set[GenericArgument]:
+        return self.value_type.get_components_to_match()
+
+    def pattern_match_impl(
+        self, target: Type, out: GenericMapping, depth: int
+    ) -> Optional[int]:
         if not target.is_reference:
-            return False
+            return None
 
         return self.value_type.pattern_match(
-            target.convert_to_value_type(), mapping_out
+            target.convert_to_value_type(), out, depth + 1
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnresolvedStructType(UnresolvedType):
-    members: list[tuple[str, UnresolvedType]]
+    members: tuple[tuple[str, UnresolvedType]]
 
     def format_for_output_to_user(self) -> str:
         member_format = ", ".join(
@@ -330,25 +387,15 @@ class UnresolvedStructType(UnresolvedType):
         )
         return "{" + ", ".join(member_format) + "}"
 
-    def get_typedef_dependencies(self) -> list[str]:
-        dependencies = []
-        for _, member_type in self.members:
-            if isinstance(member_type, UnresolvedType):
-                dependencies.extend(member_type.get_typedef_dependencies())
-        return dependencies
-
     def produce_specialized_copy(
-        self, specialization_map: dict[str, SpecializationItem]
+        self, specialization: GenericMapping
     ) -> UnresolvedType:
-        result = UnresolvedStructType([])
-        for name, member_type in self.members:
-            result.members.append(
-                (
-                    name,
-                    member_type.produce_specialized_copy(specialization_map),
-                )
+        return UnresolvedStructType(
+            tuple(
+                (name, member_type.produce_specialized_copy(specialization))
+                for name, member_type in self.members
             )
-        return result
+        )
 
     def resolve(self, lookup: Callable[[str, list[SpecializationItem]], Type]) -> Type:
         resolved_members = []
@@ -357,14 +404,19 @@ class UnresolvedStructType(UnresolvedType):
 
         return AnonymousType(StructDefinition(resolved_members))
 
-    def pattern_match(self, target: Type, mapping_out: GenericMapping) -> bool:
+    def get_components_to_match(self) -> set[GenericArgument]:
+        return set().union(
+            *(member[1].get_components_to_match() for member in self.members)
+        )
+
+    def pattern_match_impl(self, target: Type, out: GenericMapping) -> bool:
         assert False  # TODO
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnresolvedStackArrayType(UnresolvedType):
     member_type: UnresolvedType
-    dimensions: list[CompileTimeConstant]
+    dimensions: tuple[CompileTimeConstant]
 
     def format_for_output_to_user(self) -> str:
         member_format = self.member_type.format_for_output_to_user()
@@ -373,20 +425,15 @@ class UnresolvedStackArrayType(UnresolvedType):
         )
         return f"{member_format}[{dimensions_format}]"
 
-    def get_typedef_dependencies(self) -> list[str]:
-        return self.member_type.get_typedef_dependencies()
-
     def produce_specialized_copy(
-        self, specialization_map: dict[str, SpecializationItem]
+        self, specialization: GenericMapping
     ) -> UnresolvedType:
-        result = UnresolvedStackArrayType(
-            self.member_type.produce_specialized_copy(specialization_map), []
+        return UnresolvedStackArrayType(
+            self.member_type.produce_specialized_copy(specialization),
+            tuple(
+                dim.produce_specialized_copy(specialization) for dim in self.dimensions
+            ),
         )
-        for dimension in self.dimensions:
-            result.dimensions.append(
-                dimension.produce_specialized_copy(specialization_map)
-            )
-        return result
 
     def resolve(self, lookup: Callable[[str, list[SpecializationItem]], Type]) -> Type:
         resolved_dimensions = []
@@ -396,24 +443,41 @@ class UnresolvedStackArrayType(UnresolvedType):
         resolved_member = self.member_type.resolve(lookup)
         return AnonymousType(StackArrayDefinition(resolved_member, resolved_dimensions))
 
-    def pattern_match(self, target: Type, mapping_out: GenericMapping) -> bool:
+    def get_components_to_match(self) -> set[GenericArgument]:
+        return set().union(
+            self.member_type.get_components_to_match(),
+            *(dim.get_components_to_match() for dim in self.dimensions),
+        )
+
+    def pattern_match_impl(
+        self, target: Type, out: GenericMapping, depth: int
+    ) -> Optional[int]:
         if not isinstance(target.definition, StackArrayDefinition):
-            return False
+            return None
 
         if len(self.dimensions) != len(target.definition.dimensions):
-            return False
+            return None
 
+        cost = 0
         for target_dim, our_dim in zip(target.definition.dimensions, self.dimensions):
-            if not our_dim.pattern_match(target_dim, mapping_out):
-                return False
+            result = our_dim.pattern_match(target_dim, out, depth + 1)
+            if result is None:
+                return None
+            cost += result
 
-        return self.member_type.pattern_match(target.definition.member, mapping_out)
+        result = self.member_type.pattern_match(
+            target.definition.member, out, depth + 1
+        )
+        if result is None:
+            return None
+
+        return cost + result
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnresolvedHeapArrayType(UnresolvedType):
     member_type: UnresolvedType
-    known_dimensions: list[CompileTimeConstant]
+    known_dimensions: tuple[CompileTimeConstant]
 
     def format_for_output_to_user(self) -> str:
         member_format = self.member_type.format_for_output_to_user()
@@ -425,20 +489,16 @@ class UnresolvedHeapArrayType(UnresolvedType):
         )
         return f"{member_format}[&, {dimensions_format}]"
 
-    def get_typedef_dependencies(self) -> list[str]:
-        return self.member_type.get_typedef_dependencies()
-
     def produce_specialized_copy(
-        self, specialization_map: dict[str, SpecializationItem]
+        self, specialization: GenericMapping
     ) -> UnresolvedType:
-        result = UnresolvedHeapArrayType(
-            self.member_type.produce_specialized_copy(specialization_map), []
+        return UnresolvedHeapArrayType(
+            self.member_type.produce_specialized_copy(specialization),
+            tuple(
+                dim.produce_specialized_copy(specialization)
+                for dim in self.known_dimensions
+            ),
         )
-        for dimension in self.known_dimensions:
-            result.known_dimensions.append(
-                dimension.produce_specialized_copy(specialization_map)
-            )
-        return result
 
     def resolve(self, lookup: Callable[[str, list[SpecializationItem]], Type]) -> Type:
         resolved_dimensions = []
@@ -448,210 +508,712 @@ class UnresolvedHeapArrayType(UnresolvedType):
         resolved_member = self.member_type.resolve(lookup)
         return AnonymousType(HeapArrayDefinition(resolved_member, resolved_dimensions))
 
-    def pattern_match(self, target: Type, mapping_out: GenericMapping) -> bool:
+    def get_components_to_match(self) -> set[GenericArgument]:
+        return set().union(
+            self.member_type.get_components_to_match(),
+            *(dim.get_components_to_match() for dim in self.known_dimensions),
+        )
+
+    def pattern_match_impl(
+        self, target: Type, mapping_out: GenericMapping, depth: int
+    ) -> Optional[int]:
         if not isinstance(target.definition, HeapArrayDefinition):
-            return False
+            return None
 
         if len(self.known_dimensions) != len(target.definition.known_dimensions):
-            return False
+            return None
 
+        cost = 0
         for target_dim, our_dim in zip(
             target.definition.known_dimensions, self.known_dimensions
         ):
-            if not our_dim.pattern_match(target_dim, mapping_out):
+            result = our_dim.pattern_match(target_dim, mapping_out, depth + 1)
+            if result is None:
+                return None
+
+        result = self.member_type.pattern_match(
+            target.definition.member, mapping_out, depth + 1
+        )
+        if result is None:
+            return None
+        return cost + result
+
+
+@dataclass(frozen=True)
+class Typedef:
+    name: str
+    generics: tuple[GenericArgument]
+    expanded_specialization: tuple[UnresolvedSpecializationItem]
+    aliased: UnresolvedType
+    loc: Location
+
+    @staticmethod
+    def construct(
+        name: str,
+        generics: tuple[GenericArgument],
+        specialization: Iterable[UnresolvedSpecializationItem],
+        aliased: UnresolvedType,
+        loc: Location,
+    ):
+        explicitly_matched_generics = set().union(
+            *(item.get_components_to_match() for item in specialization)
+        )
+
+        unmatched_generics = [
+            generic
+            for generic in generics
+            if generic not in explicitly_matched_generics
+        ]
+
+        expanded_specialization = [*specialization]
+        # Atm we don't support both generics and pattern matching simultaneously
+        # TODO: remove this
+        if len(generics) != 0:
+            assert len(expanded_specialization) == 0
+
+        for generic in unmatched_generics:
+            if generic.is_value_arg:
+                expanded_specialization.append(GenericValueReference(generic.name))
+            else:
+                expanded_specialization.append(UnresolvedGenericType(generic.name))
+
+        return Typedef(name, generics, tuple(expanded_specialization), aliased, loc)
+
+    def pattern_match(
+        self,
+        target_specialization: list[SpecializationItem],
+        mapping_out: GenericMapping,
+    ) -> Optional[int]:
+        cost = 0
+        for item, target in zip(
+            self.expanded_specialization, target_specialization, strict=True
+        ):
+            if isinstance(item, CompileTimeConstant) != isinstance(target, int):
+                return None
+
+            if len(item.get_components_to_match()) == 0:
+                # Nothing to match, we rely on type equality instead
+                # This costs nothing
+                continue
+
+            result: Optional[int] = None
+            if isinstance(item, CompileTimeConstant):
+                assert isinstance(target, int)
+                result = item.pattern_match(target, mapping_out, 1)
+
+            if isinstance(item, UnresolvedType):
+                assert isinstance(target, Type)
+                result = item.pattern_match(target, mapping_out, 1)
+
+            if result is None:
+                return None
+
+            cost += result
+
+        return cost
+
+    def produce_specialized_copy(self, specialization: GenericMapping) -> "Typedef":
+        new_specialization = tuple(
+            item.produce_specialized_copy(specialization)
+            for item in self.expanded_specialization
+        )
+        new_alias = self.aliased.produce_specialized_copy(specialization)
+
+        return Typedef(self.name, tuple(), new_specialization, new_alias, self.loc)
+
+
+@dataclass(frozen=True)
+class UnresolvedFunctionSignature:
+    name: str
+    expanded_specialization: tuple[UnresolvedSpecializationItem]
+    arguments: tuple[UnresolvedType]
+    parameter_pack_argument_name: Optional[str]
+    return_type: UnresolvedType
+
+    def collapse_into_type(self, arg: TypedExpression | Type) -> Type:
+        if isinstance(arg, InitializerList):
+            raise NotImplementedError()
+        if isinstance(arg, TypedExpression):
+            return arg.underlying_type
+        if isinstance(arg, Type):
+            return arg
+
+        assert False
+
+    def format_for_output_to_user(self) -> str:
+        specialization_str = ""
+        if len(self.expanded_specialization) != 0:
+            specialization_list = ", ".join(
+                (
+                    item.format_for_output_to_user()
+                    for item in self.expanded_specialization
+                ),
+            )
+            specialization_str = f"<{specialization_list}>"
+
+        formatted_args = [arg.format_for_output_to_user() for arg in self.arguments]
+        if self.parameter_pack_argument_name is not None:
+            format_arguments.append(self.parameter_pack_argument_name + "...")
+
+        args_str = ", ".join(formatted_args)
+        return_str = self.return_type.format_for_output_to_user()
+        return f"{self.name}{specialization_str}({args_str}) -> {return_str}"
+
+    def get_components_to_match(self) -> set[GenericArgument]:
+        return set().union(
+            *(item.get_components_to_match() for item in self.expanded_specialization)
+        )
+
+    def produce_specialized_copy(
+        self,
+        specialization: GenericMapping,
+    ) -> "UnresolvedFunctionSignature":
+        unmatched_generics = (
+            self.get_components_to_match() - specialization.mapping.keys()
+        )
+        if len(unmatched_generics) != 0:
+            raise PatternMatchDeductionFailure(self.name, unmatched_generics.pop().name)
+
+        specialization_items: list[UnresolvedSpecializationItem] = []
+        for item in self.expanded_specialization:
+            specialization_items.append(item.produce_specialized_copy(specialization))
+
+        arguments: list[UnresolvedType] = []
+        for arg in self.arguments:
+            arguments.append(arg.produce_specialized_copy(specialization))
+
+        if self.parameter_pack_argument_name is not None:
+            arguments.extend(
+                [UnresolvedTypeWrapper(pack_item) for pack_item in specialization.pack]
+            )
+
+        specialization_items.extend(
+            [UnresolvedTypeWrapper(pack_type) for pack_type in specialization.pack]
+        )
+
+        return UnresolvedFunctionSignature(
+            self.name,
+            tuple(specialization_items),
+            tuple(arguments),
+            None,  # We have just expanded the parameter pack
+            self.return_type.produce_specialized_copy(specialization),
+        )
+
+    def pattern_match(
+        self,
+        target_args: list[TypedExpression] | list[Type],
+        target_specialization: list[SpecializationItem],
+        out: GenericMapping,
+        depth: int,
+    ) -> Optional[int]:
+        cost = 0
+
+        # Match the specialization
+        for target_item, item in zip(
+            target_specialization, self.expanded_specialization
+        ):
+            if isinstance(item, CompileTimeConstant) != isinstance(target_item, int):
                 return False
 
-        return self.member_type.pattern_match(target.definition.member, mapping_out)
+            if len(item.get_components_to_match()) == 0:
+                continue  # Allow for implicit conversions + type equivalency
+
+            result: Optional[int] = None
+            if isinstance(item, CompileTimeConstant):
+                assert isinstance(target_item, int)
+                result = item.pattern_match(target_item, out, depth + 1)
+
+            if isinstance(item, UnresolvedType):
+                assert isinstance(target_item, Type)
+                result = item.pattern_match(target_item, out, depth + 1)
+
+            if result is None:
+                return None
+
+            cost += result
+
+        # Check the argument count
+        if self.parameter_pack_argument_name is None:
+            if len(self.arguments) != len(target_args):
+                return None
+        else:
+            if len(self.arguments) >= len(target_args):
+                return None
+
+        # Match the (non-packed) arguments
+        for target_arg, unresolved_arg in zip(
+            target_args[: len(self.arguments)], self.arguments
+        ):
+            if len(unresolved_arg.get_components_to_match()) == 0:
+                continue  # Allow for implicit conversions + type equivalency
+
+            if isinstance(target_arg, InitializerList):
+                # See: `docs/types_overview.c3`
+                # TODO: we should convert this to an anonymous struct
+                #   for now we just ignore initializer lists
+                continue
+
+            arg_type = self.collapse_into_type(target_arg)
+            result = unresolved_arg.pattern_match(arg_type, out, depth + 1)
+            if result is None:
+                return None
+
+            cost += result
+
+        # Match the packed arguments
+        if self.parameter_pack_argument_name is not None:
+            assert len(out.pack) == 0
+            out.pack.extend(
+                (
+                    self.collapse_into_type(arg)
+                    for arg in target_args[len(self.arguments) :]
+                )
+            )
+            cost += get_cost_at_pattern_match_depth(depth + 1) * len(out.pack)
+
+        return cost
 
 
-@dataclass
-class SpecializedTypedef:
-    name: str
-    specialization: list[UnresolvedSpecializationItem]
-    aliased: UnresolvedType
-    loc: SourceLocation
+@dataclass(frozen=True)
+class FnDeclaration:
+    is_foreign: bool
+    arg_names: tuple[str]
+    pack_arg_name: Optional[str]
+    generics: tuple[GenericArgument]
+    signature: UnresolvedFunctionSignature
+    loc: Location
+
+    @staticmethod
+    def construct(
+        name: str,
+        is_foreign: bool,
+        generics: tuple[GenericArgument],
+        specialization: Iterable[UnresolvedSpecializationItem],
+        arg_names: tuple[str],
+        pack_arg_name: Optional[str],
+        arg_types: tuple[UnresolvedType],
+        parameter_pack_argument_name: Optional[str],
+        return_type: UnresolvedType,
+        location: Location,
+    ):
+        explicitly_matched_generics = set().union(
+            *(item.get_components_to_match() for item in specialization)
+        )
+
+        unmatched_generics = [
+            generic
+            for generic in generics
+            if generic not in explicitly_matched_generics
+        ]
+
+        expanded_specialization = [*specialization]
+        # Atm we don't support both generics and pattern matching simultaneously
+        assert len(expanded_specialization) == 0  # TODO: remove this
+
+        for generic in unmatched_generics:
+            if generic.is_value_arg:
+                expanded_specialization.append(GenericValueReference(generic.name))
+            else:
+                expanded_specialization.append(UnresolvedGenericType(generic.name))
+
+        signature = UnresolvedFunctionSignature(
+            name,
+            tuple(expanded_specialization),
+            arg_types,
+            parameter_pack_argument_name,
+            return_type,
+        )
+        return FnDeclaration(
+            is_foreign, arg_names, pack_arg_name, generics, signature, location
+        )
+
+    def format_for_output_to_user(self) -> str:
+        prefix = "foreign" if self.is_foreign else "function"
+        return f"{prefix} {self.signature.format_for_output_to_user()}"
+
+    def pattern_match(
+        self,
+        target_args: list[TypedExpression] | list[Type],
+        target_specialization: list[SpecializationItem],
+        out: GenericMapping,
+    ) -> Optional[int]:
+        return self.signature.pattern_match(target_args, target_specialization, out, 0)
+
+    def produce_specialized_copy(
+        self, specialization_map: GenericMapping
+    ) -> UnresolvedFunctionSignature:
+        return self.signature.produce_specialized_copy(specialization_map)
 
 
-@dataclass
-class GenericTypedef:
-    name: str
-    generics: list[GenericArgument]
-    aliased: UnresolvedType
-    loc: SourceLocation
-
-
-class TypeSymbolTable:
+class SymbolTable:
     def __init__(self) -> None:
-        self._generic_unresolved_types: dict[str, GenericTypedef] = {}
-        self._unresolved_types: dict[str, list[SpecializedTypedef]] = defaultdict(list)
-        self._unresolved_visiting_state: dict[str, int] = defaultdict(int)
+        self._base_typedefs: dict[str, BaseSymbol] = {}
 
-        self._resolved_types: dict[str, list[NamedType]] = defaultdict(list)
+        self._unresolved_fndefs: dict[str, list[FnDeclaration]] = defaultdict(list)
+        self._unresolved_typedefs: dict[tuple[str, int], list[Typedef]] = defaultdict(
+            list
+        )
 
-    def get_dependencies_for_typedef(self, typedef_name: str) -> list[str]:
-        dependencies: list[str] = []
-        if typedef_name in self._unresolved_types:
-            for node in self._unresolved_types[typedef_name]:
-                dependencies.extend(node.aliased.get_typedef_dependencies())
+        # Remember the order that symbols are added so we can give sane error messages
+        self._newly_added_unresolved_typedefs: list[Typedef] = []
+        self._newly_added_unresolved_functions: list[FnDeclaration] = []
 
-                for specialization in node.specialization:
-                    if not isinstance(specialization, UnresolvedType):
-                        continue
+        # Symbols requiring codegen + cache for future lookup
+        self._resolved_types: dict[tuple[str, int], list[NamedType]] = defaultdict(list)
+        self._resolved_functions: dict[str, list[FunctionSignature]] = defaultdict(list)
+        self._remaining_to_codegen: list[tuple[FnDeclaration, FunctionSignature]] = []
 
-                    dependencies.extend(specialization.get_typedef_dependencies())
+    def resolve_specialization_item(
+        self, unresolved: UnresolvedSpecializationItem
+    ) -> SpecializationItem:
+        if isinstance(unresolved, UnresolvedType):
+            return self.resolve_type(unresolved)
+        return unresolved.resolve()
 
-        if typedef_name in self._generic_unresolved_types:
-            generic_definition = self._generic_unresolved_types[typedef_name].aliased
-            dependencies.extend(generic_definition.get_typedef_dependencies())
-
-        return dependencies
-
-    def sort_dependencies_topologically(self, name: str, order: list[str]) -> None:
-        if self._unresolved_visiting_state[name] == 2:
-            return  # Already finished
-
-        # TODO: we can trip this assert with a MaybePtr??
-        # TODO: user facing error message (cyclic type)
-        assert self._unresolved_visiting_state[name] == 0
-        self._unresolved_visiting_state[name] = 1  # In-progress
-
-        # Recurse into dependencies
-        typedef_dependencies = self.get_dependencies_for_typedef(name)
-        for dependency in typedef_dependencies:
-            self.sort_dependencies_topologically(dependency, order)
-
-        self._unresolved_visiting_state[name] = 2  # Finished
-        order.append(name)
+    def resolve_type(self, unresolved: UnresolvedType) -> Type:
+        return unresolved.resolve(partial(SymbolTable.lookup_named_type, self))
 
     def resolve_named_type(
         self,
         name: str,
-        specialization: list[SpecializationItem],
+        unresolved_specialization: tuple[UnresolvedSpecializationItem],
         alias: UnresolvedType,
     ) -> NamedType:
+        specialization = [
+            self.resolve_specialization_item(item) for item in unresolved_specialization
+        ]
+
+        # Is the type already in the cache?
+        key = (name, len(unresolved_specialization))
+        for other in self._resolved_types[key]:
+            if do_specializations_match(other.specialization, specialization):
+                return other
+
+        # Else resolve it from scratch
         resolved_type = NamedType(name, specialization)
         try:
             # Prematurely assume type is resolvable (for cyclic types)
-            self._resolved_types[name].append(resolved_type)
+            self._resolved_types[key].append(resolved_type)
             resolved_type.update_with_finalized_alias(self.resolve_type(alias))
             if not resolved_type.is_finite:
                 raise NonDeterminableSize(resolved_type.format_for_output_to_user(True))
         except SubstitutionFailure as exc:
             # Type is NOT resolvable, undo bad assumption and rethrow error
-            self._resolved_types[name].remove(resolved_type)
+            self._resolved_types[key].remove(resolved_type)
             raise exc
 
         return resolved_type
 
-    def specialize_and_resolve_generic_type(
-        self, name: str, specialization: list[SpecializationItem]
-    ) -> NamedType:
-        generic = self._generic_unresolved_types[name]
-
-        if len(specialization) != len(generic.generics):
-            raise GenericArgumentCountError(
-                generic.name, len(specialization), len(generic.generics)
-            )
-
-        specialization_map = {}
-        # Check specialization arguments are the correct type
-        for generic_arg, specialization_item in zip(generic.generics, specialization):
-            if isinstance(specialization_item, int):
-                # TODO: proper user-facing error
-                assert generic_arg.is_value_arg
-            else:
-                assert isinstance(specialization_item, Type)
-                # TODO: proper user-facing error
-                assert not generic_arg.is_value_arg
-
-            specialization_map[generic_arg.name] = specialization_item
-
-        alias = generic.aliased.produce_specialized_copy(specialization_map)
-        return self.resolve_named_type(name, specialization, alias)
-
-    def resolve_typedef(self, typedef: SpecializedTypedef) -> None:
+    def resolve_function(
+        self, fn: UnresolvedFunctionSignature, declaration: FnDeclaration
+    ) -> FunctionSignature:
         resolved_specialization: list[SpecializationItem] = []
-
-        for arg in typedef.specialization:
+        for arg in fn.expanded_specialization:
             if isinstance(arg, CompileTimeConstant):
                 resolved_specialization.append(arg.resolve())
             else:
                 assert isinstance(arg, UnresolvedType)
                 resolved_specialization.append(self.resolve_type(arg))
 
-        # Check for duplication
-        for other in self._resolved_types[typedef.name]:
-            if other.specialization == resolved_specialization:
-                raise RedefinitionError(
-                    "type",
-                    typedef.name + format_specialization(resolved_specialization),
-                )
+        resolved_arguments: list[Type] = []
+        for arg_type in fn.arguments:
+            resolved_arguments.append(self.resolve_type(arg_type))
 
-        # Finish resolution
-        self.resolve_named_type(typedef.name, resolved_specialization, typedef.aliased)
+        resolved_return = self.resolve_type(fn.return_type)
 
-    def resolve_all_types(self) -> None:
-        # Guarantee all typedefed specializations have been resolved
-        resolution_order = []
-        for unresolved_type_name in self._unresolved_types:
-            self.sort_dependencies_topologically(unresolved_type_name, resolution_order)
+        # Check the cache, have we already resolved this function?
+        for other in self._resolved_functions[fn.name]:
+            if (
+                do_specializations_match(other.specialization, resolved_specialization)
+                and other.arguments == resolved_arguments
+                and other.return_type == resolved_return
+            ):
+                return other
 
-        for type_name in resolution_order:
-            # TODO: further sort this list to parse a single type in the correct order
-            for unresolved_type in self._unresolved_types[type_name]:
-                try:
-                    self.resolve_typedef(unresolved_type)
-                except GrapheneError as exc:
-                    raise ErrorWithLocationInfo(
-                        exc.message, unresolved_type.loc, "typedef"
-                    )
+        result = FunctionSignature(
+            fn.name,
+            resolved_arguments,
+            resolved_return,
+            resolved_specialization,
+            declaration.is_foreign,
+        )
+        self._resolved_functions[fn.name].append(result)
+        self._remaining_to_codegen.append((declaration, result))
+        return result
 
-        # Ensure we only resolve each type once
-        self._unresolved_types.clear()
-        self._unresolved_visiting_state.clear()
+    def select_function_with_least_implicit_conversion_cost(
+        self,
+        fn_name: str,
+        candidate_functions: list[tuple[FunctionSignature, FnDeclaration]],
+        fn_args: list[TypedExpression] | list[Type],
+    ) -> Optional[FunctionSignature]:
+        functions_by_cost: list[tuple[int, FunctionSignature, FnDeclaration]] = []
 
-    def lookup_type(
-        self, prefix: str, specialization: list[SpecializationItem]
-    ) -> NamedType:
-        if (
-            prefix not in self._resolved_types
-            and prefix not in self._generic_unresolved_types
-        ):
+        for function, declaration in candidate_functions:
+            total_cost = 0
+            if len(fn_args) != len(function.arguments):
+                continue
+
+            for src_expr, dest_type in zip(fn_args, function.arguments):
+                cost = get_implicit_conversion_cost(src_expr, dest_type)
+                if cost is not None:
+                    total_cost += cost
+                else:
+                    total_cost = None
+                    break
+
+            # Conversion might fail for some arguments. In that case, discard
+            # this candidate.
+            if total_cost is not None:
+                functions_by_cost.append((total_cost, function, declaration))
+
+        functions_by_cost.sort(key=lambda t: t[0])
+
+        if len(functions_by_cost) == 0:
+            return None
+
+        if len(functions_by_cost) == 1:
+            return functions_by_cost[0][1]
+
+        first, second, *_ = functions_by_cost
+        if first[0] < second[0]:
+            # The first function costs less than the second function
+            # We can unambiguously select the cheaper function
+            return functions_by_cost[0][1]
+
+        # If there are two or more equally good candidates, then this function
+        # call is ambiguous.
+        raise AmbiguousInitialization(
+            "function call",
+            f"{fn_name}{format_arguments(fn_args)}",
+            [
+                (first[2].format_for_output_to_user(), first[2].loc),
+                (second[2].format_for_output_to_user(), second[2].loc),
+            ],
+        )
+
+    def lookup_function(
+        self,
+        name: str,
+        given_specialization: list[SpecializationItem],
+        args: list[TypedExpression] | list[Type],
+    ) -> FunctionSignature:
+        # Specializes and resolves the function corresponding to the correct definition
+        # There are two types of function definition:
+        #   1) function [T] fn : ...            (pure generic)
+        #   2a) function [T] fn<Thing<T>> : ... (pattern match a)
+        #   2b) function [T] fn : (a : T) ...   (pattern match b)
+        #
+        # The first (pure generic) is syntax sugar for the following:
+        #     function [T] fn  ==> function [T] fn<T>
+        #
+        # A function may deduce its specialization based on its arguments
+        #   For now, either the full specialization must be given or none at all
+        #   TODO: relax this requirement
+        #
+        # We choose which function gets priority based on the following criteria:
+        #   1) When initialized the signature MUST not create a substitution failure
+        #   2) All parameter implicit conversions MUST succeed
+        #   3) Minimize the number of top level generic deductions
+        #   4) Minimize the number of 2nd level generic deductions
+        #   N) Minimize the number of N level generic deductions
+        #   N+1) Minimize the cost of implicit conversion
+
+        if name not in self._unresolved_fndefs:
             # Substitution impossible
             raise FailedLookupError(
-                "type", f"typedef {prefix}{format_specialization(specialization)} : ..."
+                "function", f"function {name}{format_arguments(args)}"
             )
 
-        candidates = []
-        for resolved_type in self._resolved_types[prefix]:
-            if resolved_type.specialization == specialization:
-                candidates.append(resolved_type)
+        all_candidates: list[
+            tuple[int, UnresolvedFunctionSignature, FnDeclaration]
+        ] = []
+        for candidate in self._unresolved_fndefs[name]:
+            generics = GenericMapping({}, [])
+            cost = candidate.pattern_match(args, given_specialization, generics)
+            if cost is None:
+                continue
 
-        # TODO: user facing error
-        assert len(candidates) <= 1
+            # We've matched the pattern, now we specialize the candidate
+            # TODO: catch these errors
+            specialized = candidate.produce_specialized_copy(generics)
+            all_candidates.append((cost, specialized, candidate))
 
-        if len(candidates) != 0:
-            return candidates[0]
+        # Find the cheapest valid candidate (doing overload resolution if cost is the same)
+        all_candidates.sort(key=lambda item: item[0])
+        for _, candidates in groupby(all_candidates, key=lambda item: item[0]):
+            resolved_candidates: list[tuple[FunctionSignature, FnDeclaration]] = []
+            for _, candidate, declaration in candidates:
+                try:
+                    resolved_candidates.append(
+                        (self.resolve_function(candidate, declaration), declaration)
+                    )
+                except SubstitutionFailure:
+                    pass  # SFINAE
 
-        # We haven't found a specialization so we produce one from the the generic
-        if prefix not in self._generic_unresolved_types:
-            raise SubstitutionFailure(prefix + format_specialization(specialization))
+            if len(resolved_candidates) != 0:
+                # TODO: pass along the specialization for error messages
+                signature = self.select_function_with_least_implicit_conversion_cost(
+                    name, resolved_candidates, args
+                )
+                if signature is not None:
+                    return signature
 
-        return self.specialize_and_resolve_generic_type(prefix, specialization)
+        raise OverloadResolutionError(
+            f"{name}{format_specialization(given_specialization)}{format_arguments(args)}",
+            [fn.format_for_output_to_user() for fn in self._unresolved_fndefs[name]],
+        )
 
-    def add_generic_unresolved_type(self, unresolved_typedef: GenericTypedef) -> None:
-        # TODO: user facing error
-        assert unresolved_typedef.name not in self._generic_unresolved_types
-        self._generic_unresolved_types[unresolved_typedef.name] = unresolved_typedef
+    def lookup_named_type(
+        self, prefix: str, specialization: list[SpecializationItem]
+    ) -> Type:
+        # Specializes and resolves the type corresponding to the correct typedef
+        # There are two types of typedef:
+        #   1) typedef [T] MyType : ...            (pure generic)
+        #   2) typedef [T] MyType<Thing<T>> : ...  (pattern match)
+        #
+        # The first (pure generic) is syntax sugar for the following:
+        #     typedef [U, V] MyType  ==> typedef [U, V] MyType<U, V>
+        #
+        # We choose which typedef gets priority based on the following criteria:
+        #   1) The specialization argument count MUST match
+        #   2) When initialized the type MUST not create a substitution failure
+        #   3) Minimize the number of top level generic deductions
+        #   4) Minimize the number of 2nd level generic deductions
+        #   N) Minimize the number of N level generic deductions
 
-    def add_unresolved_type(self, unresolved_typedef: SpecializedTypedef) -> None:
-        self._unresolved_types[unresolved_typedef.name].append(unresolved_typedef)
+        if (prefix, len(specialization)) not in self._unresolved_typedefs:
+            # Substitution impossible
+            raise FailedLookupError(
+                "type",
+                f"typedef {prefix}{format_specialization(specialization)} : ...",
+            )
 
-    def add_resolved_type(self, resolved_type: NamedType) -> None:
-        self._resolved_types[resolved_type.name].append(resolved_type)
+        all_candidates: list[tuple[int, Typedef]] = []
+        for candidate in self._unresolved_typedefs[(prefix, len(specialization))]:
+            # Deduce the generic mapping by comparing (un)resolved specializations
+            generics = GenericMapping({}, [])
+            cost = candidate.pattern_match(specialization, generics)
 
-    def resolve_type(self, unresolved_type: UnresolvedType) -> Type:
-        return unresolved_type.resolve(partial(TypeSymbolTable.lookup_type, self))
+            if cost is None:
+                continue
+
+            # We've matched the pattern, now we specialize the candidate
+            # TODO: catch these errors
+            specialized = candidate.produce_specialized_copy(generics)
+            all_candidates.append((cost, specialized))
+
+        # Find the cheapest valid candidate (doing overload resolution if cost is the same)
+        all_candidates.sort(key=lambda item: item[0])
+        for _, candidates in groupby(all_candidates, key=lambda item: item[0]):
+            resolved_candidates: list[tuple[Type, Location]] = []
+            for _, candidate in candidates:
+                try:
+                    resolved_type = self.resolve_named_type(
+                        candidate.name,
+                        candidate.expanded_specialization,
+                        candidate.aliased,
+                    )
+
+                    if do_specializations_match(
+                        resolved_type.specialization, specialization
+                    ):
+                        resolved_candidates.append((resolved_type, candidate.loc))
+                except SubstitutionFailure:
+                    pass  # SFINAE
+                except GrapheneError as e:
+                    raise ErrorWithLocationInfo(e.message, candidate.loc, "typedef")
+
+            if len(resolved_candidates) == 0:
+                continue
+            if len(resolved_candidates) == 1:
+                return resolved_candidates[0][0]
+
+            specialization_str = format_specialization(specialization)
+            raise AmbiguousInitialization(
+                "type",
+                f"{prefix}{specialization_str}",
+                [
+                    (candidate.format_for_output_to_user(True), loc)
+                    for candidate, loc in resolved_candidates
+                ],
+            )
+
+        raise SubstitutionFailure(prefix + format_specialization(specialization))
+
+    def add_function(self, fn_to_add: FnDeclaration) -> None:
+        matched_functions = self._unresolved_fndefs[fn_to_add.signature.name]
+
+        for target in matched_functions:
+            if target.is_foreign or fn_to_add.is_foreign:
+                raise RedefinitionError(
+                    "non-overloadable foreign function",
+                    target.signature.format_for_output_to_user(),
+                )
+
+        matched_functions.append(fn_to_add)
+        self._newly_added_unresolved_functions.append(fn_to_add)
+
+    def add_builtin_type(self, type_to_add: PrimitiveType) -> None:
+        self._resolved_types[type_to_add.name, 0].append(type_to_add)
+        self.add_type(
+            Typedef(
+                type_to_add.name,
+                tuple(),
+                tuple(),
+                UnresolvedNamedType(type_to_add.name, tuple()),
+                BuiltinSourceLocation(),
+            )
+        )
+
+    def add_type(self, type_to_add: Typedef) -> None:
+        # TODO: check for duplicates etc.
+        key = (type_to_add.name, len(type_to_add.expanded_specialization))
+        self._unresolved_typedefs[key].append(type_to_add)
+        self._newly_added_unresolved_typedefs.append(type_to_add)
+
+    def resolve_all_non_generics(self) -> None:
+        for typedef in self._newly_added_unresolved_typedefs:
+            if len(typedef.generics) != 0:
+                continue  # We can't lookup this type because it isn't fully specialized yet
+
+            try:
+                resolved_specialization = [
+                    self.resolve_specialization_item(item)
+                    for item in typedef.expanded_specialization
+                ]
+                self.lookup_named_type(typedef.name, resolved_specialization)
+            except GrapheneError as e:
+                raise ErrorWithLocationInfo(e.message, typedef.loc, "typedef")
+
+        for fn in self._newly_added_unresolved_functions:
+            if len(fn.generics) != 0 or fn.pack_arg_name is not None:
+                continue
+
+            try:
+                resolved_specialization = [
+                    self.resolve_specialization_item(item)
+                    for item in fn.signature.expanded_specialization
+                ]
+                resolved_args = [
+                    self.resolve_type(item) for item in fn.signature.arguments
+                ]
+                self.lookup_function(
+                    fn.signature.name, resolved_specialization, resolved_args
+                )
+            except GrapheneError as e:
+                raise ErrorWithLocationInfo(e.message, fn.loc, "function declaration")
+
+        self._newly_added_unresolved_typedefs.clear()
+        self._newly_added_unresolved_functions.clear()
+
+    def get_next_function_to_codegen(
+        self,
+    ) -> Optional[tuple[FnDeclaration, FunctionSignature]]:
+        try:
+            return self._remaining_to_codegen.pop()
+        except IndexError:
+            return None
 
     def get_ir_for_initialization(self) -> list[str]:
         ir: list[str] = []
@@ -666,4 +1228,10 @@ class TypeSymbolTable:
                 ir.append(
                     f"{defined_type.ir_type} = type {defined_type.definition.ir_type}"
                 )
+
+        for fn_name in self._resolved_functions:
+            for signature in self._resolved_functions[fn_name]:
+                if signature.is_foreign:
+                    ir.append(signature.generate_declaration_ir())
+
         return ir

--- a/codegen/type_resolution.py
+++ b/codegen/type_resolution.py
@@ -28,13 +28,14 @@ from .interfaces import (
 )
 from .type_conversions import get_implicit_conversion_cost
 from .user_facing_errors import (
-    AmbiguousInitialization,
+    AmbiguousFunctionCall,
     BuiltinSourceLocation,
     DoubleReferenceError,
     ErrorWithLocationInfo,
     FailedLookupError,
     GrapheneError,
     Location,
+    MultipleTypeDefinitions,
     NonDeterminableSize,
     OverloadResolutionError,
     PatternMatchDeductionFailure,
@@ -995,8 +996,7 @@ class SymbolTable:
 
         # If there are two or more equally good candidates, then this function
         # call is ambiguous.
-        raise AmbiguousInitialization(
-            "function call",
+        raise AmbiguousFunctionCall(
             f"{fn_name}{format_arguments(fn_args)}",
             [(fn.format_for_output_to_user(), fn.loc) for _, fn in best_functions],
         )
@@ -1146,8 +1146,7 @@ class SymbolTable:
                 return resolved_candidates[0][0]
 
             specialization_str = format_specialization(specialization)
-            raise AmbiguousInitialization(
-                "type",
+            raise MultipleTypeDefinitions(
                 f"{prefix}{specialization_str}",
                 [
                     (candidate.format_for_output_to_user(True), loc)

--- a/codegen/type_resolution.py
+++ b/codegen/type_resolution.py
@@ -45,10 +45,6 @@ from .user_facing_errors import (
 )
 
 
-class GenericResolutionImpossible(ValueError):
-    pass
-
-
 def get_cost_at_pattern_match_depth(depth: int) -> int:
     # TODO: maybe this should be a list for infinite precision?
     # ATM. only 16 generic deductions/ nested levels are allowed
@@ -158,7 +154,7 @@ class GenericValueReference(CompileTimeConstant):
         return NumericLiteralConstant(specialized_value)
 
     def resolve(self) -> int:
-        raise GenericResolutionImpossible("Generic value reference")
+        assert False
 
     def get_generics_taking_part_in_pattern_match(self) -> set[GenericArgument]:
         return {self.argument}
@@ -317,8 +313,8 @@ class UnresolvedGenericType(UnresolvedType):
 
         return UnresolvedTypeWrapper(specialized_type)
 
-    def resolve(self, lookup: Callable[[str, list[SpecializationItem]], Type]) -> Type:
-        raise GenericResolutionImpossible("Generic type")
+    def resolve(self, _: Callable[[str, list[SpecializationItem]], Type]) -> Type:
+        assert False
 
     def get_generics_taking_part_in_pattern_match(self) -> set[GenericArgument]:
         return {self.argument}

--- a/codegen/user_facing_errors.py
+++ b/codegen/user_facing_errors.py
@@ -133,8 +133,10 @@ class OverloadResolutionError(GrapheneError):
     def __init__(
         self,
         fn_call: str,
-        available_overloads: list[str],
+        available_overloads_unordered: Iterable[str],
     ) -> None:
+        # Sort for consistent error messages
+        available_overloads = sorted(available_overloads_unordered)
         msg = [f"Error: overload resolution for function call '{fn_call}' failed"]
 
         # TODO need a better way to indent these.
@@ -154,8 +156,10 @@ class AmbiguousInitialization(GrapheneError):
         self,
         thing: Literal["type", "function call"],
         thing_format: str,
-        candidates: list[tuple[str, Location]],
+        candidates_unordered: Iterable[tuple[str, Location]],
     ) -> None:
+        # Sort for consistent error messages
+        candidates = sorted(candidates_unordered, key=lambda item: item[0])
         longest_candidate = max(len(candidate[0]) for candidate in candidates)
         candidates_fmt = "\n".join(
             f"     - {candidate:{longest_candidate+5}} ({loc})"

--- a/codegen/user_facing_errors.py
+++ b/codegen/user_facing_errors.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 from typing import Iterable, Literal, Optional
 
 
-@dataclass
 class SourceLocation:
     line: int
     file: str
     include_hierarchy: list[str]
+
+    def __str__(self):
+        return f"File '{self.file}', line {self.line}"
 
 
 class GrapheneError(ValueError):

--- a/codegen/user_facing_errors.py
+++ b/codegen/user_facing_errors.py
@@ -125,7 +125,8 @@ class PatternMatchDeductionFailure(GrapheneError):
 class NonDeterminableSize(GrapheneError):
     def __init__(self, type_name: str) -> None:
         super().__init__(
-            f"Error: cannot construct recursive type '{type_name}' since it has a non-determinable size"
+            f"Error: cannot construct recursive type '{type_name}' "
+            "since it has a non-determinable size"
         )
 
 
@@ -193,15 +194,6 @@ class InvalidIntSize(GrapheneError):
         super().__init__(
             f"Error: {type_name} cannot store value {actual_value}, permitted range"
             f" [{expected_lower}, {expected_upper})"
-        )
-
-
-class GenericArgumentCountError(GrapheneError):
-    def __init__(self, name: str, actual: int, expected: int) -> None:
-        arguments = "argument" if expected == 1 else "arguments"
-
-        super().__init__(
-            f"Error: generic '{name}' expects {expected} {arguments} but received {actual}"
         )
 
 
@@ -351,7 +343,8 @@ class VoidStructDeclaration(GrapheneError):
         member_type: str,
     ) -> None:
         super().__init__(
-            f"Error: struct '{struct_type}' cannot have member '{member_name}' of type '{member_type}'"
+            f"Error: struct '{struct_type}' cannot have member "
+            f"'{member_name}' of type '{member_type}'"
         )
 
 

--- a/graphene_parser.py
+++ b/graphene_parser.py
@@ -23,6 +23,8 @@ from codegen.user_facing_errors import (
     VoidVariableDeclaration,
 )
 
+UnresolvedGenericMapping = dict[str, cg.UnresolvedSpecializationItem]
+
 
 class ResolvedPath(str):
     def __new__(cls, path: Path) -> "ResolvedPath":
@@ -93,7 +95,7 @@ def parse_generic_definition(definition: Token) -> cg.GenericArgument:
 
 
 class TypeTransformer(Transformer):
-    def __init__(self, generic_args: cg.UnresolvedGenericMapping) -> None:
+    def __init__(self, generic_args: UnresolvedGenericMapping) -> None:
         super().__init__(visit_tokens=True)
         self._generic_args = generic_args
 
@@ -186,7 +188,7 @@ class TypeTransformer(Transformer):
         tree: Tree,
         generic_mapping: cg.GenericMapping,
     ) -> cg.SpecializationItem:
-        unresolved_mapping: cg.UnresolvedGenericMapping = {}
+        unresolved_mapping: UnresolvedGenericMapping = {}
         for key, item in generic_mapping.mapping.items():
             if isinstance(item, cg.Type):
                 unresolved_mapping[key.name] = cg.UnresolvedTypeWrapper(item)
@@ -204,7 +206,7 @@ class TypeTransformer(Transformer):
 
     @classmethod
     def parse(
-        cls, tree: Tree, generic_mapping: cg.UnresolvedGenericMapping
+        cls, tree: Tree, generic_mapping: UnresolvedGenericMapping
     ) -> cg.UnresolvedType:
         result = cls(generic_mapping).transform(tree)
         assert isinstance(result, cg.UnresolvedType)
@@ -235,7 +237,7 @@ class ParseTypeDefinitions(Interpreter):
             prefix.meta.start.line, self._file, tuple(self._include_hierarchy)
         )
 
-        generic_mapping: cg.UnresolvedGenericMapping = {}
+        generic_mapping: UnresolvedGenericMapping = {}
         generic_definitions: list[cg.GenericArgument] = []
 
         for generic_tree in generic_definitions_tree.children:
@@ -440,7 +442,7 @@ class ParseFunctionSignatures(Interpreter):
             tuple(self._include_hierarchy),
         )
 
-        generic_mapping: cg.UnresolvedGenericMapping = {}
+        generic_mapping: UnresolvedGenericMapping = {}
         generic_definitions: list[cg.GenericArgument] = []
 
         # One for the type and one for the actual args.

--- a/graphene_parser.py
+++ b/graphene_parser.py
@@ -1324,7 +1324,7 @@ def generate_function(
     generic_mapping: cg.GenericMapping,
 ) -> None:
     try:
-        fn = cg.Function(declaration.arg_names, signature, declaration.pack_arg_name)
+        fn = cg.Function(declaration.arg_names, signature, declaration.pack_type_name)
     except GrapheneError as e:
         assert isinstance(declaration.loc, SourceLocation)
         raise ErrorWithLineInfo(e.message, declaration.loc.line, "function declaration")

--- a/graphene_parser.py
+++ b/graphene_parser.py
@@ -313,7 +313,7 @@ class ParseFunctionSignatures(Interpreter):
         self._include_hierarchy: Optional[list[str]] = None
 
         self._program = program
-        self._function_mapping: dict[cg.FnDeclaration, Tree] = {}
+        self._function_mapping: dict[cg.FunctionDeclaration, Tree] = {}
 
     def parse_file(
         self, file_name: str, include_hierarchy: list[str], tree: Tree
@@ -328,7 +328,10 @@ class ParseFunctionSignatures(Interpreter):
         self,
     ) -> Generator[
         tuple[
-            cg.FnDeclaration, cg.FunctionSignature, cg.GenericMapping, Optional[Tree]
+            cg.FunctionDeclaration,
+            cg.FunctionSignature,
+            cg.GenericMapping,
+            Optional[Tree],
         ],
         None,
         None,
@@ -480,7 +483,7 @@ class ParseFunctionSignatures(Interpreter):
                     TypeTransformer.parse(type_tree, generic_mapping)
                 )
 
-        fn_declaration = cg.FnDeclaration.construct(
+        fn_declaration = cg.FunctionDeclaration.construct(
             fn_name,
             False,
             tuple(generic_definitions),
@@ -599,7 +602,7 @@ class ParseFunctionSignatures(Interpreter):
             unresolved_args.append(TypeTransformer.parse(type_tree, {}))
             arg_names.append(name.value)
 
-        func = cg.FnDeclaration.construct(
+        func = cg.FunctionDeclaration.construct(
             fn_name,
             foreign,
             tuple(),
@@ -1285,7 +1288,7 @@ def generate_body(
 
 def generate_function(
     program: cg.Program,
-    declaration: cg.FnDeclaration,
+    declaration: cg.FunctionDeclaration,
     signature: cg.FunctionSignature,
     body: Optional[Tree],
     generic_mapping: cg.GenericMapping,

--- a/graphene_parser.py
+++ b/graphene_parser.py
@@ -1493,7 +1493,7 @@ def generate_ir_from_source(
             print("~~~ User-facing error message ~~~")
 
         context = f", in '{exc.context}'" if exc.context else ""
-        print(f"File '{exc.loc.file}', line {exc.loc.line}{context}", file=sys.stderr)
+        print(f"{exc.loc}{context}", file=sys.stderr)
         print(f"    {exc.message}", file=sys.stderr)
 
         if exc.loc.include_hierarchy:

--- a/parser/parser.c3
+++ b/parser/parser.c3
@@ -1188,7 +1188,7 @@ function parse_function_definition_generics_definition : (cursor : Cursor&) -> G
 function parse_function_definition_args : (cursor : Cursor&) -> FunctionDefinitionArguments = {
     cursor:expect_next_skipping_ws(":");
 
-    let start_offset : isize = 0;
+    let start_offset : isize = cursor.position;
     cursor:expect_next_skipping_ws("(");
 
     // TODO: better line numbers here

--- a/tests/generic_functions/sfinae_ambiguous.c3
+++ b/tests/generic_functions/sfinae_ambiguous.c3
@@ -21,5 +21,5 @@ function main : () -> int = {
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 17, in 'function main: () -> int'
 /// Error: function call 'generic_fn()' is ambiguous. Equally good candidates are:
-/// - function generic_fn<T> : () -> EnableIf<isI32<T>>      (File '*.c3', line 7)
-/// - function generic_fn<T> : () -> int                     (File '*.c3', line 11)
+/// - function [[]T[]] generic_fn<T> : () -> EnableIf<isI32<T>>      (File '*.c3', line 7)
+/// - function [[]T[]] generic_fn<T> : () -> int                     (File '*.c3', line 11)

--- a/tests/generic_functions/sfinae_ambiguous.c3
+++ b/tests/generic_functions/sfinae_ambiguous.c3
@@ -20,7 +20,6 @@ function main : () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 17, in 'function main: () -> int'
-/// Error: overload resolution for function call 'generic_fn()' is ambiguous.
-/// Equally good candidates are
-/// - function generic_fn<i32>: () -> EnableIf<TrueType>
-/// - function generic_fn<i32>: () -> int
+/// Error: function call 'generic_fn()' is ambiguous. Equally good candidates are:
+/// - function generic_fn<T> : () -> EnableIf<isI32<T>>      (File '*.c3', line 7)
+/// - function generic_fn<T> : () -> int                     (File '*.c3', line 11)

--- a/tests/generic_types/duplicate_type_specialization.c3
+++ b/tests/generic_types/duplicate_type_specialization.c3
@@ -4,5 +4,7 @@ typedef MyType<u8> : bool
 typedef MyType<u8> : int
 
 /// @COMPILE; EXPECT ERR
-/// File *.c3', line 4, in 'typedef'
-/// Error: multiple definitions of type 'MyType<u8>'
+/// File *.c3', line 3, in 'typedef'
+/// Error: type 'MyType<u8>' is ambiguous. Equally good candidates are:
+/// - typedef MyType<u8> : bool      (File '*.c3', line 3)
+/// - typedef MyType<u8> : bool      (File '*.c3', line 4)

--- a/tests/generic_types/duplicate_type_specialization.c3
+++ b/tests/generic_types/duplicate_type_specialization.c3
@@ -5,6 +5,6 @@ typedef MyType<u8> : int
 
 /// @COMPILE; EXPECT ERR
 /// File *.c3', line 3, in 'typedef'
-/// Error: type 'MyType<u8>' is ambiguous. Equally good candidates are:
+/// Error: multiple definitions of type 'MyType<u8>':
 /// - typedef MyType<u8> : bool      (File '*.c3', line 3)
 /// - typedef MyType<u8> : bool      (File '*.c3', line 4)

--- a/tests/main_return_type/invalid.c3
+++ b/tests/main_return_type/invalid.c3
@@ -5,5 +5,5 @@ function main : () -> my_int = {
 }
 
 /// @COMPILE; EXPECT ERR
-/// File '*.c3', line 3, in 'function signature'
-/// Error: type 'typedef my_int = i64' is not a valid return type for function 'main'; expected 'int'
+/// File '*.c3', line 3, in 'function declaration'
+/// Error: type 'typedef my_int : i64' is not a valid return type for function 'main'; expected 'int'

--- a/tests/misc/ambiguous_function_call.c3
+++ b/tests/misc/ambiguous_function_call.c3
@@ -7,7 +7,6 @@ function main: () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 5, in 'function main: () -> int'
-/// Error: overload resolution for function call 'a(int, int)' is ambiguous.
-/// Equally good candidates are
-/// - function a: (i32, i64) -> int
-/// - function a: (i64, i32) -> int
+/// Error: function call 'a(int, int)' is ambiguous. Equally good candidates are:
+/// - function a : (i32, i64) -> int      (File '*.c3', line 1)
+/// - function a : (i64, i32) -> int      (File '*.c3', line 2)

--- a/tests/misc/recursive_types.c3
+++ b/tests/misc/recursive_types.c3
@@ -4,21 +4,8 @@ typedef[T] LinkedListNode1 : {
     data: T
 }
 
-typedef[T] Wrapper : {data: T}
-typedef[T] LinkedListNode2 : {
-    next: Wrapper<LinkedListNode2<T>>&,
-    data: T
-}
-
-typedef[T] LinkedListNode3 : {
-    next: Wrapper<LinkedListNode3<T>&>,
-    data: T
-}
-
 function main : () -> int = {
     let a : LinkedListNode1<int>;
-    let b : LinkedListNode2<int>;
-    let c : LinkedListNode3<int>;
     return 0;
 }
 

--- a/tests/misc/recursive_types.c3
+++ b/tests/misc/recursive_types.c3
@@ -4,8 +4,21 @@ typedef[T] LinkedListNode1 : {
     data: T
 }
 
+typedef[T] Wrapper : {data: T}
+typedef[T] LinkedListNode2 : {
+    next: Wrapper<LinkedListNode2<T>>&,
+    data: T
+}
+
+typedef[T] LinkedListNode3 : {
+    next: Wrapper<LinkedListNode3<T>&>,
+    data: T
+}
+
 function main : () -> int = {
     let a : LinkedListNode1<int>;
+    let b : LinkedListNode2<int>;
+    let c : LinkedListNode3<int>;
     return 0;
 }
 

--- a/tests/misc/recursive_types_unresolvable.c3
+++ b/tests/misc/recursive_types_unresolvable.c3
@@ -11,5 +11,5 @@ function main : () -> int = {
 }
 
 /// @COMPILE; EXPECT ERR
-/// File '*.c3', line 9, in 'function main: () -> int'
-/// Error: cannot construct recursive type 'typedef LinkedListNode<int> = {next: Ptr<LinkedListNode<int>>, data: int}' since it has a non-determinable size
+/// File '*.c3', line 3, in 'typedef'
+/// Error: cannot construct recursive type 'typedef LinkedListNode<int> : {next: Ptr<LinkedListNode<int>>, data: int}' since it has a non-determinable size

--- a/tests/misc/reference_nesting.c3
+++ b/tests/misc/reference_nesting.c3
@@ -10,5 +10,5 @@ function main: () -> int = {
 }
 
 /// @COMPILE; EXPECT ERR
-/// File '*/reference_nesting.c3', line 3, in 'function signature'
-/// Error: cannot construct reference type since 'typedef int_ref = int&' is already a reference
+/// File '*/reference_nesting.c3', line 3, in 'function declaration'
+/// Error: cannot construct reference type since 'typedef int_ref : int&' is already a reference

--- a/tests/regressions/builtin_redefinition.c3
+++ b/tests/regressions/builtin_redefinition.c3
@@ -2,4 +2,6 @@ typedef int : i8
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 1, in 'typedef'
-/// Error: multiple definitions of type 'int'
+/// Error: type 'int' is ambiguous. Equally good candidates are:
+/// - int      (builtin)
+/// - int      (File '*.c3', line 1)

--- a/tests/regressions/builtin_redefinition.c3
+++ b/tests/regressions/builtin_redefinition.c3
@@ -2,6 +2,6 @@ typedef int : i8
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 1, in 'typedef'
-/// Error: type 'int' is ambiguous. Equally good candidates are:
-/// - int      (builtin)
+/// Error: multiple definitions of type 'int':
 /// - int      (File '*.c3', line 1)
+/// - int      (builtin)

--- a/tests/regressions/error_in_return_type.c3
+++ b/tests/regressions/error_in_return_type.c3
@@ -1,5 +1,8 @@
 typedef [T] Span : {}
 
+// Hmm, the error is a bit misleading...
+// The overload resolution fails due to SFINAE not parameter count.. but this is
+// also kinda the point of SFINAE, if we fixed this `EnableIf` would break.
 function [T] foo : ()
     -> Span = {}
 
@@ -9,5 +12,7 @@ function main : () -> int = {
 }
 
 /// @COMPILE; EXPECT ERR
-/// File '*.c3', line 4, in 'function return type'
-/// Error: generic 'Span' expects 1 argument but received 0
+/// File '*.c3', line 10, in 'function main: () -> int'
+/// Error: overload resolution for function call 'foo<int>()' failed
+/// Available overloads:
+/// - function [[]T[]] foo<T> : () -> Span

--- a/tests/regressions/pattern_match_heap_array.c3
+++ b/tests/regressions/pattern_match_heap_array.c3
@@ -10,6 +10,6 @@ function main : () -> int = {
 /// File '*.c3', line 5, in 'function main: () -> int'
 /// Error: overload resolution for function call 'puts(u8[[]&[]])' failed
 /// Available overloads:
+/// - function [[]@Len[]] puts<@Len> : (u8[[]@Len[]]&) -> int
 /// - function puts : (CString) -> int
 /// - function puts : (StringView) -> int
-/// - function puts<@Len> : (u8[[]@Len[]]&) -> int

--- a/tests/regressions/pattern_match_heap_array.c3
+++ b/tests/regressions/pattern_match_heap_array.c3
@@ -10,5 +10,6 @@ function main : () -> int = {
 /// File '*.c3', line 5, in 'function main: () -> int'
 /// Error: overload resolution for function call 'puts(u8[[]&[]])' failed
 /// Available overloads:
-/// - function puts: (StringView) -> int
-/// - function puts: (CString) -> int
+/// - function puts : (CString) -> int
+/// - function puts : (StringView) -> int
+/// - function puts<@Len> : (u8[[]@Len[]]&) -> int

--- a/tests/regressions/std_redefinition.c3
+++ b/tests/regressions/std_redefinition.c3
@@ -5,6 +5,6 @@ typedef EnableIf<TrueType>: {}
 
 /// @COMPILE; EXPECT ERR
 /// File '*/std_redefinition.c3', line 4, in 'typedef'
-/// Error: type 'EnableIf<TrueType>' is ambiguous. Equally good candidates are:
+/// Error: multiple definitions of type 'EnableIf<TrueType>':
 /// - typedef EnableIf<TrueType> : {}      (File '*/std/type_traits.c3', line 3)
 /// - typedef EnableIf<TrueType> : {}      (File '*/std_redefinition.c3', line 4)

--- a/tests/regressions/std_redefinition.c3
+++ b/tests/regressions/std_redefinition.c3
@@ -1,7 +1,10 @@
 @require_once "std/type_traits.c3"
 
+// Comment so that the EnableIfs aren't on the same line
 typedef EnableIf<TrueType>: {}
 
 /// @COMPILE; EXPECT ERR
-/// File '*.c3', line 3, in 'typedef'
-/// Error: multiple definitions of type 'EnableIf<TrueType>'
+/// File '*/std_redefinition.c3', line 4, in 'typedef'
+/// Error: type 'EnableIf<TrueType>' is ambiguous. Equally good candidates are:
+/// - typedef EnableIf<TrueType> : {}      (File '*/std/type_traits.c3', line 3)
+/// - typedef EnableIf<TrueType> : {}      (File '*/std_redefinition.c3', line 4)

--- a/tests/structs/init_list_with_wrong_name.c3
+++ b/tests/structs/init_list_with_wrong_name.c3
@@ -8,4 +8,4 @@ function main: () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 4, in 'function main: () -> int'
-/// Error: initializer list of the form '{b: int}' cannot be converted to 'typedef my_struct = {a: int}'
+/// Error: initializer list of the form '{b: int}' cannot be converted to 'typedef my_struct : {a: int}'

--- a/tests/structs/initializer_list_function_call_no_overloaded.c3
+++ b/tests/structs/initializer_list_function_call_no_overloaded.c3
@@ -17,5 +17,5 @@ function main : () -> int = {
 /// File '*.c3', line 13, in 'function main: () -> int'
 /// Error: overload resolution for function call 'get_x({int})' failed
 /// Available overloads:
-/// - function get_x: (MyStruct1) -> int
-/// - function get_x: (MyStruct2) -> int
+/// - function get_x : (MyStruct1) -> int
+/// - function get_x : (MyStruct2) -> int

--- a/tests/structs/initializer_list_function_call_templated.c3
+++ b/tests/structs/initializer_list_function_call_templated.c3
@@ -10,4 +10,4 @@ function main : () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 8, in 'function main: () -> int'
-/// Error: cannot deduce the destination type for initializer list '{int, int}' without a strongly typed context
+/// Error: cannot deduce generic type 'T' in function 'get_x', manual specialization is required

--- a/tests/void/arguments.c3
+++ b/tests/void/arguments.c3
@@ -1,5 +1,5 @@
 foreign foo : (x: void) -> void
 
 /// @COMPILE; EXPECT ERR
-/// File '*.c3', line 1, in 'foreign signature'
+/// File '*.c3', line 1, in 'function declaration'
 /// Error: argument 'x' cannot have type 'void'

--- a/tests/void/heap_array.c3
+++ b/tests/void/heap_array.c3
@@ -9,4 +9,4 @@ function main : () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'typedef'
-/// Error: array 'my_void[[]&[]]' cannot operate on scalar 'typedef my_void = void'
+/// Error: array 'my_void[[]&[]]' cannot operate on scalar 'typedef my_void : void'

--- a/tests/void/stack_array.c3
+++ b/tests/void/stack_array.c3
@@ -9,4 +9,4 @@ function main : () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'typedef'
-/// Error: array 'my_void[[]6[]]' cannot operate on scalar 'typedef my_void = void'
+/// Error: array 'my_void[[]6[]]' cannot operate on scalar 'typedef my_void : void'

--- a/tests/void/structs.c3
+++ b/tests/void/structs.c3
@@ -9,4 +9,4 @@ function main : () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'typedef'
-/// Error: struct '{a: int, b: my_void}' cannot have member 'b' of type 'typedef my_void = void'
+/// Error: struct '{a: int, b: my_void}' cannot have member 'b' of type 'typedef my_void : void'


### PR DESCRIPTION
I started writing this so that the LSP could dynamically load/ unload entire translation units worth of symbols but in the refactor it became convenient to make a number of related improvements/ simplifications.

- We no longer differentiate between specialized/ generic functions/ typedefs.
- We now handle function and type resolution in the same place with the same algorithms.

This has the advantage that: `decltype` is now possible, partial specializations just need to be turned on, and error messages are improved (we can finally display generic functions when overload resolution fails!!)

I have formalized function specialization in the following way:
```
Specializes and resolves the function corresponding to the correct definition
There are two types of function definition:
  1) function [T] fn : ...            (pure generic)
  2a) function [T] fn<Thing<T>> : ... (pattern match a)
  2b) function [T] fn : (a : T) ...   (pattern match b)

The first (pure generic) is syntax sugar for the following:
    function [T] fn  ==> function [T] fn<T>

A function may deduce its specialization based on its arguments. For now, either the full specialization must be given or none at all -- TODO: relax this requirement

We choose which function gets priority based on the following criteria:
  1) When initialized the signature MUST not create a substitution failure
  2) All parameter implicit conversions MUST succeed
  3) Minimize the number of top level generic deductions
  4) Minimize the number of 2nd level generic deductions
  N) Minimize the number of N level generic deductions
  N+1) Minimize the cost of implicit conversion
```

I also have formalized type specialization (compatible but more powerful than our previous definition):
```
Specializes and resolves the type corresponding to the correct typedef
There are two types of typedef:
  1) typedef [T] MyType : ...            (pure generic)
  2) typedef [T] MyType<Thing<T>> : ...  (pattern match)

The first (pure generic) is syntax sugar for the following:
    typedef [U, V] MyType  ==> typedef [U, V] MyType<U, V>

We choose which typedef gets priority based on the following criteria:
  1) The specialization argument count MUST match
  2) When initialized the type MUST not create a substitution failure
  3) Minimize the number of top level generic deductions
  4) Minimize the number of 2nd level generic deductions
  N) Minimize the number of N level generic deductions
```