### PR TITLE
Allow automatic initializer list type deduction

### DIFF
--- a/docs/types_overview.md
+++ b/docs/types_overview.md
@@ -5,8 +5,8 @@
 The syntax for aliasing types is:
 
 ```c
-typedef Name1 : TypeThatWeWantToAlias;
-typedef Name2 : TypeThatWeWantToAlias;
+typedef Name1 : TypeThatWeWantToAlias
+typedef Name2 : TypeThatWeWantToAlias
 ```
 `Name1`, `Name2`, and `TypeThatWeWantToAlias` are equivalent and can be used
 interchangeably in any context.
@@ -15,7 +15,7 @@ interchangeably in any context.
 
 The syntax for adding a generic parameter is:
 ```c
-typedef [T] Generic : TypeThatWeWantToAlias;
+typedef [T] Generic : TypeThatWeWantToAlias
 ```
 - The specialized type `Generic<GenericArgumentType>`, is equivalent to
 `TypeThatWeWantToAlias`, `Name1`, and `Name2`.
@@ -25,7 +25,7 @@ manually substituted into the aliased type.
 
 The syntax for overriding the alias for a specific specialization is:
 ```c
-typedef Generic<SpecializationType> : OtherType;
+typedef Generic<SpecializationType> : OtherType
 ```
 
 - When specialized with a type equivalent to `SpecializationType`,
@@ -36,17 +36,23 @@ when both are available.
 ## Reference Type
 
 The syntax for creating a new reference type is:
+```c
+DereferencedType&  // Immutable reference
+DereferencedType mut& // Mutable reference
 ```
-DereferencedType&
-```
-Two reference types are equivalent as long as each `DereferencedType` is also
-equivalent.
+Two reference types are equivalent if `DereferencedType` is equivalent and both
+mutabilities is the same.
 
 
 ## Array Type
 The syntax for creating a new array type is:
 ```
-MemberType[(Dimension 0 length or & for an unknown size), (Dimension 1 length), ... (Dimension N length)]
+// An array of a statically known size
+MemberType[(Dimension 0), (Dimension 1 length), ... (Dimension N length)]
+
+// An array of a dynamically determined runtime size
+MemberType[&, (Dimension 1 length), ... (Dimension N length)]
+MemberType[mut&, (Dimension 1 length), ... (Dimension N length)]
 ```
 
 - Two array types are equivalent if all of their dimensions are the same and
@@ -79,7 +85,7 @@ An initializer list has the following syntax:
 
 ```
 <as an expression>
-{member1: value1, ..., memberN, valueN} or {value1, ..., valueN}
+{.member1 = value1, ..., .memberN = valueN} or {value1, ..., valueN}
 ```
 
 
@@ -95,11 +101,11 @@ and the initializer list is used to initialize this new type.
 A function that can deduce its generic parameters takes one of the following
 syntaxes:
 ```
-function [T] name : (argument : T) -> ReturnType;
-function [T] name : (argument : GenericType<T>) -> ReturnType;
-function [T] name : (argument : T&) -> ReturnType;
-function [T] name : (argument : {member : T, ...}) -> ReturnType;
-function [T, N, M] name : (argument : T[N, M]) -> ReturnType;
+function [T] name : (argument : T) -> ReturnType = ...
+function [T] name : (argument : GenericType<T>) -> ReturnType = ...
+function [T] name : (argument : T&) -> ReturnType = ...
+function [T] name : (argument : {member : T, ...}) -> ReturnType = ...
+function [T, N, M] name : (argument : T[N, M]) -> ReturnType = ...
 ```
 NOTE: pattern matching can be nested.
 
@@ -122,28 +128,28 @@ let a : ... = ...;
 
 // Is exactly the same as:
 
-typedef __TYPE_OF_A = ...;
+typedef __TYPE_OF_A = ...
 let a : __TYPE_OF_A = ...;
 // NOTE: any type at any point in the program can be replaced with a unique
 // typedef alias to that type.
 ```
 
-```c
-typedef A : {};
-typedef B : {};
-typedef C : A;
+```js
+typedef A : {}
+typedef B : {}
+typedef C : A
 
