### PR TITLE
Small QoL improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Python: driver with demo.c3",
             "type": "python",
             "request": "launch",
-            "program": "driver.py",
+            "module": "src.glang.driver",
             "console": "integratedTerminal",
             "justMyCode": true,
             "args": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ lint = ["pylint $(git ls-files \\*.py)"]
 dependencies = ["interegular~=0.3.2", "lark~=1.1.7"]
 
 [tool.hatch.envs.test.scripts]
-run = "python tests/run_tests.py"
+run = "python tests/run_tests.py {args}"
 
 
 # Style environment. Does not depend on the project.

--- a/src/glang/codegen/builtin_types.py
+++ b/src/glang/codegen/builtin_types.py
@@ -10,7 +10,6 @@ from .interfaces import SpecializationItem, Type, TypeDefinition, format_special
 from .user_facing_errors import (
     ArrayDimensionError,
     FailedLookupError,
-    GrapheneError,
     InvalidIntSize,
     VoidArrayDeclaration,
     VoidStructDeclaration,
@@ -26,11 +25,8 @@ class PlaceholderDefinition(TypeDefinition):
         assert False
 
     def copy_with_storage_kind(self, parent: Type, kind: Type.Kind) -> Type:
-        if kind.is_reference():
-            return AnonymousType(
-                ReferenceDefinition(parent, kind == Type.Kind.MUTABLE_REF)
-            )
-        assert False
+        assert kind.is_reference()
+        return AnonymousType(ReferenceDefinition(parent, kind))
 
     @property
     def is_finite(self) -> bool:
@@ -159,13 +155,14 @@ class ValueTypeDefinition(TypeDefinition):
     def copy_with_storage_kind(self, parent: Type, kind: Type.Kind) -> Type:
         assert self.storage_kind != kind
         assert kind.is_reference()
-        return AnonymousType(ReferenceDefinition(parent, kind == Type.Kind.MUTABLE_REF))
+        return AnonymousType(ReferenceDefinition(parent, kind))
 
 
 class PtrTypeDefinition(TypeDefinition):
-    def __init__(self, is_mut: bool) -> None:
+    def __init__(self, storage_kind: Type.Kind) -> None:
         super().__init__()
-        self.is_mut = is_mut
+        # Illegal value types are allowed (used by arrays).
+        self._storage_kind = storage_kind
 
     @abstractmethod
     def copy_with_storage_kind(self, _: Type, kind: Type.Kind) -> Type:
@@ -189,9 +186,11 @@ class PtrTypeDefinition(TypeDefinition):
 
     @property
     def storage_kind(self) -> Type.Kind:
-        if self.is_mut:
-            return Type.Kind.MUTABLE_REF
-        return Type.Kind.CONST_REF
+        return self._storage_kind
+
+    @property
+    def is_mut(self) -> bool:
+        return self.storage_kind.is_mutable_reference()
 
 
 class PrimitiveDefinition(ValueTypeDefinition):
@@ -461,8 +460,9 @@ class StackArrayDefinition(ValueTypeDefinition):
 
 
 class ReferenceDefinition(PtrTypeDefinition):
-    def __init__(self, value_type: Type, is_mut: bool) -> None:
-        super().__init__(is_mut)
+    def __init__(self, value_type: Type, storage_kind: Type.Kind) -> None:
+        assert storage_kind.is_reference()
+        super().__init__(storage_kind)
 
         # TODO: user-facing error
         assert not value_type.storage_kind.is_reference()
@@ -472,8 +472,12 @@ class ReferenceDefinition(PtrTypeDefinition):
         if kind == Type.Kind.VALUE:
             return self.value_type
 
-        assert kind == self.storage_kind
-        return parent
+        if kind == self.storage_kind:
+            return parent
+
+        assert self.storage_kind == Type.Kind.MUTABLE_OR_CONST_REF
+
+        return AnonymousType(ReferenceDefinition(self.value_type, kind))
 
     def are_equivalent(self, other: TypeDefinition) -> bool:
         if not isinstance(other, ReferenceDefinition):
@@ -498,7 +502,7 @@ class HeapArrayDefinition(PtrTypeDefinition):
     def __init__(
         self, member: Type, known_dimensions: list[int], storage: Type.Kind
     ) -> None:
-        super().__init__(storage == Type.Kind.MUTABLE_REF)
+        super().__init__(storage)
 
         self.member = member
         self.known_dimensions = known_dimensions

--- a/src/glang/codegen/generatable.py
+++ b/src/glang/codegen/generatable.py
@@ -412,7 +412,7 @@ class Assignment(Generatable):
         if not storage_kind.is_reference():
             raise AssignmentToNonPointerError(dst.format_for_output_to_user())
 
-        if storage_kind == Type.Kind.CONST_REF:
+        if not storage_kind.is_mutable_reference():
             raise CannotAssignToAConstant(
                 dst.result_type_as_if_borrowed.format_for_output_to_user()
             )

--- a/src/glang/codegen/interfaces.py
+++ b/src/glang/codegen/interfaces.py
@@ -64,9 +64,14 @@ class Type(ABC):
         VALUE = 1
         MUTABLE_REF = 2
         CONST_REF = 3
+        # Mutable reference, but implicitly convertible to a const reference.
+        MUTABLE_OR_CONST_REF = 4
 
         def is_reference(self) -> bool:
             return self != Type.Kind.VALUE
+
+        def is_mutable_reference(self) -> bool:
+            return self in (self.MUTABLE_REF, self.MUTABLE_OR_CONST_REF)
 
     def __init__(self, definition: TypeDefinition) -> None:
         self.definition = definition

--- a/src/glang/codegen/translation_unit.py
+++ b/src/glang/codegen/translation_unit.py
@@ -68,7 +68,13 @@ class Function:
         self._parameters.append(fn_param)
         self.top_level_scope.add_generatable(fn_param)
 
-        fn_param_var = StackVariable(param_name, param_type, False, True)
+        # Allow assignments to parameters passed by value (but our references
+        # still need to be immutable).
+        is_value_type = param_type.storage_kind == Type.Kind.VALUE
+
+        fn_param_var = StackVariable(
+            param_name, param_type, is_mutable=is_value_type, initialized=True
+        )
         self.top_level_scope.add_variable(fn_param_var)
 
         fn_param_var_assignment = VariableInitialize(fn_param_var, fn_param)

--- a/src/glang/codegen/type_resolution.py
+++ b/src/glang/codegen/type_resolution.py
@@ -368,7 +368,11 @@ class UnresolvedReferenceType(UnresolvedType):
         if target.storage_kind == Type.Kind.VALUE:
             return None
 
-        if (target.storage_kind == Type.Kind.MUTABLE_REF) != self.is_mutable:
+        if (
+            target.storage_kind.is_reference()
+            and target.storage_kind != Type.Kind.MUTABLE_OR_CONST_REF
+            and (target.storage_kind == Type.Kind.MUTABLE_REF) != self.is_mutable
+        ):
             return None
 
         if isinstance(target.definition, HeapArrayDefinition):
@@ -552,8 +556,11 @@ class UnresolvedHeapArrayType(UnresolvedType):
         if not isinstance(target.definition, HeapArrayDefinition):
             return None
 
-        # TODO: do we pattern match mutable refs into constant refs?
-        if (target.storage_kind == Type.Kind.MUTABLE_REF) != self.is_mutable:
+        if (
+            target.storage_kind.is_reference()
+            and target.storage_kind != Type.Kind.MUTABLE_OR_CONST_REF
+            and (target.storage_kind == Type.Kind.MUTABLE_REF) != self.is_mutable
+        ):
             return None
 
         if len(self.known_dimensions) != len(target.definition.known_dimensions):

--- a/tests/constants/ufcs.c3
+++ b/tests/constants/ufcs.c3
@@ -1,21 +1,24 @@
-// I don't particually like this, I think I'll change it to something smarter later
+@require_once "std/arithmetic.c3"
 
-typedef A : {
-    a : int
+typedef A : {}
+
+function foo : (a : A&) -> int = {
+    return 0;
 }
 
+function bar : (a : A&) -> int = {
+    return 1;
+}
 
-function run : (a : A&) -> int = {
-    return a.a;
+function bar : (a : A mut&) -> int = {
+    return 0;
 }
 
 function main : () -> int = {
-    mut a : A = {1};
-    return a:run();
+    mut a : A = {};
+    // Can match with A&, but should prefer A mut&.
+    return a:foo() + a:bar();
 }
 
-/// @COMPILE; EXPECT ERR
-/// File '*.c3', line 14, in 'function main: () -> int'
-/// Error: overload resolution for function call 'run(A mut&)' failed
-/// Available overloads:
-/// - function run : (A&) -> int
+/// @COMPILE
+/// @RUN

--- a/tests/misc/arguments_are_mutable.c3
+++ b/tests/misc/arguments_are_mutable.c3
@@ -1,0 +1,10 @@
+function main : (argc : int, argv : u8[&][&]) -> int = {
+    // We test two things
+    // - argc is mutable
+    // - argv is immutable (tested implicitly, otherwise this wouldn't compile)
+    argc = 1;
+    return 0;
+}
+
+/// @COMPILE
+/// @RUN


### PR DESCRIPTION
- Function arguments that were passed by value should be mutable
- Handle arguments passed to `hatch run test:run`
- Allow UFCS calls to match with both `mut&` and `&` (`mut&` preferred)
- Fix debug configuration