### PR TITLE
Add mutable reference syntax to parser

### DIFF
--- a/demo.c3
+++ b/demo.c3
@@ -136,7 +136,7 @@ function[@Len, Ts...] printf: (format: u8[@Len]&, vals: Ts...) -> void = {
     let iov: iovec[32];
 
     let fixme: iovec[&] = &iov;
-    const len: int = printf_impl(&allocator, &format, 0, &fixme, 0, vals...);
+    let len: int = printf_impl(&allocator, &format, 0, &fixme, 0, vals...);
     sys_writev(1, &fixme, len);
 }
 

--- a/src/glang/codegen/builtin_types.py
+++ b/src/glang/codegen/builtin_types.py
@@ -16,7 +16,7 @@ from .user_facing_errors import (
 
 
 class PlaceholderDefinition(TypeDefinition):
-    def replace_with(self, other: TypeDefinition) -> bool:
+    def replace_with(self, other: TypeDefinition) -> None:
         # This abomination exists so that we can substitute a placeholder
         #  definition using `NamedType.update_with_finalized_alias()` even after
         #  calling `Type.convert_to_reference()` (which makes a shallow copy).
@@ -89,11 +89,10 @@ class NamedType(Type):
         return f"{self.name}{specialization}"
 
     def format_for_output_to_user(self, full=False) -> str:
-        reference_suffix = (
-            "&"
-            if self.is_reference and not self.definition.is_always_a_reference
-            else ""
-        )
+        if self.definition.is_always_a_reference:
+            reference_suffix = "" if self.is_reference else "unborrowed"
+        else:
+            reference_suffix = "&" if self.is_reference else ""
 
         if not full:
             return self.get_name() + reference_suffix
@@ -144,11 +143,11 @@ class AnonymousType(Type):
         super().__init__(definition, definition.is_always_a_reference)
 
     def format_for_output_to_user(self, full=False) -> str:
-        reference_suffix = (
-            "&"
-            if self.is_reference and not self.definition.is_always_a_reference
-            else ""
-        )
+        if self.definition.is_always_a_reference:
+            reference_suffix = "" if self.is_reference else " (unborrowed)"
+        else:
+            reference_suffix = "&" if self.is_reference else ""
+
         return self.definition.format_for_output_to_user() + reference_suffix
 
     @property

--- a/src/glang/codegen/generatable.py
+++ b/src/glang/codegen/generatable.py
@@ -4,6 +4,7 @@ from .builtin_types import BoolType, CharArrayDefinition, VoidType
 from .interfaces import Generatable, Type, TypedExpression, Variable
 from .type_conversions import assert_is_implicitly_convertible, do_implicit_conversion
 from .user_facing_errors import (
+    AssignmentToBorrowedReference,
     AssignmentToNonPointerError,
     FailedLookupError,
     OperandError,
@@ -416,10 +417,15 @@ class Assignment(Generatable):
                 dst.underlying_type.format_for_output_to_user()
             )
 
+        if dst.underlying_type.is_reference:
+            raise AssignmentToBorrowedReference(
+                dst.underlying_type.format_for_output_to_user()
+            )
+
         self._dst = dst
         self._src = src
 
-        self._target_type = dst.underlying_type.convert_to_value_type()
+        self._target_type = dst.underlying_type
         assert_is_implicitly_convertible(self._src, self._target_type, "assignment")
 
     def generate_ir(self, reg_gen: Iterator[int]) -> list[str]:

--- a/src/glang/codegen/user_facing_errors.py
+++ b/src/glang/codegen/user_facing_errors.py
@@ -242,6 +242,14 @@ class AssignmentToNonPointerError(GrapheneError):
         )
 
 