-function takes_A(arg : A) -> void = {};
+function takes_A : (arg : A) -> void = {};
 
 takes_A(b_obj); // Error: B is a different struct, struct types are never
                 // equivalent
 takes_A(c_obj); // Good: A and C are the same struct due to the alias
 ```
 
-```c
+```js
 function function_with_temp_type : (
     arg: {a : int, b : int} /* Makes a new struct type */
-  ) -> void = {};
+  ) -> void = {}
 
 let object_1 : {a : int, b : int} /* Makes a new struct type */ = {a : 1, b : 2};
 let object_2 = {a : 1, b : 2}; // Initializer list is not implicitly converted
@@ -158,28 +164,28 @@ function_with_temp_type({a : 1, b : 2}); // Good: initializer list implicitly
                                          // converts to struct type
 ```
 
-```rust
-function[T] function_with_generic_type : (arg: {a : T, b : int}) -> void = {};
+```js
+function[T] function_with_generic_type : (arg: {a : T, b : int}) -> void = {}
 // function_with_generic_type can only match against an initializer list since
 // after substituting `T`, any struct would have a different type to the
 // argument (since we create a NEW struct type as the argument's type).
 ```
 
-```c
-typedef Type1<i16> : int;
+```js
+typedef Type1<i16> : int
 
-function[T] foo : (x: Type1<T>) -> T = {...};
+function[T] foo : (x: Type1<T>) -> T = {...}
 
-const val : int = 2;
+let val : int = 2;
 foo(val);  // Error: pattern match fails since `int` does not alias a `Type1`
            // specialization at any point -- even though they are equivalent for
            // `Type1<i16>`
 ```
 
-```c
-typedef[Len] string : u8[Len];
+```js
+typedef[Len] string : u8[Len]
 
-function[Len] puts : (str: u8[Len]&) -> int = {...};
+function[Len] puts : (str: u8[Len]&) -> int = {...}
 
 const str: string<2>& = "abXX";
 puts(&str);  // Good: pattern match succeeds since `string<2>` aliases `u8[2]`

--- a/src/glang/codegen/builtin_callables.py
+++ b/src/glang/codegen/builtin_callables.py
@@ -9,13 +9,13 @@ from .builtin_types import (
     IPtrType,
     SizeType,
 )
-from .expressions import ConstantExpression
+from .expressions import ConstantExpression, StaticTypedExpression
 from .interfaces import SpecializationItem, Type, TypedExpression
 from .type_conversions import do_implicit_conversion
 from .user_facing_errors import OperandError
 
 
-class BuiltinCallable(TypedExpression):
+class BuiltinCallable(StaticTypedExpression):
     @abstractmethod
     def __init__(
         self, specialization: list[SpecializationItem], arguments: list[TypedExpression]
@@ -35,11 +35,11 @@ class UnaryIntegerExpression(BuiltinCallable):
         assert self.IR_FORMAT_STR is not None
         assert len(specialization) == 0
 
-        definition = self._arg.underlying_type.definition
+        definition = self._arg.result_type.definition
         assert isinstance(definition, (IntegerDefinition, BoolDefinition))
 
-        self._arg_type = self._arg.underlying_type.convert_to_value_type()
-        TypedExpression.__init__(self, self._arg_type, Type.Kind.VALUE)
+        self._arg_type = self._arg.result_type.convert_to_value_type()
+        StaticTypedExpression.__init__(self, self._arg_type, Type.Kind.VALUE)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._arg})"
@@ -102,15 +102,17 @@ class BasicIntegerExpression(BuiltinCallable):
         assert self.SIGNED_IR is not None
         assert self.UNSIGNED_IR is not None
         assert len(specialization) == 0
-        lhs_definition = lhs.underlying_type.definition
-        rhs_definition = rhs.underlying_type.definition
+        lhs_definition = lhs.result_type.definition
+        rhs_definition = rhs.result_type.definition
         assert isinstance(lhs_definition, (IntegerDefinition, BoolDefinition))
         assert isinstance(rhs_definition, (IntegerDefinition, BoolDefinition))
-        assert lhs.underlying_type == rhs.underlying_type
+        assert lhs.result_type == rhs.result_type
 
-        TypedExpression.__init__(self, self.get_result_type(arguments), Type.Kind.VALUE)
+        StaticTypedExpression.__init__(
+            self, self.get_result_type(arguments), Type.Kind.VALUE
+        )
 
-        self._arg_type = lhs.underlying_type.convert_to_value_type()
+        self._arg_type = lhs.result_type.convert_to_value_type()
         self._lhs = lhs
         self._rhs = rhs
 
@@ -160,7 +162,7 @@ class BasicIntegerExpression(BuiltinCallable):
 class ArithmeticExpression(BasicIntegerExpression):
     @staticmethod
     def get_result_type(arguments: list[TypedExpression]) -> Type:
-        return arguments[0].underlying_type.convert_to_value_type()
+        return arguments[0].result_type.convert_to_value_type()
 
 
 class AddExpression(ArithmeticExpression):
@@ -264,7 +266,9 @@ class AlignOfExpression(BuiltinCallable):
             SizeType(), str(self._argument_type.alignment)
         )
 
-        TypedExpression.__init__(self, self._result.underlying_type, Type.Kind.VALUE)
+        StaticTypedExpression.__init__(
+            self, self._result.underlying_type, Type.Kind.VALUE
+        )
 
     def __repr__(self) -> str:
         return f"AlignOf({self._argument_type})"
@@ -296,7 +300,9 @@ class SizeOfExpression(BuiltinCallable):
 
         self._result = ConstantExpression(SizeType(), str(self._argument_type.size))
 
-        TypedExpression.__init__(self, self._result.underlying_type, Type.Kind.VALUE)
+        StaticTypedExpression.__init__(
+            self, self._result.underlying_type, Type.Kind.VALUE
+        )
 
     def __repr__(self) -> str:
         return f"SizeOf({self._argument_type})"
@@ -325,7 +331,7 @@ class NarrowExpression(BuiltinCallable):
         (return_type,) = specialization
         assert isinstance(return_type, Type)
 
-        self._arg_value_type = self._argument.underlying_type.convert_to_value_type()
+        self._arg_value_type = self._argument.result_type.convert_to_value_type()
 
         to_definition = return_type.definition
         from_definition = self._arg_value_type.definition
@@ -335,7 +341,7 @@ class NarrowExpression(BuiltinCallable):
         assert from_definition.bits > to_definition.bits
         assert from_definition.is_signed == to_definition.is_signed
 
-        TypedExpression.__init__(self, return_type, Type.Kind.VALUE)
+        StaticTypedExpression.__init__(self, return_type, Type.Kind.VALUE)
 
     def __repr__(self) -> str:
         return f"Narrow({self._argument} to {self.underlying_type})"
@@ -376,7 +382,7 @@ class PtrToIntExpression(BuiltinCallable):
         (self._src_expr,) = arguments
         assert self._src_expr.has_address
 
-        TypedExpression.__init__(self, IPtrType(), Type.Kind.VALUE)
+        StaticTypedExpression.__init__(self, IPtrType(), Type.Kind.VALUE)
 
     def __repr__(self) -> str:
         return f"PtrToInt({self._src_expr} to {self.underlying_type})"
@@ -415,9 +421,9 @@ class IntToPtrExpression(BuiltinCallable):
         assert self._ptr_type.storage_kind.is_reference()
 
         (self._src_expr,) = arguments
-        assert isinstance(self._src_expr.underlying_type, GenericIntType)
+        assert isinstance(self._src_expr.result_type, GenericIntType)
 
