### PR TITLE
Add red-black trees to the standard library

### DIFF
--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -424,7 +424,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
     if u.left:has_value() and u.right:has_value() {
         // u has two children.
         let v : RB_Node<K>& = &u.right:data():minmax(LEFT());
-        must_fix = v.colour == BLACK();
+        must_fix = (v.colour == BLACK());
         x = v.right;
 
         if &v != &u.right:data() {

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -431,7 +431,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
             // v doesn't have a left child, otherwise that child would be the
             // minimum. It might have a right child though, so replace v with
             // its right child before we move it around the tree. Set x_parent
-            // before the shift, as v might be an empty optional.
+            // before the shift, as the right child might be an empty optional.
             x_parent = v.parent;
             self:replace_node_with(&v, v.right);
 

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -128,9 +128,9 @@ function [K, V] rotate : (
     let v : RB_Node<K, V>& = &get_child(&u, !side):data();
 
     // Move child from v to u, and update the child's parent pointer.
-    get_child(&u, !side) = get_child(&v, side);
-    if get_child(&u, !side):has_value() {
-        get_child(&u, !side):data().parent:store(&u);
+    u:get_child(!side) = v:get_child(side);
+    if u:get_child(!side):has_value() {
+        u:get_child(!side):data().parent:store(&u);
     }
 
     // Replace u with v.

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -422,7 +422,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
     // which is represented as an empty optional.
     let x : Optional<RB_Node<K>&> = make_optional<RB_Node<K>&>();
     let x_parent : Optional<RB_Node<K>&>;
-    let must_fix : bool = u.colour == BLACK();
+    let must_fix : bool = (u.colour == BLACK());
 
     if u.left:has_value() and u.right:has_value() {
         // u has two children.

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -17,6 +17,14 @@ function RIGHT : () -> bool = {
     return true;
 }
 
+function left_if : (condition : bool) -> bool = {
+    if condition {
+        return LEFT();
+    }
+
+    return RIGHT();
+}
+
 typedef [K, V] RB_Node : {
     key    : K,
     value  : V,
@@ -231,28 +239,18 @@ function [K, V] insert : (
             u.value = value;
             return;
         }
-        else {
-            // Keep track of the parent node.
-            p_opt:store(&u_ptr:data():data());
 
-            if key < u.key {
-                u_ptr = {&u.left};
-            }
-            else {
-                u_ptr = {&u.right};
-            }
-        }
+        // Keep track of the parent node.
+        p_opt:store(&u_ptr:data():data());
+
+        u_ptr = {&u:get_child(left_if(key < u.key))};
     }
 
     u_ptr:data():store(&self:new<RB_Node<K, V>>(key, value, p_opt));
 
     if p_opt:has_value() {
-        if key < p_opt:data().key {
-            p_opt:data().left = u_ptr:data();
-        }
-        else {
-            p_opt:data().right = u_ptr:data();
-        }
+        let p : RB_Node<K, V>& = &p_opt:data();
+        p:get_child(left_if(key < p.key)) = u_ptr:data();
     }
 
     self:fix_after_insert(&u_ptr:data():data());
@@ -268,12 +266,7 @@ function [K, V] search : (self : RB_Tree<K, V>&, key : K) -> Optional<V> = {
             return make_optional(u:data().value);
         }
 
-        if key < u_key {
-            u = u:data().left;
-        }
-        else {
-            u = u:data().right;
-        }
+        u = u:data():get_child(left_if(key < u_key));
     }
 
     return make_optional<V>();

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -42,22 +42,24 @@ typedef [K] RB_Tree : {
     return ref_to_addr(&left) == ref_to_addr(&right);
 }
 
-function [IO, K] write : (
-    io : IO&, node : RB_Node<K>
-) -> TypeIf<StringView, IsStreamableTextIO<IO>> = {
-    // NOTE for debugging only.
-    io:write(node.key);
-    if node.colour == RED() {
-        io:write(sv(" (red)"));
+@operator [K] != : (left : RB_Node<K>&, right : RB_Node<K>&) -> bool = {
+    return !(&left == &right);
+}
+
+@operator [K] == : (
+    left : Optional<RB_Node<K>&>, right : Optional<RB_Node<K>&>
+) -> bool = {
+    if left:has_value() and right:has_value() {
+        return &left:data() == &right:data();
     }
-    else {
-        io:write(sv(" (black)"));
-    }
-    io:write(sv("\nleft: {\n"));
-    io:write(node.left);
-    io:write(sv("\n}\nright: {\n"));
-    io:write(node.right);
-    return io:write(sv("\n}\n"));
+
+    return left:has_value() == right:has_value();
+}
+
+@operator [K] != : (
+    left : Optional<RB_Node<K>&>, right : Optional<RB_Node<K>&>
+) -> bool = {
+    return !(left == right);
 }
 
 function [K] new<RB_Node<K>> : (
@@ -93,17 +95,23 @@ function [K] get_child : (
     return &node.right;
 }
 
-function [K] which_child_am_i : (node : RB_Node<K>&) -> bool = {
-    runtime_assert(node.parent:has_value());
-    let parent : RB_Node<K>& = &node.parent:data();
+function [K] which_child_am_i : (
+    node : Optional<RB_Node<K>&>, parent : RB_Node<K>&
+) -> bool = {
+    // Use this overload if node could be a leaf node (nil node).
 
     // NOTE we have to borrow explicitly to call operator == with references.
-    if parent.left:has_value() and &parent.left:data() == &node {
+    if parent.left == node {
         return LEFT();
     }
 
-    runtime_assert(parent.right:has_value() and &parent.right:data() == &node);
+    runtime_assert(parent.right == node);
     return RIGHT();
+}
+
+function [K] which_child_am_i : (node : RB_Node<K>&) -> bool = {
+    runtime_assert(node.parent:has_value());
+    return which_child_am_i(make_optional(&node), &node.parent:data());
 }
 
 function [K] is_red : (node_opt : Optional<RB_Node<K>&>&) -> bool = {
@@ -249,18 +257,210 @@ function [K] insert : (self : RB_Tree<K>&, key : K) -> void = {
     self:fix_after_insert(&u_ptr:data():data());
 }
 
-function [K] search : (self : RB_Tree<K>&, key : K) -> Optional<K> = {
+function [K] search_impl : (
+    self : RB_Tree<K>&, key : K
+) -> Optional<RB_Node<K>&> = {
     let u : Optional<RB_Node<K>&> = self.root;
 
-    while u:has_value() {
-        let u_key : K& = &u:data().key;
+    while u:has_value() and key != u:data().key {
+        u = u:data():get_child(left_if(key < u:data().key));
+    }
 
-        if key == u_key {
-            return make_optional(u_key);
-        }
+    return u;
+}
 
-        u = u:data():get_child(left_if(key < u_key));
+function [K] search : (self : RB_Tree<K>&, key : K) -> Optional<K> = {
+    let result : Optional<RB_Node<K>&> = self:search_impl(key);
+
+    if result:has_value() {
+        return make_optional(result:data().key);
     }
 
     return make_optional<K>();
+}
+
+function [K] shift_nodes : (
+    self : RB_Tree<K>&, old : RB_Node<K>&, new : Optional<RB_Node<K>&>
+) -> void = {
+    // Make old's parent point to new instead of old.
+    if old.parent:has_value() {
+        old.parent:data():get_child(old:which_child_am_i()) = new;
+    }
+    else {
+        self.root = new;
+    }
+
+    // Set new's new parent, if it's not a leaf node (nil node).
+    if new:has_value() {
+        new:data().parent = old.parent;
+    }
+}
+
+function [K] minimum : (node : RB_Node<K>&) -> RB_Node<K>& = {
+    let u : Ptr<RB_Node<K>> = {&node};
+
+    while u:data().left:has_value() {
+        u = {&u:data().left:data()};
+    }
+
+    return &u:data();
+}
+
+function [K] fix_after_delete_impl : (
+    self : RB_Tree<K>&, x : Optional<RB_Node<K>&>, y : RB_Node<K>&
+) -> Optional<RB_Node<K>&> = {
+    // x is guaranteed not to be the root. y is guaranteed to be x's parent.
+    let x_side : bool = which_child_am_i(x, &y);
+    let w_side : bool = !x_side;
+
+    // x's sibling, w, cannot be a leaf node (nil node). If x is double black,
+    // then its sibling tree must also have a height of at least 2 black nodes.
+    let w : RB_Node<K>& = &y:get_child(w_side):data();
+
+    // Case 1: w is red.
+    if w.colour == RED() {
+        // The rotation makes x's new sibling black.
+        self:rotate(&y, x_side);
+        y.colour = RED();
+        w.colour = BLACK();
+
+        // x is unchanged; we loop again and enter one of the other three cases.
+        return x;
+    }
+
+    // Case 2: w is black, w's children are black.
+    if w.left:is_black() and w.right:is_black() {
+        // Colour w red, to decrement the height of the sibling tree (in term of
+        // black nodes). This allows us to move x up to our parent: if y was
+        // black, then now it is double black; if it was red, then now it is
+        // red-and-black.
+        w.colour = RED();
+        return make_optional(&y);
+    }
+
+    // Case 3: w is black with red close and black distant child.
+    if w:get_child(x_side):is_red() and w:get_child(w_side):is_black() {
+        // Make w's red child w's new parent, and colour it black, such that x's
+        // sibling is now black. w must in turn become red, to compensate.
+        self:rotate(&w, w_side);
+        w.colour = RED();
+        w.parent:colour_black();
+
+        // x remains in place, and we get case 4.
+        return x;
+    }
+
+    // Case 4: w is black and w's distant child is red.
+    runtime_assert(w:get_child(w_side):is_red());
+
+    // Essentially, we make w y's parent, which means that there is an
+    // additional black node now in the path of x. This allows us to remove the
+    // double black. The root of the sibling tree is now w's red child, which
+    // we colour black to compensate.
+    self:rotate(&y, x_side);
+
+    // w takes y's colour, so the colour of this subtree's root is preserved.
+    w.colour = y.colour;
+
+    // We have removed one black node from w's side of the tree (w itself), so
+    // we need to make its red child black to compensate (as it is now the root
+    // of that subtree). On the other side, the new root should also be black,
+    // as it absorbs the "double black" from x.
+    w.left:colour_black();
+    w.right:colour_black();
+
+    // Remove the double black; we are done.
+    return self.root;
+}
+
+function [K] fix_after_delete : (
+    self : RB_Tree<K>&, x : Optional<RB_Node<K>&>, y : Optional<RB_Node<K>&>
+) -> void = {
+    // x is "double black" inside the loop.
+    while x != self.root and x:is_black() {
+        // x might be a leaf node (nil node), so take its parent, y as an
+        // argument. y is an optional, as the root node has no parent. However,
+        // it should have a value in all other cases.
+        x = self:fix_after_delete_impl(x, &y:data());
+
+        // In cases 1 and 3, x is unchanged, so it could still be an empty
+        // optional, representing a leaf node (nil node). In the other cases, x
+        // moves up the tree, so we must update y.
+        if x:has_value() {
+            y = x:data().parent;
+        }
+    }
+
+    // If x was the root, then it must always be black. If x was
+    // "red-and-black" (i.e. x was originally red), we can colour it black to
+    // resolve the issue.
+    x:colour_black();
+}
+
+function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
+    // x is the "double black" or "red-and-black" node which we use to fix any
+    // red-black tree violations that arise from the deletion. y is its parent,
+    // as x might be a leaf node (nil node), which is represented as an empty
+    // optional.
+    let x : Optional<RB_Node<K>&> = make_optional<RB_Node<K>&>();
+    let y : Optional<RB_Node<K>&>;
+    let must_fix : bool = u.colour == BLACK();
+
+    if u.left:has_value() and u.right:has_value() {
+        // u has two children.
+        let v : RB_Node<K>& = &u.right:data():minimum();
+        must_fix = v.colour == BLACK();
+        x = v.right;
+
+        if &v != &u.right:data() {
+            // v doesn't have a left child, otherwise that child would be the
+            // minimum. It might have a right child though, so replace v with
+            // its right child before we move it around the tree. Set y before
+            // the shift, as v might be an empty optional.
+            y = v.parent;
+            self:shift_nodes(&v, v.right);
+
+            // v now adopts the branch on the right of u. We could have made v
+            // the right child of u now, but there's no point, as we are about
+            // to remove u and relink its children anyway. v is effectively the
+            // right child of u now though.
+            v.right = u.right;
+            v.right:data().parent:store(&v);
+        }
+        else {
+            y = make_optional(&v);
+        }
+
+        // Replace u with v.
+        self:shift_nodes(&u, make_optional(&v));
+        v.left = u.left;
+        v.left:data().parent:store(&v);
+        v.colour = u.colour;
+    }
+    else {
+        // u has zero or one children.
+        // Get the child that might have the value.
+        let side : bool = left_if(u.left:has_value());
+        x = u:get_child(side);
+        y = u.parent;
+
+        // And replace u with it. It's fine if x is empty; the code is just
+        // simpler this way.
+        self:shift_nodes(&u, x);
+    }
+
+    self.allocator:deallocate(&u);
+
+    if must_fix {
+        self:fix_after_delete(x, y);
+    }
+}
+
+function [K] delete : (self : RB_Tree<K>&, key : K) -> void = {
+    let node : Optional<RB_Node<K>&> = self:search_impl(key);
+
+    // Do nothing if the key is not in the tree.
+    if node:has_value() {
+        self:delete_impl(&node:data());
+    }
 }

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -248,11 +248,6 @@ function [K] insert : (self : RB_Tree<K>&, key : K) -> void = {
 
     u_ptr:data():store(&self:new<RB_Node<K>>(key, p_opt));
 
-    if p_opt:has_value() {
-        let p : RB_Node<K>& = &p_opt:data();
-        p:get_child(left_if(key < p.key)) = u_ptr:data();
-    }
-
     self:fix_after_insert(&u_ptr:data():data());
 }
 

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -27,14 +27,14 @@ function left_if : (condition : bool) -> bool = {
 
 typedef [K] RB_Node : {
     key    : K,
-    left   : Optional<RB_Node<K>&>,
-    right  : Optional<RB_Node<K>&>,
-    parent : Optional<RB_Node<K>&>,
+    left   : Optional<RB_Node<K> mut&>,
+    right  : Optional<RB_Node<K> mut&>,
+    parent : Optional<RB_Node<K> mut&>,
     colour : bool
 }
 
 typedef [K] RB_Tree : {
-    root : Optional<RB_Node<K>&>,
+    root : Optional<RB_Node<K> mut&>,
     allocator : Allocator,  // FIXME use global allocator.
 }
 
@@ -47,7 +47,7 @@ typedef [K] RB_Tree : {
 }
 
 @operator [K] == : (
-    left : Optional<RB_Node<K>&>, right : Optional<RB_Node<K>&>
+    left : Optional<RB_Node<K> mut&>, right : Optional<RB_Node<K> mut&>
 ) -> bool = {
     if left:has_value() and right:has_value() {
         return &left:data() == &right:data();
@@ -57,46 +57,46 @@ typedef [K] RB_Tree : {
 }
 
 @operator [K] != : (
-    left : Optional<RB_Node<K>&>, right : Optional<RB_Node<K>&>
+    left : Optional<RB_Node<K> mut&>, right : Optional<RB_Node<K> mut&>
 ) -> bool = {
     return !(left == right);
 }
 
 function [K] new<RB_Node<K>> : (
-    self : RB_Tree<K>&, key : K, parent : Optional<RB_Node<K>&>
-) -> RB_Node<K>& = {
-    let node : RB_Node<K>& = &self.allocator:allocate<RB_Node<K>>();
+    self : RB_Tree<K> mut&, key : K, parent : Optional<RB_Node<K> mut&>
+) -> RB_Node<K> mut& = {
+    let node : RB_Node<K> mut& = &mut self.allocator:allocate<RB_Node<K>>();
 
     node = {
         .key = key,
-        .left = make_optional<RB_Node<K>&>(),
-        .right = make_optional<RB_Node<K>&>(),
+        .left = make<Optional<RB_Node<K> mut&>>(),
+        .right = make<Optional<RB_Node<K> mut&>>(),
         .parent = parent,
         .colour = RED(), // NOTE new nodes are red.
     };
 
-    return &node;
+    return &mut node;
 }
 
 function [K] make<RB_Tree<K>> : () -> RB_Tree<K> = {
     return {
-        .root = make_optional<RB_Node<K>&>(),
+        .root = make<Optional<RB_Node<K> mut&>>(),
         .allocator = initialize_allocator(),
     };
 }
 
 function [K] get_child : (
-    node : RB_Node<K>&, side : bool
-) -> Optional<RB_Node<K>&>& = {
+    node : RB_Node<K> mut&, side : bool
+) -> Optional<RB_Node<K> mut&> mut& = {
     if side == LEFT() {
-        return &node.left;
+        return &mut node.left;
     }
 
-    return &node.right;
+    return &mut node.right;
 }
 
 function [K] which_child_am_i : (
-    node : Optional<RB_Node<K>&>, parent : RB_Node<K>&
+    node : Optional<RB_Node<K> mut&>, parent : RB_Node<K> mut&
 ) -> bool = {
     // Use this overload if node could be a leaf node (nil node).
 
@@ -109,20 +109,20 @@ function [K] which_child_am_i : (
     return RIGHT();
 }
 
-function [K] which_child_am_i : (node : RB_Node<K>&) -> bool = {
-    return which_child_am_i(make_optional(&node), &node.parent:data());
+function [K] which_child_am_i : (node : RB_Node<K> mut&) -> bool = {
+    return which_child_am_i(make(&mut node), &mut node.parent:data());
 }
 
-function [K] is_red : (node_opt : Optional<RB_Node<K>&>&) -> bool = {
+function [K] is_red : (node_opt : Optional<RB_Node<K> mut&>&) -> bool = {
     // Using property 3 of red-black trees: every leaf node (nil node) is black.
     return node_opt:has_value() and node_opt:data().colour == RED();
 }
 
-function [K] is_black : (node_opt : Optional<RB_Node<K>&>&) -> bool = {
+function [K] is_black : (node_opt : Optional<RB_Node<K> mut&>&) -> bool = {
     return !node_opt:is_red();
 }
 
-function [K] colour_black : (node_opt : Optional<RB_Node<K>&>&) -> void = {
+function [K] colour_black : (node_opt : Optional<RB_Node<K> mut&> mut&) -> void = {
     // Using property 3 of red-black trees: every leaf node (nil node) is black.
     if node_opt:has_value() {
         node_opt:data().colour = BLACK();
@@ -130,41 +130,41 @@ function [K] colour_black : (node_opt : Optional<RB_Node<K>&>&) -> void = {
 }
 
 function [K] rotate : (
-    self : RB_Tree<K>&, u : RB_Node<K>&, side : bool
+    self : RB_Tree<K> mut&, u : RB_Node<K> mut&, side : bool
 ) -> void = {
     // If we are rotating left, get the right child.
-    let v : RB_Node<K>& = &u:get_child(!side):data();
+    let v : RB_Node<K> mut& = &mut u:get_child(!side):data();
 
     // Move child from v to u, and update the child's parent pointer.
     u:get_child(!side) = v:get_child(side);
     if u:get_child(!side):has_value() {
-        u:get_child(!side):data().parent:store(&u);
+        u:get_child(!side):data().parent:store(&mut u);
     }
 
     // Replace u with v.
     v.parent = u.parent;
     if v.parent:has_value() {
-        const u_side : bool = u:which_child_am_i();
-        u.parent:data():get_child(u_side):store(&v);
+        let u_side : bool = u:which_child_am_i();
+        u.parent:data():get_child(u_side):store(&mut v);
     }
     else {
-        self.root:store(&v);
+        self.root:store(&mut v);
     }
 
     // Make u a child of v;
-    v:get_child(side):store(&u);
-    u.parent:store(&v);
+    v:get_child(side):store(&mut u);
+    u.parent:store(&mut v);
 }
 
 function [K] fix_after_insert : (
-    self : RB_Tree<K>&, node : RB_Node<K>&
+    self : RB_Tree<K> mut&, node : RB_Node<K> mut&
 ) -> void = {
     // We need to use a Ptr here so that we can update the value on every
     // iteration.
-    let u_ptr : Ptr<RB_Node<K>> = {&node};
+    mut u_ptr : MutPtr<RB_Node<K>> = {&mut node};
 
     while u_ptr:data().colour == RED() {
-        let u : RB_Node<K>& = &u_ptr:data();
+        let u : RB_Node<K> mut& = &mut u_ptr:data();
 
         // Case 4: u has no parent.
         if !u.parent:has_value() {
@@ -173,7 +173,7 @@ function [K] fix_after_insert : (
             return;
         }
 
-        let v : RB_Node<K>& = &u.parent:data();
+        let v : RB_Node<K> mut& = &mut u.parent:data();
 
         // Case 1: u has a black parent.
         if v.colour == BLACK() {
@@ -184,7 +184,7 @@ function [K] fix_after_insert : (
 
         // u has a red parent. Property 2 of red-black trees states that the
         // root node is black, therefore v also has a parent.
-        let w : RB_Node<K>& = &v.parent:data();
+        let w : RB_Node<K> mut& = &mut v.parent:data();
 
         // Case 2: u has a red parent and a red uncle.
         if w.left:is_red() and w.right:is_red() {
@@ -193,19 +193,19 @@ function [K] fix_after_insert : (
 
             // Push the issue up the tree.
             w.colour = RED();
-            u_ptr = {&w};
+            u_ptr = {&mut w};
             // TODO continue;
         }
         else {
             // Case 3: u has a red parent and a black uncle.
-            const u_side : bool = u:which_child_am_i();
-            const uncle_side : bool = !v:which_child_am_i();
+            let u_side : bool = u:which_child_am_i();
+            let uncle_side : bool = !v:which_child_am_i();
 
             if u_side != uncle_side {
                 // Case 3a: u is away from its uncle.
                 // Rotate, then leave u red and colour w, its new sibling, red.
                 // Their new parent should thus be black.
-                self:rotate(&w, !u_side);
+                self:rotate(&mut w, !u_side);
                 v.colour = BLACK();
                 w.colour = RED();
             }
@@ -213,8 +213,8 @@ function [K] fix_after_insert : (
                 // Case 3b: u is towards its uncle.
                 // Now u becomes the parent of v and w. Colour it black, leave v
                 // red, and make w red.
-                self:rotate(&v, !u_side);
-                self:rotate(&w, u_side);
+                self:rotate(&mut v, !u_side);
+                self:rotate(&mut w, u_side);
                 u.colour = BLACK();
                 w.colour = RED();
             }
@@ -224,12 +224,12 @@ function [K] fix_after_insert : (
     }
 }
 
-function [K] insert : (self : RB_Tree<K>&, key : K) -> void = {
-    let p_opt : Optional<RB_Node<K>&> = make_optional<RB_Node<K>&>();
-    let u_ptr : Ptr<Optional<RB_Node<K>&>> = {&self.root};
+function [K] insert : (self : RB_Tree<K> mut&, key : K) -> void = {
+    mut p_opt : Optional<RB_Node<K> mut&> = make<Optional<RB_Node<K> mut&>>();
+    mut u_ptr : MutPtr<Optional<RB_Node<K> mut&>> = {&mut self.root};
 
     while u_ptr:data():has_value() {
-        let u : RB_Node<K>& = &u_ptr:data():data();
+        let u : RB_Node<K> mut& = &mut u_ptr:data():data();
 
         if key == u.key {
             // Key already exists. Overwrite it with the new key (if the tree is
@@ -241,20 +241,20 @@ function [K] insert : (self : RB_Tree<K>&, key : K) -> void = {
         }
 
         // Keep track of the parent node.
-        p_opt:store(&u_ptr:data():data());
+        p_opt:store(&mut u_ptr:data():data());
 
-        u_ptr = {&u:get_child(left_if(key < u.key))};
+        u_ptr = {&mut u:get_child(left_if(key < u.key))};
     }
 
-    u_ptr:data():store(&self:new<RB_Node<K>>(key, p_opt));
+    u_ptr:data():store(&mut self:new<RB_Node<K>>(key, p_opt));
 
-    self:fix_after_insert(&u_ptr:data():data());
+    self:fix_after_insert(&mut u_ptr:data():data());
 }
 
 function [K, Comparable] search_impl : (
-    self : RB_Tree<K>&, key : Comparable
-) -> Optional<RB_Node<K>&> = {
-    let u : Optional<RB_Node<K>&> = self.root;
+    self : RB_Tree<K> mut&, key : Comparable
+) -> Optional<RB_Node<K> mut&> = {
+    mut u : Optional<RB_Node<K> mut&> = self.root;
 
     while u:has_value() and key != u:data().key {
         u = u:data():get_child(left_if(key < u:data().key));
@@ -264,19 +264,19 @@ function [K, Comparable] search_impl : (
 }
 
 function [K, Comparable] search : (
-    self : RB_Tree<K>&, key : Comparable
+    self : RB_Tree<K> mut&, key : Comparable
 ) -> Optional<K> = {
-    let result : Optional<RB_Node<K>&> = self:search_impl(key);
+    mut result : Optional<RB_Node<K> mut&> = self:search_impl(key);
 
     if result:has_value() {
-        return make_optional(result:data().key);
+        return make(result:data().key);
     }
 
-    return make_optional<K>();
+    return make<Optional<K>>();
 }
 
 function [K] replace_node_with : (
-    self : RB_Tree<K>&, old : RB_Node<K>&, new : Optional<RB_Node<K>&>
+    self : RB_Tree<K> mut&, old : RB_Node<K> mut&, new : Optional<RB_Node<K> mut&>
 ) -> void = {
     // Make old's parent point to new instead of old.
     if old.parent:has_value() {
@@ -292,47 +292,47 @@ function [K] replace_node_with : (
     }
 }
 
-function [K] minmax : (node : RB_Node<K>&, direction : bool) -> RB_Node<K>& = {
-    let u : Ptr<RB_Node<K>> = {&node};
+function [K] minmax : (node : RB_Node<K> mut&, direction : bool) -> RB_Node<K> mut& = {
+    mut u : MutPtr<RB_Node<K>> = {&mut node};
 
     // TODO some sort of lambda/local function would really help here.
     while u:data():get_child(direction):has_value() {
-        u = {&u:data():get_child(direction):data()};
+        u = {&mut u:data():get_child(direction):data()};
     }
 
-    return &u:data();
+    return &mut u:data();
 }
 
-function [K] minmax : (tree : RB_Tree<K>&, direction : bool) -> Optional<K> = {
+function [K] minmax : (tree : RB_Tree<K> mut&, direction : bool) -> Optional<K> = {
     if tree.root:has_value() {
-        return make_optional(tree.root:data():minmax(direction).key);
+        return make(tree.root:data():minmax(direction).key);
     }
-    return make_optional<K>();
+    return make<Optional<K>>();
 }
 
-function [K] minimum : (tree : RB_Tree<K>&) -> Optional<K> = {
+function [K] minimum : (tree : RB_Tree<K> mut&) -> Optional<K> = {
     return tree:minmax(LEFT());
 }
 
-function [K] maximum : (tree : RB_Tree<K>&) -> Optional<K> = {
+function [K] maximum : (tree : RB_Tree<K> mut&) -> Optional<K> = {
     return tree:minmax(RIGHT());
 }
 
 function [K] fix_after_delete_impl : (
-    self : RB_Tree<K>&, x : Optional<RB_Node<K>&>, x_parent : RB_Node<K>&
-) -> Optional<RB_Node<K>&> = {
+    self : RB_Tree<K> mut&, x : Optional<RB_Node<K> mut&>, x_parent : RB_Node<K> mut&
+) -> Optional<RB_Node<K> mut&> = {
     // x is guaranteed not to be the root.
-    let x_side : bool = which_child_am_i(x, &x_parent);
-    let w_side : bool = !x_side;
+    mut x_side : bool = which_child_am_i(x, &mut x_parent);
+    mut w_side : bool = !x_side;
 
     // x's sibling, w, cannot be a leaf node (nil node). If x is double black,
     // then its sibling tree must also have a height of at least 2 black nodes.
-    let w : RB_Node<K>& = &x_parent:get_child(w_side):data();
+    let w : RB_Node<K> mut& = &mut x_parent:get_child(w_side):data();
 
     // Case 1: w is red.
     if w.colour == RED() {
         // The rotation makes x's new sibling black.
-        self:rotate(&x_parent, x_side);
+        self:rotate(&mut x_parent, x_side);
         x_parent.colour = RED();
         w.colour = BLACK();
 
@@ -347,14 +347,14 @@ function [K] fix_after_delete_impl : (
         // was black, then now it is double black; if it was red, then now it is
         // red-and-black.
         w.colour = RED();
-        return make_optional(&x_parent);
+        return make(&mut x_parent);
     }
 
     // Case 3: w is black with red close and black distant child.
     if w:get_child(x_side):is_red() and w:get_child(w_side):is_black() {
         // Make w's red child w's new parent, and colour it black, such that x's
         // sibling is now black. w must in turn become red, to compensate.
-        self:rotate(&w, w_side);
+        self:rotate(&mut w, w_side);
         w.colour = RED();
         w.parent:colour_black();
 
@@ -369,7 +369,7 @@ function [K] fix_after_delete_impl : (
     // additional black node now in the path of x. This allows us to remove the
     // double black. The root of the sibling tree is now w's red child, which
     // we colour black to compensate.
-    self:rotate(&x_parent, x_side);
+    self:rotate(&mut x_parent, x_side);
 
     // w takes x_parent's colour, so the colour of this subtree's root is
     // preserved.
@@ -387,16 +387,16 @@ function [K] fix_after_delete_impl : (
 }
 
 function [K] fix_after_delete : (
-    self : RB_Tree<K>&,
-    x : Optional<RB_Node<K>&>,
-    x_parent : Optional<RB_Node<K>&>
+    self : RB_Tree<K> mut&,
+    x : Optional<RB_Node<K> mut&>,
+    x_parent : Optional<RB_Node<K> mut&>
 ) -> void = {
     // x is "double black" inside the loop.
     while x != self.root and x:is_black() {
         // x might be a leaf node (nil node), so take its parent as an argument.
         // x_parent is an optional, as the root node has no parent. However, it
         // should have a value in all other cases.
-        x = self:fix_after_delete_impl(x, &x_parent:data());
+        x = self:fix_after_delete_impl(x, &mut x_parent:data());
 
         // In cases 1 and 3, x is unchanged, so it could still be an empty
         // optional, representing a leaf node (nil node). In the other cases, x
@@ -412,18 +412,18 @@ function [K] fix_after_delete : (
     x:colour_black();
 }
 
-function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
+function [K] delete_impl : (self : RB_Tree<K> mut&, u : RB_Node<K> mut&) -> void = {
     // x is the "double black" or "red-and-black" node which we use to fix any
     // red-black tree violations that arise from the deletion. x_parent is used
     // to keep track of its parent node, as x might be a leaf node (nil node),
     // which is represented as an empty optional.
-    let x : Optional<RB_Node<K>&> = make_optional<RB_Node<K>&>();
-    let x_parent : Optional<RB_Node<K>&> = make_optional<RB_Node<K>&>();
-    let must_fix : bool = (u.colour == BLACK());
+    mut x : Optional<RB_Node<K> mut&> = make<Optional<RB_Node<K> mut&>>();
+    mut x_parent : Optional<RB_Node<K> mut&> = make<Optional<RB_Node<K> mut&>>();
+    mut must_fix : bool = (u.colour == BLACK());
 
     if u.left:has_value() and u.right:has_value() {
         // u has two children.
-        let v : RB_Node<K>& = &u.right:data():minmax(LEFT());
+        let v : RB_Node<K> mut& = &mut u.right:data():minmax(LEFT());
         must_fix = (v.colour == BLACK());
         x = v.right;
 
@@ -433,23 +433,24 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
             // its right child before we move it around the tree. Set x_parent
             // before the shift, as the right child might be an empty optional.
             x_parent = v.parent;
-            self:replace_node_with(&v, v.right);
+            self:replace_node_with(&mut v, v.right);
 
             // v now adopts the branch on the right of u. We could have made v
             // the right child of u now, but there's no point, as we are about
             // to remove u and relink its children anyway. v is effectively the
             // right child of u now though.
             v.right = u.right;
-            v.right:data().parent:store(&v);
+            let x : RB_Node<K> mut& = &mut v.right:data();
+            x.parent:store(&mut v);
         }
         else {
-            x_parent = make_optional(&v);
+            x_parent = make(&mut v);
         }
 
         // Replace u with v.
-        self:replace_node_with(&u, make_optional(&v));
+        self:replace_node_with(&mut u, make(&mut v));
         v.left = u.left;
-        v.left:data().parent:store(&v);
+        v.left:data().parent:store(&mut v);
         v.colour = u.colour;
     }
     else {
@@ -461,7 +462,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
 
         // And replace u with it. It's fine if x is empty; the code is just
         // simpler this way.
-        self:replace_node_with(&u, x);
+        self:replace_node_with(&mut u, x);
     }
 
     self.allocator:deallocate(&u);
@@ -471,12 +472,12 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
     }
 }
 
-function [K] delete : (self : RB_Tree<K>&, key : K) -> bool = {
-    let node : Optional<RB_Node<K>&> = self:search_impl(key);
+function [K] delete : (self : RB_Tree<K> mut&, key : K) -> bool = {
+    mut node : Optional<RB_Node<K> mut&> = self:search_impl(key);
 
     // Do nothing if the key is not in the tree.
     if node:has_value() {
-        self:delete_impl(&node:data());
+        self:delete_impl(&mut node:data());
         return true;
     }
 

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -25,26 +25,25 @@ function left_if : (condition : bool) -> bool = {
     return RIGHT();
 }
 
-typedef [K, V] RB_Node : {
+typedef [K] RB_Node : {
     key    : K,
-    value  : V,
-    left   : Optional<RB_Node<K, V>&>,
-    right  : Optional<RB_Node<K, V>&>,
-    parent : Optional<RB_Node<K, V>&>,
+    left   : Optional<RB_Node<K>&>,
+    right  : Optional<RB_Node<K>&>,
+    parent : Optional<RB_Node<K>&>,
     colour : bool
 }
 
-typedef [K, V] RB_Tree : {
-    root : Optional<RB_Node<K, V>&>,
+typedef [K] RB_Tree : {
+    root : Optional<RB_Node<K>&>,
     allocator : Allocator,  // FIXME use global allocator.
 }
 
-@operator [K, V] == : (left : RB_Node<K, V>&, right : RB_Node<K, V>&) -> bool = {
+@operator [K] == : (left : RB_Node<K>&, right : RB_Node<K>&) -> bool = {
     return ref_to_addr(&left) == ref_to_addr(&right);
 }
 
-function [IO, K, V] write : (
-    io : IO&, node : RB_Node<K, V>
+function [IO, K] write : (
+    io : IO&, node : RB_Node<K>
 ) -> TypeIf<StringView, IsStreamableTextIO<IO>> = {
     // NOTE for debugging only.
     io:write(node.key);
@@ -54,8 +53,6 @@ function [IO, K, V] write : (
     else {
         io:write(sv(" (black)"));
     }
-    io:write(sv(": "));
-    io:write(node.value);
     io:write(sv("\nleft: {\n"));
     io:write(node.left);
     io:write(sv("\n}\nright: {\n"));
@@ -63,16 +60,15 @@ function [IO, K, V] write : (
     return io:write(sv("\n}\n"));
 }
 
-function [K, V] new<RB_Node<K, V>> : (
-    self : RB_Tree<K, V>&, key : K, value : V, parent : Optional<RB_Node<K, V>&>
-) -> RB_Node<K, V>& = {
-    let node : RB_Node<K, V>& = &self.allocator:allocate<RB_Node<K, V>>();
+function [K] new<RB_Node<K>> : (
+    self : RB_Tree<K>&, key : K, parent : Optional<RB_Node<K>&>
+) -> RB_Node<K>& = {
+    let node : RB_Node<K>& = &self.allocator:allocate<RB_Node<K>>();
 
     node = {
         .key = key,
-        .value = value,
-        .left = make_optional<RB_Node<K, V>&>(),
-        .right = make_optional<RB_Node<K, V>&>(),
+        .left = make_optional<RB_Node<K>&>(),
+        .right = make_optional<RB_Node<K>&>(),
         .parent = parent,
         .colour = RED(), // NOTE new nodes are red.
     };
@@ -80,16 +76,16 @@ function [K, V] new<RB_Node<K, V>> : (
     return &node;
 }
 
-function [K, V] make<RB_Tree<K, V>> : () -> RB_Tree<K, V> = {
+function [K] make<RB_Tree<K>> : () -> RB_Tree<K> = {
     return {
-        .root = make_optional<RB_Node<K, V>&>(),
+        .root = make_optional<RB_Node<K>&>(),
         .allocator = initialize_allocator(),
     };
 }
 
-function [K, V] get_child : (
-    node : RB_Node<K, V>&, side : bool
-) -> Optional<RB_Node<K, V>&>& = {
+function [K] get_child : (
+    node : RB_Node<K>&, side : bool
+) -> Optional<RB_Node<K>&>& = {
     if side == LEFT() {
         return &node.left;
     }
@@ -97,9 +93,9 @@ function [K, V] get_child : (
     return &node.right;
 }
 
-function [K, V] which_child_am_i : (node : RB_Node<K, V>&) -> bool = {
+function [K] which_child_am_i : (node : RB_Node<K>&) -> bool = {
     runtime_assert(node.parent:has_value());
-    let parent : RB_Node<K, V>& = &node.parent:data();
+    let parent : RB_Node<K>& = &node.parent:data();
 
     // NOTE we have to borrow explicitly to call operator == with references.
     if parent.left:has_value() and &parent.left:data() == &node {
@@ -110,29 +106,27 @@ function [K, V] which_child_am_i : (node : RB_Node<K, V>&) -> bool = {
     return RIGHT();
 }
 
-function [K, V] is_red : (node_opt : Optional<RB_Node<K, V>&>&) -> bool = {
+function [K] is_red : (node_opt : Optional<RB_Node<K>&>&) -> bool = {
     // Using property 3 of red-black trees: every leaf node (nil node) is black.
     return node_opt:has_value() and node_opt:data().colour == RED();
 }
 
-function [K, V] is_black : (node_opt : Optional<RB_Node<K, V>&>&) -> bool = {
+function [K] is_black : (node_opt : Optional<RB_Node<K>&>&) -> bool = {
     return !node_opt:is_red();
 }
 
-function [K, V] colour_black : (
-    node_opt : Optional<RB_Node<K, V>&>&
-) -> void = {
+function [K] colour_black : (node_opt : Optional<RB_Node<K>&>&) -> void = {
     // Using property 3 of red-black trees: every leaf node (nil node) is black.
     if node_opt:has_value() {
         node_opt:data().colour = BLACK();
     }
 }
 
-function [K, V] rotate : (
-    self : RB_Tree<K, V>&, u : RB_Node<K, V>&, side : bool
+function [K] rotate : (
+    self : RB_Tree<K>&, u : RB_Node<K>&, side : bool
 ) -> void = {
     // If we are rotating left, get the right child.
-    let v : RB_Node<K, V>& = &get_child(&u, !side):data();
+    let v : RB_Node<K>& = &u:get_child(!side):data();
 
     // Move child from v to u, and update the child's parent pointer.
     u:get_child(!side) = v:get_child(side);
@@ -155,15 +149,15 @@ function [K, V] rotate : (
     u.parent:store(&v);
 }
 
-function [K, V] fix_after_insert : (
-    self : RB_Tree<K, V>&, node : RB_Node<K, V>&
+function [K] fix_after_insert : (
+    self : RB_Tree<K>&, node : RB_Node<K>&
 ) -> void = {
     // We need to use a Ptr here so that we can update the value on every
     // iteration.
-    let u_ptr : Ptr<RB_Node<K, V>> = {&node};
+    let u_ptr : Ptr<RB_Node<K>> = {&node};
 
     while u_ptr:data().colour == RED() {
-        let u : RB_Node<K, V>& = &u_ptr:data();
+        let u : RB_Node<K>& = &u_ptr:data();
 
         // Case 4: u has no parent.
         if !u.parent:has_value() {
@@ -172,7 +166,7 @@ function [K, V] fix_after_insert : (
             return;
         }
 
-        let v : RB_Node<K, V>& = &u.parent:data();
+        let v : RB_Node<K>& = &u.parent:data();
 
         // Case 1: u has a black parent.
         if v.colour == BLACK() {
@@ -183,7 +177,7 @@ function [K, V] fix_after_insert : (
 
         // u has a red parent. Property 2 of red-black trees states that the
         // root node is black, therefore v also has a parent.
-        let w : RB_Node<K, V>& = &v.parent:data();
+        let w : RB_Node<K>& = &v.parent:data();
 
         // Case 2: u has a red parent and a red uncle.
         if w.left:is_red() and w.right:is_red() {
@@ -223,19 +217,19 @@ function [K, V] fix_after_insert : (
     }
 }
 
-function [K, V] insert : (
-    self : RB_Tree<K, V>&, key : K, value : V
-) -> void = {
-    let p_opt : Optional<RB_Node<K, V>&> = make_optional<RB_Node<K, V>&>();
-    let u_ptr : Ptr<Optional<RB_Node<K, V>&>> = {&self.root};
+function [K] insert : (self : RB_Tree<K>&, key : K) -> void = {
+    let p_opt : Optional<RB_Node<K>&> = make_optional<RB_Node<K>&>();
+    let u_ptr : Ptr<Optional<RB_Node<K>&>> = {&self.root};
 
     while u_ptr:data():has_value() {
-        let u : RB_Node<K, V>& = &u_ptr:data():data();
+        let u : RB_Node<K>& = &u_ptr:data():data();
 
         if key == u.key {
-            // Key already exists. We can just replace the value and return
-            // early, as the red-black tree is already valid.
-            u.value = value;
+            // Key already exists. Overwrite it with the new key (if the tree is
+            // used to implement a map, then the associated value could be
+            // different) and return early, as the red-black tree is already
+            // valid.
+            u.key = key;
             return;
         }
 
@@ -245,28 +239,28 @@ function [K, V] insert : (
         u_ptr = {&u:get_child(left_if(key < u.key))};
     }
 
-    u_ptr:data():store(&self:new<RB_Node<K, V>>(key, value, p_opt));
+    u_ptr:data():store(&self:new<RB_Node<K>>(key, p_opt));
 
     if p_opt:has_value() {
-        let p : RB_Node<K, V>& = &p_opt:data();
+        let p : RB_Node<K>& = &p_opt:data();
         p:get_child(left_if(key < p.key)) = u_ptr:data();
     }
 
     self:fix_after_insert(&u_ptr:data():data());
 }
 
-function [K, V] search : (self : RB_Tree<K, V>&, key : K) -> Optional<V> = {
-    let u : Optional<RB_Node<K, V>&> = self.root;
+function [K] search : (self : RB_Tree<K>&, key : K) -> Optional<K> = {
+    let u : Optional<RB_Node<K>&> = self.root;
 
     while u:has_value() {
         let u_key : K& = &u:data().key;
 
         if key == u_key {
-            return make_optional(u:data().value);
+            return make_optional(u_key);
         }
 
         u = u:data():get_child(left_if(key < u_key));
     }
 
-    return make_optional<V>();
+    return make_optional<K>();
 }

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -110,7 +110,6 @@ function [K] which_child_am_i : (
 }
 
 function [K] which_child_am_i : (node : RB_Node<K>&) -> bool = {
-    runtime_assert(node.parent:has_value());
     return which_child_am_i(make_optional(&node), &node.parent:data());
 }
 
@@ -145,7 +144,7 @@ function [K] rotate : (
     // Replace u with v.
     v.parent = u.parent;
     if v.parent:has_value() {
-        const u_side : bool = which_child_am_i(&u);
+        const u_side : bool = u:which_child_am_i();
         u.parent:data():get_child(u_side):store(&v);
     }
     else {
@@ -199,8 +198,8 @@ function [K] fix_after_insert : (
         }
         else {
             // Case 3: u has a red parent and a black uncle.
-            const u_side : bool = which_child_am_i(&u);
-            const uncle_side : bool = !which_child_am_i(&v);
+            const u_side : bool = u:which_child_am_i();
+            const uncle_side : bool = !v:which_child_am_i();
 
             if u_side != uncle_side {
                 // Case 3a: u is away from its uncle.

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -474,11 +474,14 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
     }
 }
 
-function [K] delete : (self : RB_Tree<K>&, key : K) -> void = {
+function [K] delete : (self : RB_Tree<K>&, key : K) -> bool = {
     let node : Optional<RB_Node<K>&> = self:search_impl(key);
 
     // Do nothing if the key is not in the tree.
     if node:has_value() {
         self:delete_impl(&node:data());
+        return true;
     }
+
+    return false;
 }

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -322,21 +322,21 @@ function [K] maximum : (tree : RB_Tree<K>&) -> Optional<K> = {
 }
 
 function [K] fix_after_delete_impl : (
-    self : RB_Tree<K>&, x : Optional<RB_Node<K>&>, y : RB_Node<K>&
+    self : RB_Tree<K>&, x : Optional<RB_Node<K>&>, x_parent : RB_Node<K>&
 ) -> Optional<RB_Node<K>&> = {
-    // x is guaranteed not to be the root. y is guaranteed to be x's parent.
-    let x_side : bool = which_child_am_i(x, &y);
+    // x is guaranteed not to be the root.
+    let x_side : bool = which_child_am_i(x, &x_parent);
     let w_side : bool = !x_side;
 
     // x's sibling, w, cannot be a leaf node (nil node). If x is double black,
     // then its sibling tree must also have a height of at least 2 black nodes.
-    let w : RB_Node<K>& = &y:get_child(w_side):data();
+    let w : RB_Node<K>& = &x_parent:get_child(w_side):data();
 
     // Case 1: w is red.
     if w.colour == RED() {
         // The rotation makes x's new sibling black.
-        self:rotate(&y, x_side);
-        y.colour = RED();
+        self:rotate(&x_parent, x_side);
+        x_parent.colour = RED();
         w.colour = BLACK();
 
         // x is unchanged; we loop again and enter one of the other three cases.
@@ -346,11 +346,11 @@ function [K] fix_after_delete_impl : (
     // Case 2: w is black, w's children are black.
     if w.left:is_black() and w.right:is_black() {
         // Colour w red, to decrement the height of the sibling tree (in term of
-        // black nodes). This allows us to move x up to our parent: if y was
-        // black, then now it is double black; if it was red, then now it is
+        // black nodes). This allows us to move x up to our parent: if x_parent
+        // was black, then now it is double black; if it was red, then now it is
         // red-and-black.
         w.colour = RED();
-        return make_optional(&y);
+        return make_optional(&x_parent);
     }
 
     // Case 3: w is black with red close and black distant child.
@@ -368,14 +368,15 @@ function [K] fix_after_delete_impl : (
     // Case 4: w is black and w's distant child is red.
     runtime_assert(w:get_child(w_side):is_red());
 
-    // Essentially, we make w y's parent, which means that there is an
+    // Essentially, we make w x_parent's parent, which means that there is an
     // additional black node now in the path of x. This allows us to remove the
     // double black. The root of the sibling tree is now w's red child, which
     // we colour black to compensate.
-    self:rotate(&y, x_side);
+    self:rotate(&x_parent, x_side);
 
-    // w takes y's colour, so the colour of this subtree's root is preserved.
-    w.colour = y.colour;
+    // w takes x_parent's colour, so the colour of this subtree's root is
+    // preserved.
+    w.colour = x_parent.colour;
 
     // We have removed one black node from w's side of the tree (w itself), so
     // we need to make its red child black to compensate (as it is now the root
@@ -389,20 +390,22 @@ function [K] fix_after_delete_impl : (
 }
 
 function [K] fix_after_delete : (
-    self : RB_Tree<K>&, x : Optional<RB_Node<K>&>, y : Optional<RB_Node<K>&>
+    self : RB_Tree<K>&,
+    x : Optional<RB_Node<K>&>,
+    x_parent : Optional<RB_Node<K>&>
 ) -> void = {
     // x is "double black" inside the loop.
     while x != self.root and x:is_black() {
-        // x might be a leaf node (nil node), so take its parent, y as an
-        // argument. y is an optional, as the root node has no parent. However,
-        // it should have a value in all other cases.
-        x = self:fix_after_delete_impl(x, &y:data());
+        // x might be a leaf node (nil node), so take its parent as an argument.
+        // x_parent is an optional, as the root node has no parent. However, it
+        // should have a value in all other cases.
+        x = self:fix_after_delete_impl(x, &x_parent:data());
 
         // In cases 1 and 3, x is unchanged, so it could still be an empty
         // optional, representing a leaf node (nil node). In the other cases, x
-        // moves up the tree, so we must update y.
+        // moves up the tree, so we must update x_parent.
         if x:has_value() {
-            y = x:data().parent;
+            x_parent = x:data().parent;
         }
     }
 
@@ -414,11 +417,11 @@ function [K] fix_after_delete : (
 
 function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
     // x is the "double black" or "red-and-black" node which we use to fix any
-    // red-black tree violations that arise from the deletion. y is its parent,
-    // as x might be a leaf node (nil node), which is represented as an empty
-    // optional.
+    // red-black tree violations that arise from the deletion. x_parent is used
+    // to keep track of its parent node, as x might be a leaf node (nil node),
+    // which is represented as an empty optional.
     let x : Optional<RB_Node<K>&> = make_optional<RB_Node<K>&>();
-    let y : Optional<RB_Node<K>&>;
+    let x_parent : Optional<RB_Node<K>&>;
     let must_fix : bool = u.colour == BLACK();
 
     if u.left:has_value() and u.right:has_value() {
@@ -430,9 +433,9 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
         if &v != &u.right:data() {
             // v doesn't have a left child, otherwise that child would be the
             // minimum. It might have a right child though, so replace v with
-            // its right child before we move it around the tree. Set y before
-            // the shift, as v might be an empty optional.
-            y = v.parent;
+            // its right child before we move it around the tree. Set x_parent
+            // before the shift, as v might be an empty optional.
+            x_parent = v.parent;
             self:shift_nodes(&v, v.right);
 
             // v now adopts the branch on the right of u. We could have made v
@@ -443,7 +446,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
             v.right:data().parent:store(&v);
         }
         else {
-            y = make_optional(&v);
+            x_parent = make_optional(&v);
         }
 
         // Replace u with v.
@@ -457,7 +460,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
         // Get the child that might have the value.
         let side : bool = left_if(u.left:has_value());
         x = u:get_child(side);
-        y = u.parent;
+        x_parent = u.parent;
 
         // And replace u with it. It's fine if x is empty; the code is just
         // simpler this way.
@@ -467,7 +470,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
     self.allocator:deallocate(&u);
 
     if must_fix {
-        self:fix_after_delete(x, y);
+        self:fix_after_delete(x, x_parent);
     }
 }
 

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -275,7 +275,7 @@ function [K, Comparable] search : (
     return make_optional<K>();
 }
 
-function [K] shift_nodes : (
+function [K] replace_node_with : (
     self : RB_Tree<K>&, old : RB_Node<K>&, new : Optional<RB_Node<K>&>
 ) -> void = {
     // Make old's parent point to new instead of old.
@@ -433,7 +433,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
             // its right child before we move it around the tree. Set x_parent
             // before the shift, as v might be an empty optional.
             x_parent = v.parent;
-            self:shift_nodes(&v, v.right);
+            self:replace_node_with(&v, v.right);
 
             // v now adopts the branch on the right of u. We could have made v
             // the right child of u now, but there's no point, as we are about
@@ -447,7 +447,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
         }
 
         // Replace u with v.
-        self:shift_nodes(&u, make_optional(&v));
+        self:replace_node_with(&u, make_optional(&v));
         v.left = u.left;
         v.left:data().parent:store(&v);
         v.colour = u.colour;
@@ -461,7 +461,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
 
         // And replace u with it. It's fine if x is empty; the code is just
         // simpler this way.
-        self:shift_nodes(&u, x);
+        self:replace_node_with(&u, x);
     }
 
     self.allocator:deallocate(&u);

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -295,14 +295,30 @@ function [K] shift_nodes : (
     }
 }
 
-function [K] minimum : (node : RB_Node<K>&) -> RB_Node<K>& = {
+function [K] minmax : (node : RB_Node<K>&, direction : bool) -> RB_Node<K>& = {
     let u : Ptr<RB_Node<K>> = {&node};
 
-    while u:data().left:has_value() {
-        u = {&u:data().left:data()};
+    // TODO some sort of lambda/local function would really help here.
+    while u:data():get_child(direction):has_value() {
+        u = {&u:data():get_child(direction):data()};
     }
 
     return &u:data();
+}
+
+function [K] minmax : (tree : RB_Tree<K>&, direction : bool) -> Optional<K> = {
+    if tree.root:has_value() {
+        return make_optional(tree.root:data():minmax(direction).key);
+    }
+    return make_optional<K>();
+}
+
+function [K] minimum : (tree : RB_Tree<K>&) -> Optional<K> = {
+    return tree:minmax(LEFT());
+}
+
+function [K] maximum : (tree : RB_Tree<K>&) -> Optional<K> = {
+    return tree:minmax(RIGHT());
 }
 
 function [K] fix_after_delete_impl : (
@@ -407,7 +423,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
 
     if u.left:has_value() and u.right:has_value() {
         // u has two children.
-        let v : RB_Node<K>& = &u.right:data():minimum();
+        let v : RB_Node<K>& = &u.right:data():minmax(LEFT());
         must_fix = v.colour == BLACK();
         x = v.right;
 

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -40,8 +40,7 @@ typedef [K, V] RB_Tree : {
 }
 
 @operator [K, V] == : (left : RB_Node<K, V>&, right : RB_Node<K, V>&) -> bool = {
-    // Assume both nodes belong to the same tree, to keep things simple.
-    return left.key == right.key;
+    return ref_to_addr(&left) == ref_to_addr(&right);
 }
 
 function [IO, K, V] write : (

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -1,0 +1,280 @@
+@require_once "std/memory.c3"
+@require_once "std/wrappers.c3"
+
+function RED : () -> bool = {
+    return false;
+}
+
+function BLACK : () -> bool = {
+    return true;
+}
+
+function LEFT : () -> bool = {
+    return false;
+}
+
+function RIGHT : () -> bool = {
+    return true;
+}
+
+typedef [K, V] RB_Node : {
+    key    : K,
+    value  : V,
+    left   : Optional<RB_Node<K, V>&>,
+    right  : Optional<RB_Node<K, V>&>,
+    parent : Optional<RB_Node<K, V>&>,
+    colour : bool
+}
+
+typedef [K, V] RB_Tree : {
+    root : Optional<RB_Node<K, V>&>,
+    allocator : Allocator,  // FIXME use global allocator.
+}
+
+@operator [K, V] == : (left : RB_Node<K, V>&, right : RB_Node<K, V>&) -> bool = {
+    // Assume both nodes belong to the same tree, to keep things simple.
+    return left.key == right.key;
+}
+
+function [IO, K, V] write : (
+    io : IO&, node : RB_Node<K, V>
+) -> TypeIf<StringView, IsStreamableTextIO<IO>> = {
+    // NOTE for debugging only.
+    io:write(node.key);
+    if node.colour == RED() {
+        io:write(sv(" (red)"));
+    }
+    else {
+        io:write(sv(" (black)"));
+    }
+    io:write(sv(": "));
+    io:write(node.value);
+    io:write(sv("\nleft: {\n"));
+    io:write(node.left);
+    io:write(sv("\n}\nright: {\n"));
+    io:write(node.right);
+    return io:write(sv("\n}\n"));
+}
+
+function [K, V] new<RB_Node<K, V>> : (
+    self : RB_Tree<K, V>&, key : K, value : V, parent : Optional<RB_Node<K, V>&>
+) -> RB_Node<K, V>& = {
+    let node : RB_Node<K, V>& = &self.allocator:allocate<RB_Node<K, V>>();
+
+    node = {
+        .key = key,
+        .value = value,
+        .left = make_optional<RB_Node<K, V>&>(),
+        .right = make_optional<RB_Node<K, V>&>(),
+        .parent = parent,
+        .colour = RED(), // NOTE new nodes are red.
+    };
+
+    return &node;
+}
+
+function [K, V] make<RB_Tree<K, V>> : () -> RB_Tree<K, V> = {
+    return {
+        .root = make_optional<RB_Node<K, V>&>(),
+        .allocator = initialize_allocator(),
+    };
+}
+
+function [K, V] get_child : (
+    node : RB_Node<K, V>&, side : bool
+) -> Optional<RB_Node<K, V>&>& = {
+    if side == LEFT() {
+        return &node.left;
+    }
+
+    return &node.right;
+}
+
+function [K, V] which_child_am_i : (node : RB_Node<K, V>&) -> bool = {
+    runtime_assert(node.parent:has_value());
+    let parent : RB_Node<K, V>& = &node.parent:data();
+
+    // NOTE we have to borrow explicitly to call operator == with references.
+    if parent.left:has_value() and &parent.left:data() == &node {
+        return LEFT();
+    }
+
+    runtime_assert(parent.right:has_value() and &parent.right:data() == &node);
+    return RIGHT();
+}
+
+function [K, V] is_red : (node_opt : Optional<RB_Node<K, V>&>&) -> bool = {
+    // Using property 3 of red-black trees: every leaf node (nil node) is black.
+    return node_opt:has_value() and node_opt:data().colour == RED();
+}
+
+function [K, V] is_black : (node_opt : Optional<RB_Node<K, V>&>&) -> bool = {
+    return !node_opt:is_red();
+}
+
+function [K, V] colour_black : (
+    node_opt : Optional<RB_Node<K, V>&>&
+) -> void = {
+    // Using property 3 of red-black trees: every leaf node (nil node) is black.
+    if node_opt:has_value() {
+        node_opt:data().colour = BLACK();
+    }
+}
+
+function [K, V] rotate : (
+    self : RB_Tree<K, V>&, u : RB_Node<K, V>&, side : bool
+) -> void = {
+    // If we are rotating left, get the right child.
+    let v : RB_Node<K, V>& = &get_child(&u, !side):data();
+
+    // Move child from v to u, and update the child's parent pointer.
+    get_child(&u, !side) = get_child(&v, side);
+    if get_child(&u, !side):has_value() {
+        get_child(&u, !side):data().parent:store(&u);
+    }
+
+    // Replace u with v.
+    v.parent = u.parent;
+    if v.parent:has_value() {
+        const u_side : bool = which_child_am_i(&u);
+        u.parent:data():get_child(u_side):store(&v);
+    }
+    else {
+        self.root:store(&v);
+    }
+
+    // Make u a child of v;
+    v:get_child(side):store(&u);
+    u.parent:store(&v);
+}
+
+function [K, V] fix_after_insert : (
+    self : RB_Tree<K, V>&, node : RB_Node<K, V>&
+) -> void = {
+    // We need to use a Ptr here so that we can update the value on every
+    // iteration.
+    let u_ptr : Ptr<RB_Node<K, V>> = {&node};
+
+    while u_ptr:data().colour == RED() {
+        let u : RB_Node<K, V>& = &u_ptr:data();
+
+        // Case 4: u has no parent.
+        if !u.parent:has_value() {
+            // u is the root node. Colour it black.
+            u.colour = BLACK();
+            return;
+        }
+
+        let v : RB_Node<K, V>& = &u.parent:data();
+
+        // Case 1: u has a black parent.
+        if v.colour == BLACK() {
+            // u is red, so both of its children must be black. Given that its
+            // parent is also black, we can just leave u red.
+            return;
+        }
+
+        // u has a red parent. Property 2 of red-black trees states that the
+        // root node is black, therefore v also has a parent.
+        let w : RB_Node<K, V>& = &v.parent:data();
+
+        // Case 2: u has a red parent and a red uncle.
+        if w.left:is_red() and w.right:is_red() {
+            w.left:colour_black();
+            w.right:colour_black();
+
+            // Push the issue up the tree.
+            w.colour = RED();
+            u_ptr = {&w};
+            // TODO continue;
+        }
+        else {
+            // Case 3: u has a red parent and a black uncle.
+            const u_side : bool = which_child_am_i(&u);
+            const uncle_side : bool = !which_child_am_i(&v);
+
+            if u_side != uncle_side {
+                // Case 3a: u is away from its uncle.
+                // Rotate, then leave u red and colour w, its new sibling, red.
+                // Their new parent should thus be black.
+                self:rotate(&w, !u_side);
+                v.colour = BLACK();
+                w.colour = RED();
+            }
+            else {
+                // Case 3b: u is towards its uncle.
+                // Now u becomes the parent of v and w. Colour it black, leave v
+                // red, and make w red.
+                self:rotate(&v, !u_side);
+                self:rotate(&w, u_side);
+                u.colour = BLACK();
+                w.colour = RED();
+            }
+
+            return;
+        }
+    }
+}
+
+function [K, V] insert : (
+    self : RB_Tree<K, V>&, key : K, value : V
+) -> void = {
+    let p_opt : Optional<RB_Node<K, V>&> = make_optional<RB_Node<K, V>&>();
+    let u_ptr : Ptr<Optional<RB_Node<K, V>&>> = {&self.root};
+
+    while u_ptr:data():has_value() {
+        let u : RB_Node<K, V>& = &u_ptr:data():data();
+
+        if key == u.key {
+            // Key already exists. We can just replace the value and return
+            // early, as the red-black tree is already valid.
+            u.value = value;
+            return;
+        }
+        else {
+            // Keep track of the parent node.
+            p_opt:store(&u_ptr:data():data());
+
+            if key < u.key {
+                u_ptr = {&u.left};
+            }
+            else {
+                u_ptr = {&u.right};
+            }
+        }
+    }
+
+    u_ptr:data():store(&self:new<RB_Node<K, V>>(key, value, p_opt));
+
+    if p_opt:has_value() {
+        if key < p_opt:data().key {
+            p_opt:data().left = u_ptr:data();
+        }
+        else {
+            p_opt:data().right = u_ptr:data();
+        }
+    }
+
+    self:fix_after_insert(&u_ptr:data():data());
+}
+
+function [K, V] search : (self : RB_Tree<K, V>&, key : K) -> Optional<V> = {
+    let u : Optional<RB_Node<K, V>&> = self.root;
+
+    while u:has_value() {
+        let u_key : K& = &u:data().key;
+
+        if key == u_key {
+            return make_optional(u:data().value);
+        }
+
+        if key < u_key {
+            u = u:data().left;
+        }
+        else {
+            u = u:data().right;
+        }
+    }
+
+    return make_optional<V>();
+}

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -418,7 +418,7 @@ function [K] delete_impl : (self : RB_Tree<K>&, u : RB_Node<K>&) -> void = {
     // to keep track of its parent node, as x might be a leaf node (nil node),
     // which is represented as an empty optional.
     let x : Optional<RB_Node<K>&> = make_optional<RB_Node<K>&>();
-    let x_parent : Optional<RB_Node<K>&>;
+    let x_parent : Optional<RB_Node<K>&> = make_optional<RB_Node<K>&>();
     let must_fix : bool = (u.colour == BLACK());
 
     if u.left:has_value() and u.right:has_value() {

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -251,8 +251,8 @@ function [K] insert : (self : RB_Tree<K>&, key : K) -> void = {
     self:fix_after_insert(&u_ptr:data():data());
 }
 
-function [K] search_impl : (
-    self : RB_Tree<K>&, key : K
+function [K, Comparable] search_impl : (
+    self : RB_Tree<K>&, key : Comparable
 ) -> Optional<RB_Node<K>&> = {
     let u : Optional<RB_Node<K>&> = self.root;
 
@@ -263,7 +263,9 @@ function [K] search_impl : (
     return u;
 }
 
-function [K] search : (self : RB_Tree<K>&, key : K) -> Optional<K> = {
+function [K, Comparable] search : (
+    self : RB_Tree<K>&, key : Comparable
+) -> Optional<K> = {
     let result : Optional<RB_Node<K>&> = self:search_impl(key);
 
     if result:has_value() {

--- a/src/glang/lib/std/wrappers.c3
+++ b/src/glang/lib/std/wrappers.c3
@@ -73,6 +73,7 @@ function [T] erase : (self : Optional<T&> mut&) -> void = {
 }
 
 function [T] data : (self : Optional<T&>&) -> T& = {
+    runtime_assert(self:has_value());
     return &addr_to_ref<T>(self._ptr);
 }
 

--- a/src/glang/lib/std/wrappers.c3
+++ b/src/glang/lib/std/wrappers.c3
@@ -81,7 +81,7 @@ function [T] make<Optional<T&>> : () -> Optional<T&> = {
     return { 0 };
 }
 
-function [T] make<T&> : (value : T&) -> Optional<T&> = {
+function [T] make<Optional<T&>> : (value : T&) -> Optional<T&> = {
     return { ref_to_addr(&value) };
 }
 
@@ -118,7 +118,7 @@ function [T] make<Optional<T mut&>> : () -> Optional<T mut&> = {
     return { 0 };
 }
 
-function [T] make<T mut&> : (value : T mut&) -> Optional<T mut&> = {
+function [T] make<Optional<T mut&>> : (value : T mut&) -> Optional<T mut&> = {
     return { ref_to_addr(&value) };
 }
 

--- a/src/glang/lib/std/wrappers.c3
+++ b/src/glang/lib/std/wrappers.c3
@@ -1,6 +1,7 @@
 @require_once "type_traits.c3"
 
 typedef [T] Ptr : { data : T& }
+typedef [T] MutPtr : { data : T mut& }
 typedef [T] MaybeNullPtr : Optional<Ptr<T>>
 
 // Maybe FIXME: this isn't really ergonomic, this SFINAE avoids &/ mut& code duplication
@@ -15,6 +16,15 @@ function [T] data : (self : Ptr<T>&) -> T& = {
 
 function [T] data : (self : Ptr<T> mut&) -> T& = {
     return &self.data;
+}
+
+// MutPtr
+function [T] data : (self : MutPtr<T>&) -> T mut& = {
+    return &mut self.data;
+}
+
+function [T] data : (self : MutPtr<T> mut&) -> T mut& = {
+    return &mut self.data;
 }
 
 // Generic Optional
@@ -55,9 +65,20 @@ function [T] has_value : (self : Optional<T>&) -> bool = {
     return self._has_value;
 }
 
+function [IO, T] write : (
+    io : IO mut&, optional : Optional<T>
+) -> TypeIf<StringView, IsStreamableTextIO<IO>> = {
+    if optional:has_value() {
+        return io:write(optional:data());
+    }
+
+    return io:write("<empty>");
+}
+
+
 // Optional<T&>
-function [T] make<T&> : (value : T&) -> Optional<T&> = {
-    return { ref_to_addr(&value) };
+function [T] make<Optional<T&>> : () -> Optional<T&> = {
+    return { 0 };
 }
 
 function [T] make<T&> : (value : T&) -> Optional<T&> = {
@@ -93,11 +114,11 @@ function [T] has_value : (self : Optional<T&> mut&) -> bool = {
 
 // HUGE DUPLICATION FOR MUTABLE REFERENCE
 // Optional<T&>
-function [T] make<T&> : (value : T mut&) -> Optional<T mut&> = {
-    return { ref_to_addr(&value) };
+function [T] make<Optional<T mut&>> : () -> Optional<T mut&> = {
+    return { 0 };
 }
 
-function [T] make<T&> : (value : T mut&) -> Optional<T mut&> = {
+function [T] make<T mut&> : (value : T mut&) -> Optional<T mut&> = {
     return { ref_to_addr(&value) };
 }
 
@@ -107,6 +128,10 @@ function [T] store : (self : Optional<T mut&> mut&, value : T mut&) -> void = {
 
 function [T] erase : (self : Optional<T mut&> mut&) -> void = {
     self._ptr = 0;
+}
+
+function [T] data : (self : Optional<T mut&>&) -> T mut& = {
+    return &mut addr_to_mut_ref<T>(self._ptr);
 }
 
 function [T] data : (self : Optional<T mut&> mut&) -> T mut& = {

--- a/tests/stdlib/rb_tree/basic.c3
+++ b/tests/stdlib/rb_tree/basic.c3
@@ -16,6 +16,17 @@ function main : () -> int = {
     print(tree:search(1));
     print(tree:search(0));
 
+    tree:delete(0);
+    tree:delete(1);
+    tree:delete(2);
+    tree:delete(3);
+
+    print(tree:search(4));
+    print(tree:search(3));
+    print(tree:search(2));
+    print(tree:search(1));
+    print(tree:search(0));
+
     return 0;
 }
 
@@ -26,3 +37,8 @@ function main : () -> int = {
 /// 2
 /// 1
 /// 0
+/// <empty>
+/// <empty>
+/// <empty>
+/// <empty>
+/// <empty>

--- a/tests/stdlib/rb_tree/basic.c3
+++ b/tests/stdlib/rb_tree/basic.c3
@@ -1,5 +1,6 @@
 @require_once "std/rb_tree.c3"
 @require_once "std/format.c3"
+@require_once "std/assert.c3"
 
 function main : () -> int = {
     let tree : RB_Tree<int> = make<RB_Tree<int>>();
@@ -15,10 +16,11 @@ function main : () -> int = {
     print(tree:search(1));
     print(tree:search(0));
 
-    tree:delete(0);
-    tree:delete(1);
-    tree:delete(2);
-    tree:delete(3);
+    runtime_assert(tree:delete(0));
+    runtime_assert(tree:delete(1));
+    runtime_assert(tree:delete(2));
+    runtime_assert(tree:delete(3));
+    runtime_assert(!tree:delete(4));
 
     print(tree:search(4));
     print(tree:search(3));

--- a/tests/stdlib/rb_tree/basic.c3
+++ b/tests/stdlib/rb_tree/basic.c3
@@ -3,7 +3,7 @@
 @require_once "std/assert.c3"
 
 function main : () -> int = {
-    let tree : RB_Tree<int> = make<RB_Tree<int>>();
+    mut tree : RB_Tree<int> = make<RB_Tree<int>>();
 
     tree:insert(0);
     tree:insert(1);

--- a/tests/stdlib/rb_tree/basic.c3
+++ b/tests/stdlib/rb_tree/basic.c3
@@ -3,12 +3,12 @@
 @require_once "std/string.c3"
 
 function main : () -> int = {
-    let tree : RB_Tree<int, StringView> = make<RB_Tree<int, StringView>>();
+    let tree : RB_Tree<int> = make<RB_Tree<int>>();
 
-    tree:insert(0, sv("V0"));
-    tree:insert(1, sv("V1"));
-    tree:insert(2, sv("V2"));
-    tree:insert(3, sv("V3"));
+    tree:insert(0);
+    tree:insert(1);
+    tree:insert(2);
+    tree:insert(3);
 
     print(tree:search(4));
     print(tree:search(3));
@@ -22,7 +22,7 @@ function main : () -> int = {
 /// @COMPILE
 /// @RUN; EXPECT OUT
 /// <empty>
-/// V3
-/// V2
-/// V1
-/// V0
+/// 3
+/// 2
+/// 1
+/// 0

--- a/tests/stdlib/rb_tree/basic.c3
+++ b/tests/stdlib/rb_tree/basic.c3
@@ -1,6 +1,5 @@
-@require_once "std/format.c3"
 @require_once "std/rb_tree.c3"
-@require_once "std/string.c3"
+@require_once "std/format.c3"
 
 function main : () -> int = {
     let tree : RB_Tree<int> = make<RB_Tree<int>>();

--- a/tests/stdlib/rb_tree/basic.c3
+++ b/tests/stdlib/rb_tree/basic.c3
@@ -1,0 +1,28 @@
+@require_once "std/format.c3"
+@require_once "std/rb_tree.c3"
+@require_once "std/string.c3"
+
+function main : () -> int = {
+    let tree : RB_Tree<int, StringView> = make<RB_Tree<int, StringView>>();
+
+    tree:insert(0, sv("V0"));
+    tree:insert(1, sv("V1"));
+    tree:insert(2, sv("V2"));
+    tree:insert(3, sv("V3"));
+
+    print(tree:search(4));
+    print(tree:search(3));
+    print(tree:search(2));
+    print(tree:search(1));
+    print(tree:search(0));
+
+    return 0;
+}
+
+/// @COMPILE
+/// @RUN; EXPECT OUT
+/// <empty>
+/// V3
+/// V2
+/// V1
+/// V0

--- a/tests/stdlib/rb_tree/extended.c3
+++ b/tests/stdlib/rb_tree/extended.c3
@@ -17,6 +17,10 @@ function [K] is_valid_rb_tree_impl : (node : RB_Node<K>&) -> Optional<int> = {
     let black_count_r : int = 1;
 
     if node.left:has_value() {
+        if node.left:data().key >= node.key {
+            return make_optional<int>();
+        }
+
         let left_res : Optional<int> = node.left:data():is_valid_rb_tree_impl();
         if left_res:has_value() {
             black_count_l = left_res:data();
@@ -25,7 +29,12 @@ function [K] is_valid_rb_tree_impl : (node : RB_Node<K>&) -> Optional<int> = {
             return make_optional<int>();
         }
     }
+
     if node.right:has_value() {
+        if node.right:data().key <= node.key {
+            return make_optional<int>();
+        }
+
         let right_res : Optional<int> = node.right:data():is_valid_rb_tree_impl();
         if right_res:has_value() {
             black_count_r = right_res:data();

--- a/tests/stdlib/rb_tree/extended.c3
+++ b/tests/stdlib/rb_tree/extended.c3
@@ -2,7 +2,7 @@
 @require_once "std/iterators.c3"
 @require_once "std/wrappers.c3"
 
-function [K, V] is_valid_rb_tree_impl : (node : RB_Node<K, V>&) -> Optional<int> = {
+function [K] is_valid_rb_tree_impl : (node : RB_Node<K>&) -> Optional<int> = {
     if node.colour == RED() {
         // Property 4: if a node is red, both of its children are black.
         if node.left:is_red() or node.right:is_red() {
@@ -45,7 +45,7 @@ function [K, V] is_valid_rb_tree_impl : (node : RB_Node<K, V>&) -> Optional<int>
     return make_optional<int>();
 }
 
-function [K, V] is_valid_rb_tree : (tree : RB_Tree<K, V>&) -> bool = {
+function [K] is_valid_rb_tree : (tree : RB_Tree<K>&) -> bool = {
     // Property 2: the root node is black.
     if tree.root:is_red() {
         return false;
@@ -60,10 +60,10 @@ function [K, V] is_valid_rb_tree : (tree : RB_Tree<K, V>&) -> bool = {
 }
 
 function main : () -> int = {
-    let tree : RB_Tree<int, int> = make<RB_Tree<int, int>>();
+    let tree : RB_Tree<int> = make<RB_Tree<int>>();
 
     for i in range(10000) {
-        tree:insert(i, i);
+        tree:insert(i);
         if !tree:is_valid_rb_tree() {
             return i;
         }

--- a/tests/stdlib/rb_tree/extended.c3
+++ b/tests/stdlib/rb_tree/extended.c3
@@ -1,5 +1,6 @@
-@require_once "std/rb_tree.c3"
 @require_once "std/iterators.c3"
+@require_once "std/rb_tree.c3"
+@require_once "std/util.c3"
 @require_once "std/wrappers.c3"
 
 function [K] child_is_valid_rb_tree: (
@@ -12,6 +13,12 @@ function [K] child_is_valid_rb_tree: (
     }
 
     let child : RB_Node<K>& = &child_opt:data();
+
+    // Check that the child's parent reference is correct.
+    if !child.parent:has_value() or
+        ref_to_addr(&child.parent:data()) != ref_to_addr(&node) {
+        return make_optional<int>();
+    }
 
     if side == LEFT() {
         if child.key >= node.key {

--- a/tests/stdlib/rb_tree/extended.c3
+++ b/tests/stdlib/rb_tree/extended.c3
@@ -61,28 +61,52 @@ function [K] is_valid_rb_tree : (tree : RB_Tree<K>&) -> bool = {
 
 function main : () -> int = {
     let tree : RB_Tree<int> = make<RB_Tree<int>>();
+    let n : int = 1000;
 
-    for i in range(10000) {
+    for i in range(n) {
         tree:insert(i);
         if !tree:is_valid_rb_tree() {
-            return i;
+            return 1;
         }
     }
 
-    for i in range(10000) {
+    for i in range(n) {
         let value : Optional<int> = tree:search(i);
-
         if !value:has_value() or value:data() != i {
-            return i;
+            return 2;
         }
     }
 
-    for i in range(1, 1000) {
+    for i in range(1, n) {
         let value : Optional<int> = tree:search(-i);
-
         if value:has_value() {
-            return -i;
+            return 3;
         }
+    }
+
+    for i in range(1, n, 5) {
+        tree:delete(i);
+        if !tree:is_valid_rb_tree() {
+            return 4;
+        }
+    }
+
+    for i in range(0, n, 7) {
+        tree:delete(i);
+        if !tree:is_valid_rb_tree() {
+            return 5;
+        }
+    }
+
+    for i in range(n) {
+        tree:delete(i);
+        if !tree:is_valid_rb_tree() {
+            return 6;
+        }
+    }
+
+    if tree.root:has_value() {
+        return 7;
     }
 
     return 0;

--- a/tests/stdlib/rb_tree/extended.c3
+++ b/tests/stdlib/rb_tree/extended.c3
@@ -1,0 +1,92 @@
+@require_once "std/rb_tree.c3"
+@require_once "std/iterators.c3"
+@require_once "std/wrappers.c3"
+
+function [K, V] is_valid_rb_tree_impl : (node : RB_Node<K, V>&) -> Optional<int> = {
+    if node.colour == RED() {
+        // Property 4: if a node is red, both of its children are black.
+        if node.left:is_red() or node.right:is_red() {
+            return make_optional<int>();
+        }
+    }
+
+    // Property 3: every leaf node (nil node) is black.
+    // Property 5: starting from any node, all simple paths down to leaf nodes
+    // hold the same number of black nodes.
+    let black_count_l : int = 1;
+    let black_count_r : int = 1;
+
+    if node.left:has_value() {
+        let left_res : Optional<int> = node.left:data():is_valid_rb_tree_impl();
+        if left_res:has_value() {
+            black_count_l = left_res:data();
+        }
+        else {
+            return make_optional<int>();
+        }
+    }
+    if node.right:has_value() {
+        let right_res : Optional<int> = node.right:data():is_valid_rb_tree_impl();
+        if right_res:has_value() {
+            black_count_r = right_res:data();
+        }
+        else {
+            return make_optional<int>();
+        }
+    }
+
+    if black_count_l == black_count_r {
+        if node.colour == BLACK() {
+            black_count_l += 1;
+        }
+        return make_optional(black_count_l);
+    }
+
+    return make_optional<int>();
+}
+
+function [K, V] is_valid_rb_tree : (tree : RB_Tree<K, V>&) -> bool = {
+    // Property 2: the root node is black.
+    if tree.root:is_red() {
+        return false;
+    }
+
+    if tree.root:has_value() {
+        let ret : Optional<int> = tree.root:data():is_valid_rb_tree_impl();
+        return ret:has_value();
+    }
+
+    return true;
+}
+
+function main : () -> int = {
+    let tree : RB_Tree<int, int> = make<RB_Tree<int, int>>();
+
+    for i in range(10000) {
+        tree:insert(i, i);
+        if !tree:is_valid_rb_tree() {
+            return i;
+        }
+    }
+
+    for i in range(10000) {
+        let value : Optional<int> = tree:search(i);
+
+        if !value:has_value() or value:data() != i {
+            return i;
+        }
+    }
+
+    for i in range(1, 1000) {
+        let value : Optional<int> = tree:search(-i);
+
+        if value:has_value() {
+            return -i;
+        }
+    }
+
+    return 0;
+}
+
+/// @COMPILE
+/// @RUN

--- a/tests/stdlib/rb_tree/extended.c3
+++ b/tests/stdlib/rb_tree/extended.c3
@@ -4,40 +4,40 @@
 @require_once "std/wrappers.c3"
 
 function [K] child_is_valid_rb_tree: (
-    node : RB_Node<K>&, side : bool
+    node : RB_Node<K> mut&, side : bool
 ) -> Optional<int> = {
-    let child_opt : Optional<RB_Node<K>&> = node:get_child(side);
+    let child_opt : Optional<RB_Node<K> mut&> = node:get_child(side);
 
     if !child_opt:has_value() {
-        return make_optional(1);
+        return make<Optional<int>>(1);
     }
 
-    let child : RB_Node<K>& = &child_opt:data();
+    let child : RB_Node<K> mut& = &mut child_opt:data();
 
     // Check that the child's parent reference is correct.
     if !child.parent:has_value() or
         ref_to_addr(&child.parent:data()) != ref_to_addr(&node) {
-        return make_optional<int>();
+        return make<Optional<int>>();
     }
 
     if side == LEFT() {
         if child.key >= node.key {
-            return make_optional<int>();
+            return make<Optional<int>>();
         }
     }
     else {
         if child.key <= node.key {
-            return make_optional<int>();
+            return make<Optional<int>>();
         }
     }
 
     return child:is_valid_rb_tree_impl();
 }
 
-function [K] is_valid_rb_tree_impl : (node : RB_Node<K>&) -> Optional<int> = {
+function [K] is_valid_rb_tree_impl : (node : RB_Node<K> mut&) -> Optional<int> = {
     // Property 4: if a node is red, both of its children are black.
     if node.colour == RED() and (node.left:is_red() or node.right:is_red()) {
-        return make_optional<int>();
+        return make<Optional<int>>();
     }
 
     // Property 3: every leaf node (nil node) is black.
@@ -45,26 +45,26 @@ function [K] is_valid_rb_tree_impl : (node : RB_Node<K>&) -> Optional<int> = {
     // hold the same number of black nodes.
     let black_count_l : Optional<int> = node:child_is_valid_rb_tree(LEFT());
     if !black_count_l:has_value() {
-        return make_optional<int>();
+        return make<Optional<int>>();
     }
 
     let black_count_r : Optional<int> = node:child_is_valid_rb_tree(RIGHT());
     if !black_count_r:has_value() {
-        return make_optional<int>();
+        return make<Optional<int>>();
     }
 
     if black_count_l:data() != black_count_r:data() {
-        return make_optional<int>();
+        return make<Optional<int>>();
     }
 
     if node.colour == BLACK() {
-        return make_optional(black_count_l:data() + 1);
+        return make<Optional<int>>(black_count_l:data() + 1);
     }
 
     return black_count_l;
 }
 
-function [K] is_valid_rb_tree : (tree : RB_Tree<K>&) -> bool = {
+function [K] is_valid_rb_tree : (tree : RB_Tree<K> mut&) -> bool = {
     // Property 2: the root node is black.
     if tree.root:is_red() {
         return false;
@@ -79,8 +79,8 @@ function [K] is_valid_rb_tree : (tree : RB_Tree<K>&) -> bool = {
 }
 
 function main : () -> int = {
-    let tree : RB_Tree<int> = make<RB_Tree<int>>();
-    let n : int = 1000;
+    mut tree : RB_Tree<int> = make<RB_Tree<int>>();
+    mut n : int = 1000;
 
     for i in range(n) {
         tree:insert(i);

--- a/tests/stdlib/rb_tree/extended.c3
+++ b/tests/stdlib/rb_tree/extended.c3
@@ -2,56 +2,59 @@
 @require_once "std/iterators.c3"
 @require_once "std/wrappers.c3"
 
-function [K] is_valid_rb_tree_impl : (node : RB_Node<K>&) -> Optional<int> = {
-    if node.colour == RED() {
-        // Property 4: if a node is red, both of its children are black.
-        if node.left:is_red() or node.right:is_red() {
+function [K] child_is_valid_rb_tree: (
+    node : RB_Node<K>&, side : bool
+) -> Optional<int> = {
+    let child_opt : Optional<RB_Node<K>&> = node:get_child(side);
+
+    if !child_opt:has_value() {
+        return make_optional(1);
+    }
+
+    let child : RB_Node<K>& = &child_opt:data();
+
+    if side == LEFT() {
+        if child.key >= node.key {
             return make_optional<int>();
         }
+    }
+    else {
+        if child.key <= node.key {
+            return make_optional<int>();
+        }
+    }
+
+    return child:is_valid_rb_tree_impl();
+}
+
+function [K] is_valid_rb_tree_impl : (node : RB_Node<K>&) -> Optional<int> = {
+    // Property 4: if a node is red, both of its children are black.
+    if node.colour == RED() and (node.left:is_red() or node.right:is_red()) {
+        return make_optional<int>();
     }
 
     // Property 3: every leaf node (nil node) is black.
     // Property 5: starting from any node, all simple paths down to leaf nodes
     // hold the same number of black nodes.
-    let black_count_l : int = 1;
-    let black_count_r : int = 1;
-
-    if node.left:has_value() {
-        if node.left:data().key >= node.key {
-            return make_optional<int>();
-        }
-
-        let left_res : Optional<int> = node.left:data():is_valid_rb_tree_impl();
-        if left_res:has_value() {
-            black_count_l = left_res:data();
-        }
-        else {
-            return make_optional<int>();
-        }
+    let black_count_l : Optional<int> = node:child_is_valid_rb_tree(LEFT());
+    if !black_count_l:has_value() {
+        return make_optional<int>();
     }
 
-    if node.right:has_value() {
-        if node.right:data().key <= node.key {
-            return make_optional<int>();
-        }
-
-        let right_res : Optional<int> = node.right:data():is_valid_rb_tree_impl();
-        if right_res:has_value() {
-            black_count_r = right_res:data();
-        }
-        else {
-            return make_optional<int>();
-        }
+    let black_count_r : Optional<int> = node:child_is_valid_rb_tree(RIGHT());
+    if !black_count_r:has_value() {
+        return make_optional<int>();
     }
 
-    if black_count_l == black_count_r {
-        if node.colour == BLACK() {
-            black_count_l += 1;
-        }
-        return make_optional(black_count_l);
+    if black_count_l:data() != black_count_r:data() {
+        return make_optional<int>();
     }
 
-    return make_optional<int>();
+    if node.colour == BLACK() {
+        return make_optional(black_count_l:data() + 1);
+    }
+
+    return black_count_l;
 }
 
 function [K] is_valid_rb_tree : (tree : RB_Tree<K>&) -> bool = {

--- a/tests/stdlib/rb_tree/minmax.c3
+++ b/tests/stdlib/rb_tree/minmax.c3
@@ -2,8 +2,8 @@
 @require_once "std/iterators.c3"
 
 function main : () -> int = {
-    let tree : RB_Tree<int> = make<RB_Tree<int>>();
-    let res : Optional<int>;
+    mut tree : RB_Tree<int> = make<RB_Tree<int>>();
+    mut res : Optional<int>;
 
     for i in range(-10, 11) {
         tree:insert(i);

--- a/tests/stdlib/rb_tree/minmax.c3
+++ b/tests/stdlib/rb_tree/minmax.c3
@@ -1,0 +1,26 @@
+@require_once "std/rb_tree.c3"
+@require_once "std/iterators.c3"
+
+function main : () -> int = {
+    let tree : RB_Tree<int> = make<RB_Tree<int>>();
+    let res : Optional<int>;
+
+    for i in range(-10, 11) {
+        tree:insert(i);
+    }
+
+    res = tree:minimum();
+    if res:data() != -10 {
+        return 1;
+    }
+
+    res = tree:maximum();
+    if res:data() != 10 {
+        return 2;
+    }
+
+    return 0;
+}
+
+/// @COMPILE
+/// @RUN


### PR DESCRIPTION
Required for an efficient `map` container.

Insertion and search work, but we are missing ~~deletion and~~ the traversals.