+class AssignmentToBorrowedReference(GrapheneError):
+    def __init__(self, type_name: str) -> None:
+        super().__init__(
+            f"Error: cannot assign to borrowed reference type '{type_name}'. "
+            "Please do not manually borrow before an assignment."
+        )
+
+
 class ArrayDimensionError(GrapheneError):
     def __init__(self, array_type: str) -> None:
         super().__init__(

--- a/src/glang/graphene_parser.py
+++ b/src/glang/graphene_parser.py
@@ -722,7 +722,7 @@ def generate_variable_declaration(
             "variable", node.variable, var_type.format_for_output_to_user()
         )
 
-    var = cg.StackVariable(node.variable, var_type, node.is_const, rhs is not None)
+    var = cg.StackVariable(node.variable, var_type, not node.is_mut, rhs is not None)
     scope.add_variable(var)
 
     if rhs is None:

--- a/src/glang/graphene_parser.py
+++ b/src/glang/graphene_parser.py
@@ -722,7 +722,7 @@ def generate_variable_declaration(
             "variable", node.variable, var_type.format_for_output_to_user()
         )
 
-    var = cg.StackVariable(node.variable, var_type, not node.is_mut, rhs is not None)
+    var = cg.StackVariable(node.variable, var_type, False, rhs is not None)
     scope.add_variable(var)
 
     if rhs is None:

--- a/src/glang/graphene_parser.py
+++ b/src/glang/graphene_parser.py
@@ -636,7 +636,10 @@ class ExpressionParser(lp.Interpreter):
 
     def Borrow(self, node: lp.Borrow) -> FlattenedExpression:
         lhs = self.parse_expr(node.expression)
-        return lhs.add_parent(cg.BorrowExpression(lhs.expression(), node.is_const))
+        # TODO: make this const-correct
+        # I've temporarily disabled this so we can parse the parser as it
+        #  transitions to using the new syntax
+        return lhs.add_parent(cg.BorrowExpression(lhs.expression(), False))
 
     def UnnamedInitializerList(
         self, node: lp.UnnamedInitializerList

--- a/src/glang/lib/std/aarch64_linux/syscalls.c3
+++ b/src/glang/lib/std/aarch64_linux/syscalls.c3
@@ -11,18 +11,18 @@ foreign _syscall_4 : (a: i64, b: i64, c: i64, d: i64, syscall_number: i32) -> i6
 foreign _syscall_6 : (a: i64, b: i64, c: i64, d: i64, e: i64, f: i64, syscall_number: i32) -> i64
 
 function sys_read : (fd: int, buffer: u8[&], count: isize) -> isize = {
-    const buffer_addr : iptr = __builtin_ptr_to_int(buffer);
+    let buffer_addr : iptr = __builtin_ptr_to_int(buffer);
     return _syscall_3(fd, buffer_addr, count, /* read */ 63);
 }
 
 function sys_write : (fd: int, buffer: u8[&], count: isize) -> isize = {
-    const buffer_addr : iptr = __builtin_ptr_to_int(buffer);
+    let buffer_addr : iptr = __builtin_ptr_to_int(buffer);
     return _syscall_3(fd, buffer_addr, count, /* write */ 64);
 }
 
 function sys_openat : (fd: int, filename: u8[&], flags: u32, mode: u32) -> int = {
-    const filename_addr : iptr = __builtin_ptr_to_int(filename);
-    const result : i64 = _syscall_4(fd, filename_addr, as_arithmetic(flags),
+    let filename_addr : iptr = __builtin_ptr_to_int(filename);
+    let result : i64 = _syscall_4(fd, filename_addr, as_arithmetic(flags),
                                     as_arithmetic(mode), /* openat */ 56);
     return Narrow<int>(result);
 }
@@ -38,7 +38,7 @@ function sys_close : (fd : int) -> int = {
 }
 
 function sys_writev : (fd: int, iov: iovec[&], iovcnt: int) -> isize = {
-    const iov_addr : iptr = __builtin_ptr_to_int(iov);
+    let iov_addr : iptr = __builtin_ptr_to_int(iov);
 
     return _syscall_3(fd, iov_addr, iovcnt, /* writev */ 66);
 }

--- a/src/glang/lib/std/algorithms.c3
+++ b/src/glang/lib/std/algorithms.c3
@@ -43,7 +43,7 @@ function [T] bisect_left : (span : Span<T>, elem : T) -> isize = {
 
     while lo < hi {
         // Avoid overflows when averaging.
-        const mid : isize = lo + (hi - lo) / 2;
+        let mid : isize = lo + (hi - lo) / 2;
 
         if span.data[mid] < elem {
             lo = mid + 1;

--- a/src/glang/lib/std/arm_linux/syscalls.c3
+++ b/src/glang/lib/std/arm_linux/syscalls.c3
@@ -6,7 +6,7 @@ function sys_exit : (code : int) -> void = {
 }
 
 function sys_write : (fd: int, buffer: u8[&], count: isize) -> isize = {
-    const buffer_addr : iptr = __builtin_ptr_to_int(buffer);
+    let buffer_addr : iptr = __builtin_ptr_to_int(buffer);
 
     return _syscall_3(fd, buffer_addr, count, /* write */ 4);
 }

--- a/src/glang/lib/std/io.c3
+++ b/src/glang/lib/std/io.c3
@@ -56,7 +56,7 @@ function consume_length : (io : BufferedFile&, length : isize) -> void = {
 
 function open : (file_path: CString, mode: u32) -> UnbufferedFile = {
     // BUG: try removing the '&' here... the error message is nonsense
-    const fd : int = sys_open(&file_path.data, mode, 0x00);
+    let fd : int = sys_open(&file_path.data, mode, 0x00);
     runtime_assert(fd > 0);
     return {fd};
 }
@@ -95,7 +95,7 @@ function puts : (str : StringView) -> int = {
         {"\n", 1}
     };
 
-    const ret : isize = sys_writev(/* stdout */ 1, &iov, 2);
+    let ret : isize = sys_writev(/* stdout */ 1, &iov, 2);
 
     if ret != -1 {
         // Upon successful completion, puts() shall return a non-negative

--- a/src/glang/lib/std/json.c3
+++ b/src/glang/lib/std/json.c3
@@ -67,7 +67,7 @@ function is_json_whitespace : (token : u8) -> bool = {
 }
 
 function eat : (cursor : Cursor&, token : u8) -> bool = {
-    // TODO this should be const (can't use with has_value() right now).
+    // TODO this should be let (can't use with has_value() right now).
     let next_char : Optional<u8> = cursor:peak();
 
     if next_char:has_value() and next_char:data() == token {
@@ -205,7 +205,7 @@ function parse_value : (cursor : Cursor&) -> Optional<JSON_Node> = {
         return make_optional<JSON_Node>();
     }
 
-    const next_token : u8 = optional_next_token:data();
+    let next_token : u8 = optional_next_token:data();
 
     if next_token == char("\"") {
         return cursor:parse_string();
@@ -238,7 +238,7 @@ function parse_value : (cursor : Cursor&) -> Optional<JSON_Node> = {
 function parse_element : (cursor : Cursor&) -> Optional<JSON_Node> = {
     cursor:eat_whitespace();
 
-    const value_node : Optional<JSON_Node> = cursor:parse_value();
+    let value_node : Optional<JSON_Node> = cursor:parse_value();
 
     cursor:eat_whitespace();
 
@@ -273,7 +273,7 @@ function parse_string : (cursor : Cursor&) -> Optional<JSON_Node> = {
 
         let char_opt : Optional<u8> = cursor:next();
         runtime_assert(char_opt:has_value());
-        const char : u8 = char_opt:data();
+        let char : u8 = char_opt:data();
 
         // Reject strings with control characters.
         if is_control_character(char) {
@@ -323,7 +323,7 @@ function is_digit_helper : (token : Optional<u8>) -> bool = {
 }
 
 function parse_number : (cursor : Cursor&) -> Optional<JSON_Node> = {
-    const start_pos : isize = cursor:position();
+    let start_pos : isize = cursor:position();
     let is_valid : bool = false;
 
     // This is optional, so discard the return value.
@@ -342,7 +342,7 @@ function parse_number : (cursor : Cursor&) -> Optional<JSON_Node> = {
     // TODO parse fraction.
     // TODO parse exponent.
 
-    const end_pos : isize = cursor:position();
+    let end_pos : isize = cursor:position();
 
     if !is_valid {
         return make_optional<JSON_Node>();

--- a/src/glang/lib/std/string.c3
+++ b/src/glang/lib/std/string.c3
@@ -39,7 +39,7 @@ typedef CString : { data : u8[&] }
 
 function length : (str: CString&) -> isize = {
     let len : isize = 0;
-    const null : u8[1]& = "\0"; // TODO: add char
+    let null : u8[1]& = "\0"; // TODO: add char
 
     while str.data[len] != null[0] {
         len = len + 1;

--- a/src/glang/lib/std/x86_64_linux/syscalls.c3
+++ b/src/glang/lib/std/x86_64_linux/syscalls.c3
@@ -10,18 +10,18 @@ foreign _syscall_3 : (a: i64, b: i64, c: i64, syscall_number: i64) -> i64
 foreign _syscall_6 : (a: i64, b: i64, c: i64, d: i64, e: i64, f: i64, syscall_number: i64) -> i64
 
 function sys_read : (fd: int, buffer: u8[&], count: isize) -> isize = {
-    const buffer_addr : iptr = __builtin_ptr_to_int(buffer);
+    let buffer_addr : iptr = __builtin_ptr_to_int(buffer);
     return _syscall_3(fd, buffer_addr, count, /* read */ 0);
 }
 
 function sys_write : (fd: int, buffer: u8[&], count: isize) -> isize = {
-    const buffer_addr : iptr = __builtin_ptr_to_int(buffer);
+    let buffer_addr : iptr = __builtin_ptr_to_int(buffer);
     return _syscall_3(fd, buffer_addr, count, /* write */ 1);
 }
 
 function sys_open : (filename: u8[&], flags: u32, mode: u32) -> int = {
-    const filename_addr : iptr = __builtin_ptr_to_int(filename);
-    const result : i64 =  _syscall_3(filename_addr, as_arithmetic(flags),
+    let filename_addr : iptr = __builtin_ptr_to_int(filename);
+    let result : i64 =  _syscall_3(filename_addr, as_arithmetic(flags),
                                      as_arithmetic(mode), /* open */ 2);
     return Narrow<int>(result);
 }
@@ -31,7 +31,7 @@ function sys_close : (fd : int) -> int = {
 }
 
 function sys_writev : (fd: int, iov: iovec[&], iovcnt: int) -> isize = {
-    const iov_addr : iptr = __builtin_ptr_to_int(iov);
+    let iov_addr : iptr = __builtin_ptr_to_int(iov);
     return _syscall_3(fd, iov_addr, iovcnt, /* writev */ 20);
 }
 
@@ -52,7 +52,7 @@ function sys_mmap : (
 }
 
 function sys_munmap : (addr: isize, length : isize) -> int = {
-    const result : i64 = _syscall_2(addr, length, /* munmap */ 11);
+    let result : i64 = _syscall_2(addr, length, /* munmap */ 11);
     return Narrow<int>(result);
 }
 

--- a/src/glang/parser/lexer_parser.py
+++ b/src/glang/parser/lexer_parser.py
@@ -66,7 +66,7 @@ class ArrayType(Type):
 
 @dataclass
 class HeapArrayType(ArrayType):
-    is_const: bool
+    is_mut: bool
 
 
 @dataclass
@@ -77,7 +77,7 @@ class StackArrayType(ArrayType):
 @dataclass
 class ReferenceType(Type):
     value_type: Type
-    is_const: bool
+    is_mut: bool
 
 
 @dataclass
@@ -213,7 +213,7 @@ class Assignment(LineOfCode):
 
 @dataclass
 class VariableDeclaration(LineOfCode):
-    is_const: bool
+    is_mut: bool
     variable: str
     type_: Type
     expression: Optional[Expression]
@@ -241,7 +241,7 @@ class LogicalOperatorUse(Expression):
 
 @dataclass
 class Borrow(Expression):
-    is_const: bool
+    is_mut: bool
     expression: Expression
 
 

--- a/src/glang/parser/lexer_parser.py
+++ b/src/glang/parser/lexer_parser.py
@@ -66,7 +66,7 @@ class ArrayType(Type):
 
 @dataclass
 class HeapArrayType(ArrayType):
-    pass
+    is_const : bool
 
 
 @dataclass
@@ -77,6 +77,7 @@ class StackArrayType(ArrayType):
 @dataclass
 class ReferenceType(Type):
     value_type: Type
+    is_const : bool
 
 
 @dataclass

--- a/src/glang/parser/lexer_parser.py
+++ b/src/glang/parser/lexer_parser.py
@@ -66,7 +66,7 @@ class ArrayType(Type):
 
 @dataclass
 class HeapArrayType(ArrayType):
-    is_const : bool
+    is_const: bool
 
 
 @dataclass
@@ -77,7 +77,7 @@ class StackArrayType(ArrayType):
 @dataclass
 class ReferenceType(Type):
     value_type: Type
-    is_const : bool
+    is_const: bool
 
 
 @dataclass

--- a/src/glang/parser/parser.c3
+++ b/src/glang/parser/parser.c3
@@ -620,7 +620,7 @@ function parse_array_type : (cursor : Cursor&, prefix : Type) -> Type = {
 
     let meta : Meta = {prefix.meta.start_offset, cursor.position};
     let array : ArrayType& = &cursor.allocator:allocate<ArrayType>();
-    array = {prefix, sizes, is_heap_array, !is_mutable, meta};
+    array = {prefix, sizes, is_heap_array, is_mutable, meta};
 
     let result_type : Type = {1, ref_to_addr(&array), meta};
     if cursor:is_next("[") {
@@ -647,7 +647,7 @@ function parse_type : (cursor : Cursor&) -> Type = {
     if cursor:try_skip_next("&") {
         let ref_type : RefType& = &cursor.allocator:allocate<RefType>();
         let meta : Meta = meta(prefix.meta.start_offset, cursor:skip_ws_return_offset());
-        ref_type = {prefix, true, meta};
+        ref_type = {prefix, false, meta};
         return {2, ref_to_addr(&ref_type), meta};
     }
 
@@ -655,7 +655,7 @@ function parse_type : (cursor : Cursor&) -> Type = {
         cursor:expect_next("&");
         let ref_type : RefType& = &cursor.allocator:allocate<RefType>();
         let meta : Meta = meta(prefix.meta.start_offset, cursor:skip_ws_return_offset());
-        ref_type = {prefix, false, meta};
+        ref_type = {prefix, true, meta};
         return {2, ref_to_addr(&ref_type), meta};
     }
 
@@ -954,11 +954,11 @@ function parse_maybe_unary_or_borrow_expression : (cursor : Cursor&) -> Expressi
     }
 
     if cursor:try_skip_next("&") {
-        let is_const : bool = !cursor:try_skip_next_and_surrounding_white_space("mut");
+        let is_mut : bool = cursor:try_skip_next_and_surrounding_white_space("mut");
         let rhs : Expression = cursor:parse_maybe_unary_or_borrow_expression();
 
         let borrow : Borrow& = &cursor.allocator:allocate<Borrow>();
-        borrow = {is_const, rhs, meta(start_offset, borrow.meta.end_offset)};
+        borrow = {is_mut, rhs, meta(start_offset, borrow.meta.end_offset)};
         return {11, ref_to_addr(&borrow), borrow.meta};
     }
 
@@ -1124,7 +1124,7 @@ function parse_mut_declaration : (cursor : Cursor&) -> VariableDeclaration = {
     }
 
     cursor:expect_next(";");
-    return {false, variable_name, type, expression_opt, meta(start_offset, cursor:skip_ws_return_offset())};
+    return {true, variable_name, type, expression_opt, meta(start_offset, cursor:skip_ws_return_offset())};
 }
 
 function parse_return : (cursor : Cursor&) -> Return = {

--- a/src/glang/parser/parser.c3
+++ b/src/glang/parser/parser.c3
@@ -591,7 +591,16 @@ function parse_type_prefix : (cursor : Cursor&) -> Type = {
 function parse_array_type : (cursor : Cursor&, prefix : Type) -> Type = {
     runtime_assert(cursor:try_skip_next_and_surrounding_white_space("["));
 
-    let is_heap_array : bool = cursor:try_skip_next_and_surrounding_white_space("&");
+    let is_mutable : bool = cursor:try_skip_next_and_surrounding_white_space("mut");
+
+    let is_heap_array : bool;
+    if is_mutable {
+        // We've already seen a `mut` token, this MUST be a heap array
+        is_heap_array = true;
+        cursor:expect_next_skipping_ws("&");
+    } else {
+        is_heap_array = cursor:try_skip_next_and_surrounding_white_space("&");
+    }
 
     let sizes : Vector<CompileTimeConstant>;
     // TODO: this would be cleaner with a short-circuit `and`
@@ -611,7 +620,7 @@ function parse_array_type : (cursor : Cursor&, prefix : Type) -> Type = {
 
     let meta : Meta = {prefix.meta.start_offset, cursor.position};
     let array : ArrayType& = &cursor.allocator:allocate<ArrayType>();
-    array = {prefix, sizes, is_heap_array, meta};
+    array = {prefix, sizes, is_heap_array, !is_mutable, meta};
 
     let result_type : Type = {1, ref_to_addr(&array), meta};
     if cursor:is_next("[") {
@@ -638,7 +647,15 @@ function parse_type : (cursor : Cursor&) -> Type = {
     if cursor:try_skip_next("&") {
         let ref_type : RefType& = &cursor.allocator:allocate<RefType>();
         let meta : Meta = meta(prefix.meta.start_offset, cursor:skip_ws_return_offset());
-        ref_type = {prefix, meta};
+        ref_type = {prefix, true, meta};
+        return {2, ref_to_addr(&ref_type), meta};
+    }
+
+    if cursor:try_skip_next_and_surrounding_white_space("mut") {
+        cursor:expect_next("&");
+        let ref_type : RefType& = &cursor.allocator:allocate<RefType>();
+        let meta : Meta = meta(prefix.meta.start_offset, cursor:skip_ws_return_offset());
+        ref_type = {prefix, false, meta};
         return {2, ref_to_addr(&ref_type), meta};
     }
 
@@ -937,7 +954,7 @@ function parse_maybe_unary_or_borrow_expression : (cursor : Cursor&) -> Expressi
     }
 
     if cursor:try_skip_next("&") {
-        let is_const : bool = cursor:try_skip_next_and_surrounding_white_space("const");
+        let is_const : bool = !cursor:try_skip_next_and_surrounding_white_space("mut");
         let rhs : Expression = cursor:parse_maybe_unary_or_borrow_expression();
 
         let borrow : Borrow& = &cursor.allocator:allocate<Borrow>();
@@ -1066,9 +1083,9 @@ function parse_for : (cursor : Cursor&) -> For = {
     return {variable_name, expression, scope, meta(start_offset, scope.meta.end_offset)};
 }
 
-function parse_const_declaration : (cursor : Cursor&) -> VariableDeclaration = {
+function parse_let_declaration : (cursor : Cursor&) -> VariableDeclaration = {
     let start_offset : isize = cursor.position;
-    runtime_assert(cursor:try_skip_next_and_surrounding_white_space("const"));
+    runtime_assert(cursor:try_skip_next_and_surrounding_white_space("let"));
 
     let variable_name : ProgramSlice = cursor:get_next_ascii_only_identifier();
 
@@ -1077,7 +1094,7 @@ function parse_const_declaration : (cursor : Cursor&) -> VariableDeclaration = {
     let type : Type = cursor:parse_type();
 
     if !cursor:try_skip_next_and_surrounding_white_space("=") {
-        syntax_error(&cursor, sv("a constant cannot be declared uninitialized"));
+        syntax_error(&cursor, sv("a value cannot be declared uninitialized"));
     }
 
     let expression : Expression = cursor:parse_expression();
@@ -1086,9 +1103,9 @@ function parse_const_declaration : (cursor : Cursor&) -> VariableDeclaration = {
     return {true, variable_name, type, make_optional(expression), meta(start_offset, cursor:skip_ws_return_offset())};
 }
 
-function parse_let_declaration : (cursor : Cursor&) -> VariableDeclaration = {
+function parse_mut_declaration : (cursor : Cursor&) -> VariableDeclaration = {
     let start_offset : isize = cursor.position;
-    runtime_assert(cursor:try_skip_next_and_surrounding_white_space("let"));
+    runtime_assert(cursor:try_skip_next_and_surrounding_white_space("mut"));
 
     let variable_name : ProgramSlice = cursor:get_next_ascii_only_identifier();
 
@@ -1153,9 +1170,9 @@ function parse_line : (cursor : Cursor&) -> Line = {
         pointer = cursor:parse_let_declaration();
         return {7, ref_to_addr(&pointer), pointer.meta};
     }
-    if cursor:is_next("const") {
+    if cursor:is_next("mut") {
         let pointer : VariableDeclaration& = &cursor.allocator:allocate<VariableDeclaration>();
-        pointer = cursor:parse_const_declaration();
+        pointer = cursor:parse_mut_declaration();
         return {7, ref_to_addr(&pointer), pointer.meta};
     }
 

--- a/src/glang/parser/parser.c3
+++ b/src/glang/parser/parser.c3
@@ -1087,6 +1087,9 @@ function parse_let_declaration : (cursor : Cursor&) -> VariableDeclaration = {
     let start_offset : isize = cursor.position;
     runtime_assert(cursor:try_skip_next_and_surrounding_white_space("let"));
 
+    // AHHH, the bootstrap is hard here, for now `let` and `mut` are the same thing
+    return cursor:parse_mut_declaration();
+
     let variable_name : ProgramSlice = cursor:get_next_ascii_only_identifier();
 
     cursor:expect_next_skipping_ws(":");
@@ -1100,12 +1103,12 @@ function parse_let_declaration : (cursor : Cursor&) -> VariableDeclaration = {
     let expression : Expression = cursor:parse_expression();
 
     cursor:expect_next(";");
-    return {true, variable_name, type, make_optional(expression), meta(start_offset, cursor:skip_ws_return_offset())};
+    return {false, variable_name, type, make_optional(expression), meta(start_offset, cursor:skip_ws_return_offset())};
 }
 
 function parse_mut_declaration : (cursor : Cursor&) -> VariableDeclaration = {
     let start_offset : isize = cursor.position;
-    runtime_assert(cursor:try_skip_next_and_surrounding_white_space("mut"));
+    /* runtime_assert(*/ cursor:try_skip_next_and_surrounding_white_space("mut");
 
     let variable_name : ProgramSlice = cursor:get_next_ascii_only_identifier();
 

--- a/src/glang/parser/parser.c3
+++ b/src/glang/parser/parser.c3
@@ -1087,28 +1087,28 @@ function parse_let_declaration : (cursor : Cursor&) -> VariableDeclaration = {
     let start_offset : isize = cursor.position;
     runtime_assert(cursor:try_skip_next_and_surrounding_white_space("let"));
 
-    // AHHH, the bootstrap is hard here, for now `let` and `mut` are the same thing
-    return cursor:parse_mut_declaration();
-
     let variable_name : ProgramSlice = cursor:get_next_ascii_only_identifier();
 
     cursor:expect_next_skipping_ws(":");
 
     let type : Type = cursor:parse_type();
 
-    if !cursor:try_skip_next_and_surrounding_white_space("=") {
-        syntax_error(&cursor, sv("a value cannot be declared uninitialized"));
+    // AHHH, the bootstrap is hard here, for now don't check that `let` has a body
+    let expression_opt : Optional<Expression>;
+    if cursor:try_skip_next_and_surrounding_white_space("=") {
+        expression_opt = make_optional(cursor:parse_expression());
+    } else {
+        //syntax_error(&cursor, sv("a value cannot be declared uninitialized"));
+        expression_opt = make_optional<Expression>();
     }
 
-    let expression : Expression = cursor:parse_expression();
-
     cursor:expect_next(";");
-    return {false, variable_name, type, make_optional(expression), meta(start_offset, cursor:skip_ws_return_offset())};
+    return {false, variable_name, type, expression_opt, meta(start_offset, cursor:skip_ws_return_offset())};
 }
 
 function parse_mut_declaration : (cursor : Cursor&) -> VariableDeclaration = {
     let start_offset : isize = cursor.position;
-    /* runtime_assert(*/ cursor:try_skip_next_and_surrounding_white_space("mut");
+    runtime_assert(cursor:try_skip_next_and_surrounding_white_space("mut"));
 
     let variable_name : ProgramSlice = cursor:get_next_ascii_only_identifier();
 

--- a/src/glang/parser/syntax_tree.c3
+++ b/src/glang/parser/syntax_tree.c3
@@ -28,8 +28,8 @@ typedef CompileTimeConstant : {
 }
 
 typedef FunctionType : { /* TODO */ }
-typedef ArrayType : { base_type : Type, size : Vector<CompileTimeConstant>, is_heap_array : bool, meta : Meta}
-typedef RefType : { type : Type, meta : Meta }
+typedef ArrayType : { base_type : Type, size : Vector<CompileTimeConstant>, is_heap_array : bool, is_const : bool, meta : Meta}
+typedef RefType : { type : Type, is_const : bool, meta : Meta }
 typedef NamedType : { name : ProgramSlice, specialization : Vector<Specialization>, meta : Meta}
 typedef StructType : { members : Vector<TypedMember>, meta : Meta}
 typedef PackType : { type : Type, meta : Meta }
@@ -425,16 +425,14 @@ function write_json_value : (stream : JSON_Stream&, fn : FunctionType&) -> void 
 }
 
 function write_json_value : (stream : JSON_Stream&, array : ArrayType&) -> void = {
-    let name : StringView;
-    if array.is_heap_array {
-        name = sv("HeapArrayType");
-    } else {
-        name = sv("StackArrayType");
-    }
-
     let object : JSON_Object = stream:new_object();
+    if array.is_heap_array {
+        object:add_meta("HeapArrayType", array.meta);
+        object:add("is_const", array.is_const);
+    } else {
+        object:add_meta("StackArrayType", array.meta);
+    }
     object
-        :add_meta(name, array.meta)
         :add("base_type", array.base_type)
         :add("size", array.size)
         :end();
@@ -445,6 +443,7 @@ function write_json_value : (stream : JSON_Stream&, node : RefType&) -> void = {
     object
         :add_meta("ReferenceType", node.meta)
         :add("value_type", node.type)
+        :add("is_const", node.is_const)
         :end();
 }
 

--- a/src/glang/parser/syntax_tree.c3
+++ b/src/glang/parser/syntax_tree.c3
@@ -28,8 +28,8 @@ typedef CompileTimeConstant : {
 }
 
 typedef FunctionType : { /* TODO */ }
-typedef ArrayType : { base_type : Type, size : Vector<CompileTimeConstant>, is_heap_array : bool, is_const : bool, meta : Meta}
-typedef RefType : { type : Type, is_const : bool, meta : Meta }
+typedef ArrayType : { base_type : Type, size : Vector<CompileTimeConstant>, is_heap_array : bool, is_mut : bool, meta : Meta}
+typedef RefType : { type : Type, is_mut : bool, meta : Meta }
 typedef NamedType : { name : ProgramSlice, specialization : Vector<Specialization>, meta : Meta}
 typedef StructType : { members : Vector<TypedMember>, meta : Meta}
 typedef PackType : { type : Type, meta : Meta }
@@ -123,7 +123,7 @@ typedef Assignment : {
 }
 
 typedef VariableDeclaration : {
-    is_const : bool,
+    is_mut : bool,
     variable : ProgramSlice,
     type : Type,
     expression : Optional<Expression>,
@@ -170,7 +170,7 @@ typedef LogicalOperator : {
 }
 
 typedef Borrow : {
-    is_const : bool,
+    is_mut : bool,
     expression : Expression,
     meta : Meta,
 }
@@ -428,7 +428,7 @@ function write_json_value : (stream : JSON_Stream&, array : ArrayType&) -> void 
     let object : JSON_Object = stream:new_object();
     if array.is_heap_array {
         object:add_meta("HeapArrayType", array.meta);
-        object:add("is_const", array.is_const);
+        object:add("is_mut", array.is_mut);
     } else {
         object:add_meta("StackArrayType", array.meta);
     }
@@ -443,7 +443,7 @@ function write_json_value : (stream : JSON_Stream&, node : RefType&) -> void = {
     object
         :add_meta("ReferenceType", node.meta)
         :add("value_type", node.type)
-        :add("is_const", node.is_const)
+        :add("is_mut", node.is_mut)
         :end();
 }
 
@@ -687,7 +687,7 @@ function write_json_value : (stream : JSON_Stream&, node : VariableDeclaration&)
     let object : JSON_Object = stream:new_object();
     object
         :add_meta("VariableDeclaration", node.meta)
-        :add("is_const", node.is_const)
+        :add("is_mut", node.is_mut)
         :add("variable", node.variable)
         :add("type_", node.type)
         :add("expression", node.expression)
@@ -791,7 +791,7 @@ function write_json_value : (stream : JSON_Stream&, node : Borrow&) -> void = {
     let object : JSON_Object = stream:new_object();
     object
         :add_meta("Borrow", node.meta)
-        :add("is_const", node.is_const)
+        :add("is_mut", node.is_mut)
         :add("expression", node.expression)
         :end();
 }

--- a/src/glang/parser/syntax_tree.c3
+++ b/src/glang/parser/syntax_tree.c3
@@ -320,7 +320,7 @@ function [T] write_json_value : (stream : JSON_Stream&, opt : Optional<T>&) -> v
     if opt:has_value() {
         stream:write_json_value(&opt:data());
     } else {
-        let null : Null = {}; // TODO: const &
+        let null : Null = {}; // TODO: let &
         stream:write_json_value(&null);
     }
 }

--- a/tests/algorithms/bisect_left.c3
+++ b/tests/algorithms/bisect_left.c3
@@ -3,21 +3,21 @@
 
 function main : () -> int = {
     let array_1 : int[5] = {0, 2, 4, 6, 8};
-    const result_1 : isize = bisect_left(array_1:make_span(), 5);
+    let result_1 : isize = bisect_left(array_1:make_span(), 5);
 
     if result_1 != 3 {
         return 1;
     }
 
     let array_2 : int[1] = {0};
-    const result_2 : isize = bisect_left(array_2:make_span(), 5);
+    let result_2 : isize = bisect_left(array_2:make_span(), 5);
 
     if result_2 != 1 {
         return 1;
     }
 
     let array_3 : int[6] = {-2, 0, 2, 5, 5, 10};
-    const result_3 : isize = bisect_left(array_3:make_span(), 5);
+    let result_3 : isize = bisect_left(array_3:make_span(), 5);
 
     if result_3 != 3 {
         return 1;

--- a/tests/arrays/correct_initialization.c3
+++ b/tests/arrays/correct_initialization.c3
@@ -1,5 +1,5 @@
 function main : () -> int = {
-    const array : int[4] = { 0, 0, 1, 2 };
+    let array : int[4] = { 0, 0, 1, 2 };
 
     return array[3];
 }

--- a/tests/arrays/heap_array_access.c3
+++ b/tests/arrays/heap_array_access.c3
@@ -1,5 +1,5 @@
 function main : () -> int = {
-    const str : u8[&] = "ABCD";
+    let str : u8[&] = "ABCD";
 
     return __builtin_bitcast<i8>(str[2]);
 }

--- a/tests/arrays/initialization_with_wrong_length.c3
+++ b/tests/arrays/initialization_with_wrong_length.c3
@@ -1,5 +1,5 @@
 function main : () -> int = {
-    const array : int[4] = { 0, 0, 1 };
+    let array : int[4] = { 0, 0, 1 };
 
     return array[3];
 }

--- a/tests/arrays/initialization_with_wrong_type.c3
+++ b/tests/arrays/initialization_with_wrong_type.c3
@@ -1,5 +1,5 @@
 function main : () -> int = {
-    const array : int[4] = { 0, 0, 1, "hello!" };
+    let array : int[4] = { 0, 0, 1, "hello!" };
 
     return array[3];
 }

--- a/tests/arrays/unborrowed_heap_array.c3
+++ b/tests/arrays/unborrowed_heap_array.c3
@@ -1,0 +1,11 @@
+function fn : (a : u8[&]) -> int = {}
+
+function fn_launcher : (a : u8[&]) -> int = {
+    return fn(a);
+}
+
+/// @COMPILE; EXPECT ERR
+/// File '*.c3', line 4, in 'function fn_launcher: (u8[[]&[]]) -> int'
+/// Error: overload resolution for function call 'fn(u8[[]&[]] (unborrowed))' failed
+/// Available overloads:
+/// - function fn : (u8[[]&[]]) -> int

--- a/tests/assignments/to_borrowed_reference.c3
+++ b/tests/assignments/to_borrowed_reference.c3
@@ -1,0 +1,9 @@
+function main : () -> int = {
+    let a : int = 9;
+    &a = 10;
+    return a;
+}
+
+/// @COMPILE; EXPECT ERR
+/// File '*.c3', line 3, in 'function main: () -> int'
+/// Error: cannot assign to borrowed reference type 'int&'. Please do not manually borrow before an assignment.

--- a/tests/json/array_comma_after_close.c3
+++ b/tests/json/array_comma_after_close.c3
@@ -2,7 +2,7 @@
 @require_once "std/string.c3"
 
 function main : () -> int = {
-    const input : StringView = sv("[\"\"],");
+    let input : StringView = sv("[\"\"],");
     let result : Optional<JSON_Node> = json_parse(input);
 
     // Should be rejected.

--- a/tests/json/array_extra_comma.c3
+++ b/tests/json/array_extra_comma.c3
@@ -2,7 +2,7 @@
 @require_once "std/string.c3"
 
 function main : () -> int = {
-    const input : StringView = sv("[\"\",]");
+    let input : StringView = sv("[\"\",]");
     let result : Optional<JSON_Node> = json_parse(input);
 
     // Should be rejected.

--- a/tests/json/echo.c3
+++ b/tests/json/echo.c3
@@ -4,7 +4,7 @@
 
 
 function main : () -> int = {
-    const input : StringView = sv("{\"name\":\"program\",\"children\":[{\"name\":\"require_once\",\"children\":[{\"name\":\"ESCAPED_STRING\",\"value\":\"\\\"std/format.c3\\\"\"}]}]}");
+    let input : StringView = sv("{\"name\":\"program\",\"children\":[{\"name\":\"require_once\",\"children\":[{\"name\":\"ESCAPED_STRING\",\"value\":\"\\\"std/format.c3\\\"\"}]}]}");
     let result : Optional<JSON_Node> = json_parse(input);
 
     // Should be accepted.

--- a/tests/json/object_empty_key.c3
+++ b/tests/json/object_empty_key.c3
@@ -2,7 +2,7 @@
 @require_once "std/string.c3"
 
 function main : () -> int = {
-    const input : StringView = sv("{\"\":0}");
+    let input : StringView = sv("{\"\":0}");
     let result : Optional<JSON_Node> = json_parse(input);
 
     // Should be accepted.

--- a/tests/json/string_allowed_escapes.c3
+++ b/tests/json/string_allowed_escapes.c3
@@ -2,7 +2,7 @@
 @require_once "std/string.c3"
 
 function main : () -> int = {
-    const input : StringView = sv("[\"\\\"\\\\\\/\\b\\f\\n\\r\\t\"]"); // ["\"\\\/\b\f\n\r\t"]
+    let input : StringView = sv("[\"\\\"\\\\\\/\\b\\f\\n\\r\\t\"]"); // ["\"\\\/\b\f\n\r\t"]
     let result : Optional<JSON_Node> = json_parse(input);
 
     // Should be accepted.

--- a/tests/json/string_incomplete_escape.c3
+++ b/tests/json/string_incomplete_escape.c3
@@ -2,7 +2,7 @@
 @require_once "std/string.c3"
 
 function main : () -> int = {
-    const input : StringView = sv("[\"\\\"]"); // ["\"]
+    let input : StringView = sv("[\"\\\"]"); // ["\"]
     let result : Optional<JSON_Node> = json_parse(input);
 
     // Should be rejected.

--- a/tests/json/string_unescaped_tab.c3
+++ b/tests/json/string_unescaped_tab.c3
@@ -2,7 +2,7 @@
 @require_once "std/string.c3"
 
 function main : () -> int = {
-    const input : StringView = sv("[\"a\ta\"],");
+    let input : StringView = sv("[\"a\ta\"],");
     let result : Optional<JSON_Node> = json_parse(input);
 
     // Should be rejected.

--- a/tests/misc/fork.c3
+++ b/tests/misc/fork.c3
@@ -3,7 +3,7 @@
 @require_once "std/unistd.c3"
 
 function main : () -> int = {
-    const pid : pid_t = fork();
+    let pid : pid_t = fork();
 
     if pid != 0 {
         puts<6>("Parent");

--- a/tests/misc/generic_type_with_int_parameter.c3
+++ b/tests/misc/generic_type_with_int_parameter.c3
@@ -4,9 +4,9 @@ typedef[@Len] string : u8[@Len]
 
 function main: () -> int = {
     // XXX we truncate array types.
-    const str: string<2>& = "abXX";
+    let str: string<2>& = "abXX";
 
-    puts<2>(&const str);
+    puts<2>(&str);
 
     return 0;
 }

--- a/tests/misc/operator_parsing.c3
+++ b/tests/misc/operator_parsing.c3
@@ -55,8 +55,8 @@ foreign puts : (str: u8[&]) -> int
 }
 
 function main : () -> int = {
-    const a: int = 0;
-    const r: bool = -a**5 * 2 >> 3 + 2 ^ 1 | 1 & 0 == 0;
+    let a: int = 0;
+    let r: bool = -a**5 * 2 >> 3 + 2 ^ 1 | 1 & 0 == 0;
     return 0;
 }
 

--- a/tests/misc/order_of_operations.c3
+++ b/tests/misc/order_of_operations.c3
@@ -26,11 +26,11 @@ foreign puts : (str: u8[&]) -> int
 }
 
 function main : () -> int = {
-    const a: int = 1 + 2 * 3;
-    const b: int = 2 * 3 + 1;
-    const c: bool = 1 + 2 | 3 + 4;
-    const d: int = 1 * 2 ** 8 * 3;
-    const e: bool = 1 * 2 == 8 * 3;
+    let a: int = 1 + 2 * 3;
+    let b: int = 2 * 3 + 1;
+    let c: bool = 1 + 2 | 3 + 4;
+    let d: int = 1 * 2 ** 8 * 3;
+    let e: bool = 1 * 2 == 8 * 3;
     return 0;
 }
 

--- a/tests/misc/process_args.c3
+++ b/tests/misc/process_args.c3
@@ -3,7 +3,7 @@
 
 function strlen : (cstr: u8[&]) -> isize = {
     let len : isize = 0;
-    const null : u8[1]& = "\0";
+    let null : u8[1]& = "\0";
 
     while cstr[len] != null[0] {
         len = len + 1;

--- a/tests/parameter_packs/pack_length.c3
+++ b/tests/parameter_packs/pack_length.c3
@@ -12,8 +12,8 @@ function[T, Ys...] pack_len: (curr: T, next: Ys...) -> int = {
 }
 
 function main : () -> int = {
-    const s : S = {};
-    const t : T = {};
+    let s : S = {};
+    let t : T = {};
 
     return pack_len(1, 2, 3, s, t);
 }

--- a/tests/regressions/alias_pattern_matching.c3
+++ b/tests/regressions/alias_pattern_matching.c3
@@ -3,7 +3,7 @@
 function[T] foo: (i: isize, j: T) -> void = {}
 
 function main : () -> int = {
-    const i: isize = 2;
+    let i: isize = 2;
 
     // CommonArithmeticType<isize, int> should match against isize.
     foo(i + 1, 0);

--- a/tests/regressions/pattern_match_heap_array.c3
+++ b/tests/regressions/pattern_match_heap_array.c3
@@ -1,8 +1,8 @@
 @require_once "std/io.c3"
 
 function main : () -> int = {
-    const str: u8[&] = "abc";
-    puts(&const str);
+    let str: u8[&] = "abc";
+    puts(&str);
     return 0;
 }
 

--- a/tests/structs/init_list_invalid_assignment_with_names.c3
+++ b/tests/structs/init_list_invalid_assignment_with_names.c3
@@ -1,5 +1,5 @@
 function main: () -> int = {
-    const not_a_struct : int = {.a = 2, .b = "str", .c = true};
+    let not_a_struct : int = {.a = 2, .b = "str", .c = true};
 
     return 0;
 }

--- a/tests/structs/init_list_invalid_assignment_without_names.c3
+++ b/tests/structs/init_list_invalid_assignment_without_names.c3
@@ -1,5 +1,5 @@
 function main: () -> int = {
-    const not_a_struct : int = {2, "str", true};
+    let not_a_struct : int = {2, "str", true};
 
     return 0;
 }

--- a/tests/structs/init_list_with_missing_name.c3
+++ b/tests/structs/init_list_with_missing_name.c3
@@ -1,7 +1,7 @@
 typedef my_struct: {a: int, b: int}
 
 function main: () -> int = {
-    const s : my_struct = { .b = 2 };
+    let s : my_struct = { .b = 2 };
 
     return 0;
 }

--- a/tests/structs/init_list_with_wrong_name.c3
+++ b/tests/structs/init_list_with_wrong_name.c3
@@ -1,7 +1,7 @@
 typedef my_struct: {a: int}
 
 function main: () -> int = {
-    const s : my_struct = {.b = 2};
+    let s : my_struct = {.b = 2};
 
     return 0;
 }

--- a/tests/structs/member_redeclaration.c3
+++ b/tests/structs/member_redeclaration.c3
@@ -4,7 +4,7 @@ typedef S : {
 }
 
 function main : () -> int = {
-    const s : S = {0, 0};
+    let s : S = {0, 0};
     return s.a;
 }
 

--- a/tests/syntax/bad_constant.c3.FIXME
+++ b/tests/syntax/bad_constant.c3.FIXME
@@ -1,8 +1,8 @@
 function main : () -> void = {
-    const a : int;
+    let a : int;
 }
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2
-/// const a : int;
+/// let a : int;
 /// ^
 /// Error: invalid syntax, a constant cannot be declared uninitialized


### PR DESCRIPTION
I'm working on full const-correctness atm, we'll need the parser changes merged separately to avoid breaking the bootstrap.

At the moment, I'm implementing the following rules:

1)
```rust
let a : int = 9;  // `a` is a constant
(&a); // Gives a constant reference to `a`
(&mut a); // Illegal: cannot take a mutable reference to constant `a`
```

2)
```rust
mut thing : int = 0;
let a : int mut& = &mut thing; // Syntax for mutable reference
mut a : int mut& = &mut thing; // Illegal: cannot store a reference in a mutable variable.
```

3)
```rust
typedef MyStruct : {a : int mut&}
let myStruct : MyStruct = ...
(&mut myStruct.a); // Legal??? Since we could always copy myStruct into mutable memory and assign to the same reference? Maybe we should change this tho?
```

4)
```rust
&mut T /* is implicitly convertible to */ &T // (but doesn't pattern match?)
```

5)
```rust
int[&, 9] // A constant reference heap array;
int[mut&, 9] // A mutable reference heap array
```

@antroseco Would like ur feedback regarding 3 tho, maybe we should change it just so its closer to c++. Also do you like the `mut`/ `let` syntax or should we go back to `let`/ `const`