-        TypedExpression.__init__(
+        StaticTypedExpression.__init__(
             self, self._ptr_type.convert_to_value_type(), self._ptr_type.storage_kind
         )
 
@@ -427,7 +433,7 @@ class IntToPtrExpression(BuiltinCallable):
     def generate_ir(self, reg_gen: Iterator[int]) -> list[str]:
         # Remove any indirect references
         conv_src_expr, extra_exprs = do_implicit_conversion(
-            self._src_expr, self._src_expr.underlying_type
+            self._src_expr, self._src_expr.result_type
         )
 
         ir = self.expand_ir(extra_exprs, reg_gen)
@@ -464,7 +470,7 @@ class BitcastExpression(BuiltinCallable):
         (self._target_type,) = specialization
         assert isinstance(self._target_type, Type)
 
-        src_type = self._src_expr.underlying_type
+        src_type = self._src_expr.result_type
 
         # We can bitcast from ptr->ptr or non-aggregate->non-aggregate
         #  We can also bitcast away const
@@ -479,7 +485,7 @@ class BitcastExpression(BuiltinCallable):
 
         assert self._target_type.size == src_type.size
 
-        TypedExpression.__init__(
+        StaticTypedExpression.__init__(
             self,
             self._target_type.convert_to_value_type(),
             self._target_type.storage_kind,
@@ -491,7 +497,7 @@ class BitcastExpression(BuiltinCallable):
     def generate_ir(self, reg_gen: Iterator[int]) -> list[str]:
         # Remove any indirect references
         conv_src_expr, extra_exprs = do_implicit_conversion(
-            self._src_expr, self._src_expr.underlying_type
+            self._src_expr, self._src_expr.result_type
         )
 
         ir = self.expand_ir(extra_exprs, reg_gen)

--- a/src/glang/codegen/expressions.py
+++ b/src/glang/codegen/expressions.py
@@ -1,7 +1,10 @@
 from abc import abstractmethod
 from typing import Iterator, Optional
 
+from glang.codegen.interfaces import Type, TypedExpression
+
 from .builtin_types import (
+    AnonymousType,
     BoolType,
     FunctionSignature,
     HeapArrayDefinition,
@@ -11,7 +14,13 @@ from .builtin_types import (
     StructDefinition,
     format_array_dims_for_ir,
 )
-from .interfaces import Generatable, Type, TypedExpression, Variable
+from .interfaces import (
+    Generatable,
+    StaticTypedExpression,
+    Type,
+    TypedExpression,
+    Variable,
+)
 from .type_conversions import (
     assert_is_implicitly_convertible,
     do_implicit_conversion,
@@ -23,7 +32,6 @@ from .user_facing_errors import (
     CannotAssignToInitializerList,
     DoubleBorrowError,
     InvalidInitializerListConversion,
-    InvalidInitializerListDeduction,
     InvalidInitializerListLength,
     MutableBorrowOfNonMutable,
     OperandError,
@@ -31,7 +39,7 @@ from .user_facing_errors import (
 )
 
 
-class ConstantExpression(TypedExpression):
+class ConstantExpression(StaticTypedExpression):
     def __init__(self, cst_type: Type, value: str) -> None:
         super().__init__(cst_type, Type.Kind.VALUE)
 
@@ -53,7 +61,7 @@ class ConstantExpression(TypedExpression):
         raise OperandError(f"cannot modify the constant {self.value}")
 
 
-class VariableReference(TypedExpression):
+class VariableReference(StaticTypedExpression):
     def __init__(self, variable: Variable) -> None:
         # Calculate the constness
         # 1) If the variable refers to a reference, the storage MUST be const,
@@ -104,7 +112,7 @@ class VariableReference(TypedExpression):
         return ir
 
 
-class FunctionParameter(TypedExpression):
+class FunctionParameter(StaticTypedExpression):
     def __init__(self, expr_type: Type) -> None:
         super().__init__(expr_type, Type.Kind.VALUE)
 
@@ -128,7 +136,7 @@ class FunctionParameter(TypedExpression):
         assert False
 
 
-class FunctionCallExpression(TypedExpression):
+class FunctionCallExpression(StaticTypedExpression):
     def __init__(
         self, signature: FunctionSignature, args: list[TypedExpression]
     ) -> None:
@@ -189,24 +197,23 @@ class FunctionCallExpression(TypedExpression):
         pass
 
 
-class BorrowExpression(TypedExpression):
+class BorrowExpression(StaticTypedExpression):
     def __init__(self, expr: TypedExpression, is_explicitly_mutable: bool) -> None:
         self._expr = expr
 
-        if expr.underlying_type.storage_kind.is_reference():
-            raise DoubleBorrowError(expr.underlying_type.format_for_output_to_user())
+        rhs_type = expr.result_type
+        if rhs_type.storage_kind.is_reference():
+            raise DoubleBorrowError(rhs_type.format_for_output_to_user())
 
         if not expr.underlying_indirection_kind.is_reference():
-            raise BorrowWithNoAddressError(
-                expr.underlying_type.format_for_output_to_user()
-            )
+            raise BorrowWithNoAddressError(rhs_type.format_for_output_to_user())
 
         if expr.underlying_indirection_kind == Type.Kind.CONST_REF:
             # TODO: should a mutable borrow of a constant value give a constant borrow?
             if is_explicitly_mutable:
                 # TODO: is this error message sufficient?
                 raise MutableBorrowOfNonMutable(
-                    expr.get_equivalent_pure_type().format_for_output_to_user()
+                    expr.result_type_as_if_borrowed.format_for_output_to_user()
                 )
 
         self._is_mut = is_explicitly_mutable
@@ -219,7 +226,7 @@ class BorrowExpression(TypedExpression):
             expr.assert_can_write_to()
 
         super().__init__(
-            expr.underlying_type.convert_to_storage_type(storage_type), Type.Kind.VALUE
+            rhs_type.convert_to_storage_type(storage_type), Type.Kind.VALUE
         )
 
     def __repr__(self) -> str:
@@ -238,12 +245,12 @@ class BorrowExpression(TypedExpression):
         self._expr.assert_can_write_to()
 
 
-class StructMemberAccess(TypedExpression):
+class StructMemberAccess(StaticTypedExpression):
     def __init__(self, lhs: TypedExpression, member_name: str) -> None:
         self._member_name = member_name
         self._lhs = lhs
 
-        self._struct_type = lhs.underlying_type.convert_to_value_type()
+        self._struct_type = lhs.result_type.convert_to_value_type()
         underlying_definition = self._struct_type.definition
         if not isinstance(underlying_definition, StructDefinition):
             raise TypeCheckerError(
@@ -264,7 +271,7 @@ class StructMemberAccess(TypedExpression):
         if self._member_type.storage_kind.is_reference():
             storage_kind = self._member_type.storage_kind
         else:
-            storage_kind = lhs.get_equivalent_pure_type().storage_kind
+            storage_kind = lhs.result_type_as_if_borrowed.storage_kind
 
         super().__init__(self._member_type.convert_to_value_type(), storage_kind)
 
@@ -313,7 +320,7 @@ class StructMemberAccess(TypedExpression):
 
     def __repr__(self) -> str:
         return (
-            f"StructMemberAccess({self.underlying_type.format_for_output_to_user()}"
+            f"StructMemberAccess({self._struct_type.format_for_output_to_user()}"
             f".{self._member_name}: {self.underlying_type})"
         )
 
@@ -330,14 +337,14 @@ class StructMemberAccess(TypedExpression):
         # TODO: check if the reference is const
 
 
-class ArrayIndexAccess(TypedExpression):
+class ArrayIndexAccess(StaticTypedExpression):
     def __init__(
         self, array_ptr: TypedExpression, indices: list[TypedExpression]
     ) -> None:
         # NOTE: needs address since getelementptr must be used for runtime indexing
         assert array_ptr.has_address
 
-        self._type_of_array: Type = array_ptr.underlying_type.convert_to_value_type()
+        self._type_of_array: Type = array_ptr.result_type.convert_to_value_type()
         self._array_ptr = array_ptr
 
         array_definition = self._type_of_array.definition
@@ -346,7 +353,7 @@ class ArrayIndexAccess(TypedExpression):
         ):
             raise TypeCheckerError(
                 "array index access",
-                array_ptr.underlying_type.format_for_output_to_user(),
+                array_ptr.format_for_output_to_user(),
                 "T[...]",
             )
 
@@ -375,9 +382,9 @@ class ArrayIndexAccess(TypedExpression):
             self._indices.append(index_expr)
             self._conversion_exprs.extend(conversions)
 
-        pure_type = array_ptr.get_equivalent_pure_type()
+        result_type = array_ptr.result_type_as_if_borrowed
         super().__init__(
-            self._element_type.convert_to_value_type(), pure_type.storage_kind
+            self._element_type.convert_to_value_type(), result_type.storage_kind
         )
 
     def generate_ir(self, reg_gen: Iterator[int]) -> list[str]:
@@ -434,7 +441,7 @@ class ArrayIndexAccess(TypedExpression):
         self._array_ptr.assert_can_write_to()
 
 
-class ArrayInitializer(TypedExpression):
+class ArrayInitializer(StaticTypedExpression):
     def __init__(self, array_type: Type, element_exprs: list[TypedExpression]) -> None:
         assert array_type.storage_kind == Type.Kind.VALUE
         assert isinstance(array_type.definition, StackArrayDefinition)
@@ -470,7 +477,7 @@ class ArrayInitializer(TypedExpression):
         for index, value in enumerate(self._elements):
             current_ref = f"%{next(reg_gen)}"
             ir.append(
-                f"{current_ref} = insertvalue {self.underlying_type.ir_type} {previous_ref}, "
+                f"{current_ref} = insertvalue {self.ir_type_annotation} {previous_ref}, "
                 f"{value.ir_ref_with_type_annotation}, {index}"
             )
 
@@ -494,7 +501,7 @@ class ArrayInitializer(TypedExpression):
         raise OperandError("cannot modify temporary array")
 
 
-class StructInitializer(TypedExpression):
+class StructInitializer(StaticTypedExpression):
     def __init__(self, struct_type: Type, member_exprs: list[TypedExpression]) -> None:
         assert struct_type.storage_kind == Type.Kind.VALUE
         assert isinstance(struct_type.definition, StructDefinition)
@@ -529,7 +536,7 @@ class StructInitializer(TypedExpression):
         for index, value in enumerate(self._members):
             current_ref = f"%{next(reg_gen)}"
             ir.append(
-                f"{current_ref} = insertvalue {self.underlying_type.ir_type} {previous_ref}, "
+                f"{current_ref} = insertvalue {self.ir_type_annotation} {previous_ref}, "
                 f"{value.ir_ref_with_type_annotation}, {index}"
             )
 
@@ -554,16 +561,13 @@ class StructInitializer(TypedExpression):
 
 
 class InitializerList(TypedExpression):
-    @abstractmethod
-    def format_for_output_to_user(self) -> str:
-        pass
-
-    def get_equivalent_pure_type(self) -> Type:
-        assert False
+    @property
+    def has_address(self) -> bool:
+        return False
 
     @property
-    def underlying_type(self) -> Type:
-        raise InvalidInitializerListDeduction(self.format_for_output_to_user())
+    def ir_type_annotation(self) -> str:
+        assert False
 
     @property
     def ir_ref_without_type_annotation(self) -> str:
@@ -592,14 +596,20 @@ class InitializerList(TypedExpression):
 
 class NamedInitializerList(InitializerList):
     def __init__(self, members: list[TypedExpression], names: list[str]) -> None:
-        super().__init__(None, Type.Kind.VALUE)
-
+        super().__init__(Type.Kind.VALUE)
         self._members = dict(zip(names, members, strict=True))
+
+    @property
+    def result_type(self) -> Type:
+        struct_items = [
+            (name, expr.result_type) for name, expr in self._members.items()
+        ]
+        return AnonymousType(StructDefinition(struct_items))
 
     def format_for_output_to_user(self) -> str:
         members = [
-            f"{name}: {type_name.underlying_type.format_for_output_to_user()}"
-            for name, type_name in self._members.items()
+            f"{name}: {expr.format_for_output_to_user()}"
+            for name, expr in self._members.items()
         ]
         return "{" + ", ".join(members) + "}"
 
@@ -628,15 +638,19 @@ class NamedInitializerList(InitializerList):
 
 class UnnamedInitializerList(InitializerList):
     def __init__(self, members: list[TypedExpression]) -> None:
-        super().__init__(None, Type.Kind.VALUE)
+        super().__init__(Type.Kind.VALUE)
 
         self._members = members
 
-    def format_for_output_to_user(self) -> str:
-        type_names = [
-            member.underlying_type.format_for_output_to_user()
-            for member in self._members
+    @property
+    def result_type(self) -> Type:
+        struct_items = [
+            (str(index), expr.result_type) for index, expr in enumerate(self._members)
         ]
+        return AnonymousType(StructDefinition(struct_items))
+
+    def format_for_output_to_user(self) -> str:
+        type_names = [member.format_for_output_to_user() for member in self._members]
         return "{" + ", ".join(type_names) + "}"
 
     def __repr__(self) -> str:
@@ -676,7 +690,7 @@ class UnnamedInitializerList(InitializerList):
         return super().try_convert_to_type(other)
 
 
-class LogicalOperator(TypedExpression):
+class LogicalOperator(StaticTypedExpression):
     def __init__(
         self,
         operator: str,

--- a/src/glang/codegen/expressions.py
+++ b/src/glang/codegen/expressions.py
@@ -1,8 +1,6 @@
 from abc import abstractmethod
 from typing import Iterator, Optional
 
-from glang.codegen.interfaces import Type, TypedExpression
-
 from .builtin_types import (
     AnonymousType,
     BoolType,

--- a/src/glang/codegen/interfaces.py
+++ b/src/glang/codegen/interfaces.py
@@ -326,6 +326,11 @@ class GenericMapping:
     mapping: dict[GenericArgument, SpecializationItem]
     pack: list[Type]
 
+    def __add__(self, other: Any) -> "GenericMapping":
+        assert isinstance(other, GenericMapping)
+        assert len(self.pack) == 0 or len(other.pack) == 0
+        return GenericMapping({**self.mapping, **other.mapping}, self.pack + other.pack)
+
 
 def do_specializations_match(
     s1: list[SpecializationItem], s2: list[SpecializationItem]

--- a/src/glang/codegen/type_resolution.py
+++ b/src/glang/codegen/type_resolution.py
@@ -668,11 +668,10 @@ class UnresolvedFunctionSignature:
     parameter_pack_argument_name: Optional[str]
     return_type: UnresolvedType
 
-    def collapse_into_type(self, arg: TypedExpression | Type) -> Type:
-        if isinstance(arg, InitializerList):
-            raise NotImplementedError()
+    @staticmethod
+    def collapse_into_type(arg: TypedExpression | Type) -> Type:
         if isinstance(arg, TypedExpression):
-            return arg.underlying_type
+            return arg.result_type
         if isinstance(arg, Type):
             return arg
 
@@ -789,12 +788,6 @@ class UnresolvedFunctionSignature:
         ):
             if len(unresolved_arg.get_generics_taking_part_in_pattern_match()) == 0:
                 continue  # Allow for implicit conversions + type equivalency
-
-            if isinstance(target_arg, InitializerList):
-                # See: `docs/types_overview.c3`
-                # TODO: we should convert this to an anonymous struct
-                #   for now we just ignore initializer lists
-                continue
 
             arg_type = self.collapse_into_type(target_arg)
             result = unresolved_arg.pattern_match(arg_type, out, depth + 1)

--- a/src/glang/codegen/user_facing_errors.py
+++ b/src/glang/codegen/user_facing_errors.py
@@ -128,7 +128,7 @@ class PatternMatchDeductionFailure(GrapheneError):
     def __init__(self, fn_name: str, unmatched_generic: str) -> None:
         super().__init__(
             f"Error: cannot deduce generic type '{unmatched_generic}' "
-            f"in function '{fn_name}', manual specialization is required"
+            f"in '{fn_name}', manual specialization is required"
         )
 
 
@@ -332,14 +332,6 @@ class InvalidInitializerListConversion(TypeCheckerError):
         super(GrapheneError, self).__init__(
             f"Error: initializer list of the form '{init_list_name}' cannot be "
             f"converted to '{struct_type}'"
-        )
-
-
-class InvalidInitializerListDeduction(TypeCheckerError):
-    def __init__(self, init_list_name: str) -> None:
-        super(GrapheneError, self).__init__(
-            "Error: cannot deduce the destination type for initializer list "
-            f"'{init_list_name}' without a strongly typed context"
         )
 
 

--- a/src/glang/graphene_parser.py
+++ b/src/glang/graphene_parser.py
@@ -419,7 +419,7 @@ class FlattenedExpression:
         return self.subexpressions[-1]
 
     def type(self) -> cg.Type:
-        return self.expression().underlying_type
+        return self.expression().result_type
 
 
 def is_flattened_expression_iterable(
@@ -593,9 +593,9 @@ class ExpressionParser(lp.Interpreter):
             elif indirection_kind == cg.Type.Kind.VALUE:
                 # (&a):fn(), (&mut a):fn(), or rvalue():fn();
                 # We do not allow the 3rd option
-                pure = this_arg.expression().get_equivalent_pure_type()
-                if pure.storage_kind == cg.Type.Kind.VALUE:
-                    raise BorrowWithNoAddressError(pure.format_for_output_to_user())
+                possible = this_arg.expression().result_type_as_if_borrowed
+                if possible.storage_kind == cg.Type.Kind.VALUE:
+                    raise BorrowWithNoAddressError(possible.format_for_output_to_user())
             else:
                 assert False
 
@@ -836,7 +836,7 @@ def generate_for_statement(
     inner_scope.add_generatable(get_next_expr)
 
     iter_result_variable = cg.StackVariable(
-        node.variable, get_next_expr.underlying_type, False, True
+        node.variable, get_next_expr.result_type, False, True
     )
     inner_scope.add_variable(iter_result_variable)
     inner_scope.add_generatable(

--- a/tests/generic_functions/deduction_failure.c3
+++ b/tests/generic_functions/deduction_failure.c3
@@ -7,4 +7,4 @@ function main : () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 4, in 'function main: () -> int'
-/// Error: cannot deduce generic type 'T' in function 'hello<T> : () -> void', manual specialization is required
+/// Error: cannot deduce generic type 'T' in 'function [[]T[]] hello<T> : () -> void', manual specialization is required

--- a/tests/generic_functions/generic_deduction_ignores_initializer_list.c3
+++ b/tests/generic_functions/generic_deduction_ignores_initializer_list.c3
@@ -1,0 +1,16 @@
+typedef A : {}
+typedef B : {}
+
+function make<A> : (val : A) -> A = { return {};}
+
+function [@Len] make<B> : (buffer : u8[@Len]&) -> B = {
+    return {};
+}
+
+function main : () -> int = {
+    let a : A = make<A>({});
+    return 0;
+}
+
+/// @COMPILE
+/// @RUN

--- a/tests/generic_functions/implicit_conversion_after_specialization.c3
+++ b/tests/generic_functions/implicit_conversion_after_specialization.c3
@@ -1,0 +1,11 @@
+function [T] a : (a : T) -> isize = {
+    return a;
+}
+
+function main : () -> int = {
+    a<isize>(8);
+    return 0;
+}
+
+/// @COMPILE
+/// @RUN

--- a/tests/structs/init_list_implicit_struct.c3
+++ b/tests/structs/init_list_implicit_struct.c3
@@ -1,0 +1,7 @@
+function main : () -> int = {
+    let a : {val : int, sign : bool} = {0, false};
+    return a.val;
+}
+
+/// @COMPILE
+/// @RUN

--- a/tests/structs/init_list_to_adhoc_struct_parameter.c3
+++ b/tests/structs/init_list_to_adhoc_struct_parameter.c3
@@ -1,0 +1,10 @@
+function test : (param : {a : int, b : int}) -> int = {
+    return param.a;
+}
+
+function main : () -> int = {
+    return test({1, 7});
+}
+
+/// @COMPILE
+/// @RUN; EXPECT 1

--- a/tests/structs/initializer_list_function_call_templated.c3
+++ b/tests/structs/initializer_list_function_call_templated.c3
@@ -1,13 +1,10 @@
-typedef MyStruct : {a: int, x: int}
-
 function[T] get_x : (struct : T) -> int = {
     return struct.x;
 }
 
 function main : () -> int = {
-    return get_x({11, 12});
+    return get_x({.x = 11, .y = 12});
 }
 
-/// @COMPILE; EXPECT ERR
-/// File '*.c3', line 8, in 'function main: () -> int'
-/// Error: cannot deduce generic type 'T' in function 'get_x<T> : (T) -> int', manual specialization is required
+/// @COMPILE
+/// @RUN; EXPECT 11

--- a/tests/structs/pattern_match_init_list.c3
+++ b/tests/structs/pattern_match_init_list.c3
@@ -1,0 +1,10 @@
+function [T1, T2] test : (param : {a : T1, b : isize, c : T2}) -> T1 = {
+    return param.a;
+}
+
+function main : () -> int = {
+    return test({.a = 100, .b = 8, .c={1}});
+}
+
+/// @COMPILE
+/// @RUN; EXPECT 100

--- a/tests/structs/pattern_match_init_list_fail.c3
+++ b/tests/structs/pattern_match_init_list_fail.c3
@@ -1,0 +1,14 @@
+function [U, V] test : (param : {a : U, b : V}) -> U = {
+    return param.a;
+}
+
+function main : () -> int = {
+    // Fails because layout would be incorrect
+    return test({.b = 50, .a = 100});
+}
+
+/// @COMPILE; EXPECT ERR
+/// File '*.c3', line 7, in 'function main: () -> int'
+/// Error: overload resolution for function call 'test({b: int, a: int})' failed
+/// Available overloads:
+/// - function [[]U, V[]] test<U, V> : ({ a: U, b: V }) -> U

--- a/tests/structs/struct_to_adhoc_struct_parameter.c3
+++ b/tests/structs/struct_to_adhoc_struct_parameter.c3
@@ -1,0 +1,16 @@
+typedef Struct : {a : int, b : int}
+
+function test : (param : {a : int, b : int}) -> int = {
+    return param.a;
+}
+
+function main : () -> int = {
+    let struct : Struct = {1, 1};
+    return test(struct);
+}
+
+/// @COMPILE; EXPECT ERR
+/// File '*.c3', line 9, in 'function main: () -> int'
+/// Error: overload resolution for function call 'test(Struct)' failed
+/// Available overloads:
+/// - function test : ({ a: int, b: int }) -> int


### PR DESCRIPTION
Initializer lists have no `underlying_type` despite being a `TypedExpression`.  This made the whole interface kind of confusing to use. Now `TypedExpression` no longer requires an underlying type, instead, it has a `result_type` (which is the type an expression would collapse to if no implicit conversion was executed).

This fixes #124 and a few other confusing template/ initializer list interactions.

These fixes allow us to *finally* match the type behavior described in the docs (namely initializer lists creating new "compatible" structs).

These fixes also exposed the awkward behavior where implicit conversion is disabled when using specialized templates so I had to fix this for the parser to compile.

```
function [T] fn : (a : T, b : T) -> ...
fn<isize>(8, 8); // 8 is now implicitly converted to isize due to the explicit specialization
fn(8, isize(8)) // The function fails to specialize since this would require an implicit conversion.
```

As a bonus, this makes something like `&any` very easy to implement... It would just be a `TypedExpression` that collapses into the best reference type available but can also be implicitly converted to any reference type.