### PR TITLE
Emit basic debugging information

### DIFF
--- a/.github/workflows/graphene_tests.yml
+++ b/.github/workflows/graphene_tests.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install Python 3.11
       run: |
         sudo apt-get update
-        sudo apt-get install -y $PYTHON_CMD $PYTHON_CMD-venv
-        $PYTHON_CMD -m venv venv/bin/activate
+        sudo apt-get install -y $PYTHON_CMD
     - name: Install hatch
       run: |
         $PYTHON_CMD -m pip install --upgrade pip

--- a/.github/workflows/graphene_tests.yml
+++ b/.github/workflows/graphene_tests.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       GRAPHENE_CLANG_CMD: clang-${{ matrix.llvm-version }}
       GRAPHENE_LLI_CMD: lli-${{ matrix.llvm-version }}
+      PYTHON_CMD: python3.11
 
     steps:
     - name: Checkout
@@ -26,12 +27,12 @@ jobs:
     - name: Install Python 3.11
       run: |
         sudo apt-get update
-        sudo apt-get install -y python3.11 python3.11-venv
-        python3.11 -m venv venv/bin/activate
+        sudo apt-get install -y $PYTHON_CMD $PYTHON_CMD-venv
+        $PYTHON_CMD -m venv venv/bin/activate
     - name: Install hatch
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install hatch
+        $PYTHON_CMD -m pip install --upgrade pip
+        $PYTHON_CMD -m pip install hatch
     - name: Install clang and lli
       run: |
         wget https://apt.llvm.org/llvm.sh

--- a/src/glang/codegen/__init__.py
+++ b/src/glang/codegen/__init__.py
@@ -6,6 +6,7 @@ from .builtin_types import (
     UIntType,
     VoidType,
 )
+from .debug import DIFile
 from .expressions import (
     ArrayIndexAccess,
     BorrowExpression,

--- a/src/glang/codegen/builtin_callables.py
+++ b/src/glang/codegen/builtin_callables.py
@@ -69,9 +69,9 @@ class UnaryIntegerExpression(BuiltinCallable):
             }
         )
 
-        di_location = self.add_di_location(ctx, ir_output)
+        dbg = self.add_di_location(ctx, ir_output)
 
-        ir_output.lines.append(f"%{self.result_reg} = {op}, !dbg !{di_location.id}")
+        ir_output.lines.append(f"%{self.result_reg} = {op}, {dbg}")
         return ir_output
 
     @property
@@ -154,13 +154,13 @@ class BasicIntegerExpression(BuiltinCallable):
             assert isinstance(self._arg_type.definition, BoolDefinition)
             ir = self.UNSIGNED_IR
 
-        di_location = self.add_di_location(ctx, ir_output)
+        dbg = self.add_di_location(ctx, ir_output)
 
         # eg. for addition
         # <result> = add [nuw] [nsw] <ty> <op1>, <op2>  ; yields ty:result
         ir_output.lines.append(
             f"%{self.result_reg} = {ir} {conv_lhs.ir_ref_with_type_annotation}, "
-            f"{conv_rhs.ir_ref_without_type_annotation}, !dbg !{di_location.id}"
+            f"{conv_rhs.ir_ref_without_type_annotation}, {dbg}"
         )
 
         return ir_output
@@ -374,13 +374,13 @@ class NarrowExpression(BuiltinCallable):
         )
         ir_output = self.expand_ir(extra_exprs_arg, ctx)
 
-        di_location = self.add_di_location(ctx, ir_output)
+        dbg = self.add_di_location(ctx, ir_output)
 
         self.result_reg = ctx.next_reg()
 
         ir_output.lines.append(
             f"%{self.result_reg} = trunc {conv_arg.ir_ref_with_type_annotation}"
-            f" to {self.underlying_type.ir_type}, !dbg !{di_location.id}"
+            f" to {self.underlying_type.ir_type}, {dbg}"
         )
 
         return ir_output
@@ -422,12 +422,12 @@ class PtrToIntExpression(BuiltinCallable):
 
         self.result_reg = ctx.next_reg()
 
-        di_location = self.add_di_location(ctx, ir_output)
+        dbg = self.add_di_location(ctx, ir_output)
 
         # <result> = ptrtoint <ty> <value> to <ty2>
         ir_output.lines.append(
             f"%{self.result_reg} = ptrtoint {self._src_expr.ir_ref_with_type_annotation}"
-            f" to {self.underlying_type.ir_type}, !dbg !{di_location.id}"
+            f" to {self.underlying_type.ir_type}, {dbg}"
         )
 
         return ir_output
@@ -480,12 +480,12 @@ class IntToPtrExpression(BuiltinCallable):
 
         self.result_reg = ctx.next_reg()
 
-        di_location = self.add_di_location(ctx, ir)
+        dbg = self.add_di_location(ctx, ir)
 
         # <result> = inttoptr <ty> <value> to <ty2>
         ir.lines.append(
             f"%{self.result_reg} = inttoptr {conv_src_expr.ir_ref_with_type_annotation}"
-            f" to {self.ir_type_annotation}, !dbg !{di_location.id}"
+            f" to {self.ir_type_annotation}, {dbg}"
         )
 
         return ir
@@ -557,12 +557,12 @@ class BitcastExpression(BuiltinCallable):
 
         self.result_ref = f"%{ctx.next_reg()}"
 
-        di_location = self.add_di_location(ctx, ir)
+        dbg = self.add_di_location(ctx, ir)
 
         # <result> = bitcast <ty> <value> to <ty2>
         ir.lines.append(
             f"{self.result_ref} = bitcast {conv_src_expr.ir_ref_with_type_annotation}"
-            f" to {self.ir_type_annotation}, !dbg !{di_location.id}",
+            f" to {self.ir_type_annotation}, {dbg}",
         )
 
         return ir

--- a/src/glang/codegen/builtin_callables.py
+++ b/src/glang/codegen/builtin_callables.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from typing import Iterator
 
 from ..parser.lexer_parser import Meta
 from .builtin_types import (
@@ -10,7 +9,6 @@ from .builtin_types import (
     IPtrType,
     SizeType,
 )
-from .debug import DISubprogram
 from .expressions import ConstantExpression, StaticTypedExpression
 from .interfaces import IRContext, IROutput, SpecializationItem, Type, TypedExpression
 from .type_conversions import do_implicit_conversion

--- a/src/glang/codegen/builtin_callables.py
+++ b/src/glang/codegen/builtin_callables.py
@@ -56,7 +56,6 @@ class UnaryExpression(BuiltinCallable):
 
     def generate_ir(self, ctx: IRContext) -> IROutput:
         # https://llvm.org/docs/LangRef.html#add-instruction (and below)
-        # https://llvm.org/docs/LangRef.html#add-instruction (and below)
         conv, extra_exprs = do_implicit_conversion(self._arg, self._arg_type)
 
         ir_output = IROutput()

--- a/src/glang/codegen/builtin_types.py
+++ b/src/glang/codegen/builtin_types.py
@@ -475,7 +475,6 @@ class StructDefinition(ValueTypeDefinition):
             None,
         )
 
-        # FIXME struct name (guess we have to pass it from the wrapping type?).
         other_metadata: list[Metadata] = []
         di_derived_types: list[DIDerivedType] = []
         curr_offset = 0
@@ -551,7 +550,6 @@ class StackArrayDefinition(ValueTypeDefinition):
         return get_abi().compute_stack_array_alignment(self.size, self.member.alignment)
 
     def to_di_type(self, metadata_gen: Iterator[int]) -> list[Metadata]:
-        # FIXME array name.
         base_type_metadata = self.member.to_di_type(metadata_gen)
         assert isinstance(base_type_metadata[-1], DIType)
 

--- a/src/glang/codegen/builtin_types.py
+++ b/src/glang/codegen/builtin_types.py
@@ -374,6 +374,7 @@ class IEEEFloatDefinition(PrimitiveDefinition):
     def __init__(self, name: str, size_in_bits: int) -> None:
         ir_type = {16: "half", 32: "float", 64: "double", 128: "fp128"}[size_in_bits]
         super().__init__(size_in_bits // 8, ir_type, name)
+        self.bits = size_in_bits
 
     def graphene_literal_to_ir_constant(self, value_str: str) -> str:
         return float_literal_to_exact_hex(value_str, 8 * self.size)
@@ -382,6 +383,17 @@ class IEEEFloatDefinition(PrimitiveDefinition):
         if not isinstance(other, IEEEFloatDefinition):
             return False
         return self.size == other.size
+
+    def to_di_type(self, metadata_gen: Iterator[int]) -> list[Metadata]:
+        return [
+            DIBasicType(
+                next(metadata_gen),
+                self._name,
+                self.bits,
+                Tag.base_type,
+                TypeKind.float,
+            )
+        ]
 
 
 class IEEEFloat(PrimitiveType):

--- a/src/glang/codegen/builtin_types.py
+++ b/src/glang/codegen/builtin_types.py
@@ -5,8 +5,6 @@ from functools import cached_property, reduce
 from operator import mul
 from typing import Callable, Iterator, Optional
 
-from glang.codegen.debug import DIType, Metadata
-
 from ..target import get_abi, get_int_type_info, get_ptr_type_info
 from .debug import (
     DIBasicType,

--- a/src/glang/codegen/builtin_types.py
+++ b/src/glang/codegen/builtin_types.py
@@ -5,8 +5,6 @@ from functools import cached_property, reduce
 from operator import mul
 from typing import Callable, Iterator, Optional
 
-from glang.codegen.debug import Metadata
-
 from ..target import get_abi, get_int_type_info, get_ptr_type_info
 from .debug import (
     DIBasicType,

--- a/src/glang/codegen/debug.py
+++ b/src/glang/codegen/debug.py
@@ -68,3 +68,13 @@ class DISubprogram(Metadata):
             f"scopeLine: {self.line}, type: !{self.subroutine_type.id}, unit: !{self.unit.id}, "
             f"{sp_flags})"
         )
+
+
+@dataclass
+class DILocation(Metadata):
+    line: int
+    column: int
+    scope: DISubprogram
+
+    def __repr__(self) -> str:
+        return f"!DILocation(line: {self.line}, column: {self.column}, scope: !{self.scope.id})"

--- a/src/glang/codegen/debug.py
+++ b/src/glang/codegen/debug.py
@@ -1,5 +1,101 @@
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
+from typing import Optional, Sequence
+
+
+class Tag(StrEnum):
+    null = "DW_TAG_null"
+    array_type = "DW_TAG_array_type"
+    class_type = "DW_TAG_class_type"
+    entry_point = "DW_TAG_entry_point"
+    enumeration_type = "DW_TAG_enumeration_type"
+    formal_parameter = "DW_TAG_formal_parameter"
+    imported_declaration = "DW_TAG_imported_declaration"
+    label = "DW_TAG_label"
+    lexical_block = "DW_TAG_lexical_block"
+    member = "DW_TAG_member"
+    pointer_type = "DW_TAG_pointer_type"
+    reference_type = "DW_TAG_reference_type"
+    compile_unit = "DW_TAG_compile_unit"
+    string_type = "DW_TAG_string_type"
+    structure_type = "DW_TAG_structure_type"
+    subroutine_type = "DW_TAG_subroutine_type"
+    typedef = "DW_TAG_typedef"
+    union_type = "DW_TAG_union_type"
+    unspecified_parameters = "DW_TAG_unspecified_parameters"
+    variant = "DW_TAG_variant"
+    common_block = "DW_TAG_common_block"
+    common_inclusion = "DW_TAG_common_inclusion"
+    inheritance = "DW_TAG_inheritance"
+    inlined_subroutine = "DW_TAG_inlined_subroutine"
+    module = "DW_TAG_module"
+    ptr_to_member_type = "DW_TAG_ptr_to_member_type"
+    set_type = "DW_TAG_set_type"
+    subrange_type = "DW_TAG_subrange_type"
+    with_stmt = "DW_TAG_with_stmt"
+    access_declaration = "DW_TAG_access_declaration"
+    base_type = "DW_TAG_base_type"
+    catch_block = "DW_TAG_catch_block"
+    const_type = "DW_TAG_const_type"
+    constant = "DW_TAG_constant"
+    enumerator = "DW_TAG_enumerator"
+    file_type = "DW_TAG_file_type"
+    friend = "DW_TAG_friend"
+    namelist = "DW_TAG_namelist"
+    namelist_item = "DW_TAG_namelist_item"
+    packed_type = "DW_TAG_packed_type"
+    subprogram = "DW_TAG_subprogram"
+    template_type_parameter = "DW_TAG_template_type_parameter"
+    template_value_parameter = "DW_TAG_template_value_parameter"
+    thrown_type = "DW_TAG_thrown_type"
+    try_block = "DW_TAG_try_block"
+    variant_part = "DW_TAG_variant_part"
+    variable = "DW_TAG_variable"
+    volatile_type = "DW_TAG_volatile_type"
+    dwarf_procedure = "DW_TAG_dwarf_procedure"
+    restrict_type = "DW_TAG_restrict_type"
+    interface_type = "DW_TAG_interface_type"
+    namespace = "DW_TAG_namespace"
+    imported_module = "DW_TAG_imported_module"
+    unspecified_type = "DW_TAG_unspecified_type"
+    partial_unit = "DW_TAG_partial_unit"
+    imported_unit = "DW_TAG_imported_unit"
+    condition = "DW_TAG_condition"
+    shared_type = "DW_TAG_shared_type"
+    type_unit = "DW_TAG_type_unit"
+    rvalue_reference_type = "DW_TAG_rvalue_reference_type"
+    template_alias = "DW_TAG_template_alias"
+    coarray_type = "DW_TAG_coarray_type"
+    generic_subrange = "DW_TAG_generic_subrange"
+    dynamic_type = "DW_TAG_dynamic_type"
+    atomic_type = "DW_TAG_atomic_type"
+    call_site = "DW_TAG_call_site"
+    call_site_parameter = "DW_TAG_call_site_parameter"
+    skeleton_unit = "DW_TAG_skeleton_unit"
+    immutable_type = "DW_TAG_immutable_type"
+
+
+class TypeKind(StrEnum):
+    # DWARF attribute type encodings.
+    address = "DW_ATE_address"
+    boolean = "DW_ATE_boolean"
+    complex_float = "DW_ATE_complex_float"
+    float = "DW_ATE_float"
+    signed = "DW_ATE_signed"
+    signed_char = "DW_ATE_signed_char"
+    unsigned = "DW_ATE_unsigned"
+    unsigned_char = "DW_ATE_unsigned_char"
+    imaginary_float = "DW_ATE_imaginary_float"
+    packed_decimal = "DW_ATE_packed_decimal"
+    numeric_string = "DW_ATE_numeric_string"
+    edited = "DW_ATE_edited"
+    signed_fixed = "DW_ATE_signed_fixed"
+    unsigned_fixed = "DW_ATE_unsigned_fixed"
+    decimal_float = "DW_ATE_decimal_float"
+    UTF = "DW_ATE_UTF"
+    UCS = "DW_ATE_UCS"
+    ASCII = "DW_ATE_ASCII"
 
 
 @dataclass
@@ -18,7 +114,28 @@ class MetadataFlag(Metadata):
 
 
 @dataclass
-class DIFile(Metadata):
+class MetadataList(Metadata):
+    children: Sequence[Metadata]
+
+    def __repr__(self) -> str:
+        return "!{" + ", ".join(map(lambda c: f"!{c.id}", self.children)) + "}"
+
+
+@dataclass
+class DISubrange(Metadata):
+    count: int
+
+    def __repr__(self) -> str:
+        return f"!DISubrange(count: {self.count})"
+
+
+@dataclass
+class DIScope(Metadata):
+    pass
+
+
+@dataclass
+class DIFile(DIScope):
     file: Path
 
     def __repr__(self) -> str:
@@ -28,7 +145,7 @@ class DIFile(Metadata):
 
 
 @dataclass
-class DICompileUnit(Metadata):
+class DICompileUnit(DIScope):
     file: DIFile
 
     def __repr__(self) -> str:
@@ -43,7 +160,80 @@ class DICompileUnit(Metadata):
 
 
 @dataclass
-class DISubroutineType(Metadata):
+class DILocation(Metadata):
+    line: int
+    column: int
+    scope: DIScope
+
+    def __repr__(self) -> str:
+        return f"!DILocation(line: {self.line}, column: {self.column}, scope: !{self.scope.id})"
+
+
+@dataclass
+class DIType(DIScope):
+    name: Optional[str]
+    size_in_bits: int
+    tag: Tag
+
+
+@dataclass
+class DIBasicType(DIType):
+    encoding: TypeKind
+
+    def __repr__(self) -> str:
+        name_flag = f'name: "{self.name}",' if self.name is not None else ""
+        return (
+            f"!DIBasicType({name_flag} size: {self.size_in_bits}, tag: {self.tag}, "
+            f"encoding: {self.encoding})"
+        )
+
+
+@dataclass
+class DICompositeType(DIType):
+    base_type: Optional[DIType]
+    elements: Optional[MetadataList]
+    # TODO
+    # scope: DIScope
+    # file: DIFile
+    # line: int
+
+    def __repr__(self) -> str:
+        # Required for arrays, or clang segfaults.
+        if self.tag == Tag.array_type:
+            assert self.elements is not None
+            assert self.base_type
+
+        name_flag = f'name: "{self.name}", ' if self.name is not None else ""
+        base_type_flag = (
+            f"baseType: !{self.base_type.id}, " if self.base_type is not None else ""
+        )
+        subrange_flag = (
+            f"elements: !{self.elements.id}, " if self.elements is not None else ""
+        )
+        return (
+            f"!DICompositeType({name_flag}{base_type_flag}{subrange_flag}"
+            f"size: {self.size_in_bits}, tag: {self.tag})"
+        )
+
+
+@dataclass
+class DIDerivedType(DIType):
+    # scope: DIScope
+    # file: DIFile
+    # line: int
+    base_type: DIType
+    # offset: int
+
+    def __repr__(self) -> str:
+        name_flag = f'name: "{self.name}",' if self.name is not None else ""
+        return (
+            f"!DIDerivedType({name_flag} size: {self.size_in_bits}, tag: {self.tag},"
+            f"baseType: !{self.base_type.id})"
+        )
+
+
+@dataclass
+class DISubroutineType(DIType):
     # TODO implementation.
 
     def __repr__(self) -> str:
@@ -51,7 +241,24 @@ class DISubroutineType(Metadata):
 
 
 @dataclass
-class DISubprogram(Metadata):
+class DILocalVariable(Metadata):
+    name: str
+    arg: Optional[int]
+    scope: DIScope
+    file: DIFile
+    line: int
+    type: DIType
+
+    def __repr__(self) -> str:
+        arg_flag = f", arg: {self.arg}" if self.arg is not None else ""
+        return (
+            f'!DILocalVariable(name: "{self.name}", scope: !{self.scope.id}, '
+            f"file: !{self.file.id}, line: {self.line}, type: !{self.type.id}{arg_flag})"
+        )
+
+
+@dataclass
+class DISubprogram(DIScope):
     name: str
     linkage_name: str
     subroutine_type: DISubroutineType
@@ -68,13 +275,3 @@ class DISubprogram(Metadata):
             f"scopeLine: {self.line}, type: !{self.subroutine_type.id}, unit: !{self.unit.id}, "
             f"{sp_flags})"
         )
-
-
-@dataclass
-class DILocation(Metadata):
-    line: int
-    column: int
-    scope: DISubprogram
-
-    def __repr__(self) -> str:
-        return f"!DILocation(line: {self.line}, column: {self.column}, scope: !{self.scope.id})"

--- a/src/glang/codegen/debug.py
+++ b/src/glang/codegen/debug.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from hashlib import file_digest
 from inspect import getmembers
 from pathlib import Path
@@ -106,6 +106,20 @@ class ChecksumKind(StrEnum):
     SHA256 = "CSK_SHA256"
 
 
+class ModuleFlagsBehavior(IntEnum):
+    # Determines how conflicting metadata flags are handled by LLVM when two or
+    # more modules are merged together.
+    # https://llvm.org/docs/LangRef.html#module-flags-metadata
+    Error = 1
+    Warning = 2
+    Require = 3
+    Override = 4
+    Append = 5
+    AppendUnique = 6
+    Max = 7
+    Min = 8
+
+
 @dataclass(repr=False, eq=False)
 class Metadata:
     id: int
@@ -140,8 +154,8 @@ class Metadata:
 
 
 @dataclass(repr=False, eq=False)
-class MetadataFlag(Metadata):
-    behaviour: int
+class ModuleFlags(Metadata):
+    behaviour: ModuleFlagsBehavior
     metadata: str
     value: int
 

--- a/src/glang/codegen/debug.py
+++ b/src/glang/codegen/debug.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import StrEnum
+from hashlib import file_digest
 from inspect import getmembers
 from pathlib import Path
 from typing import Optional, Sequence
@@ -99,6 +100,12 @@ class TypeKind(StrEnum):
     ASCII = "DW_ATE_ASCII"
 
 
+class ChecksumKind(StrEnum):
+    MD5 = "CSK_MD5"
+    SHA1 = "CSK_SHA1"
+    SHA256 = "CSK_SHA256"
+
+
 @dataclass(repr=False, eq=False)
 class Metadata:
     id: int
@@ -162,7 +169,6 @@ class DIScope(Metadata):
 
 @dataclass(repr=False, eq=False)
 class DIFile(DIScope):
-    # TODO checksum.
     _file: Path
 
     @property
@@ -172,6 +178,15 @@ class DIFile(DIScope):
     @property
     def directory(self) -> str:
         return str(self._file.resolve(strict=True).parent)
+
+    @property
+    def checksum(self) -> str:
+        with self._file.open("rb") as file:
+            return file_digest(file, "sha256").hexdigest()
+
+    @property
+    def checksumkind(self) -> ChecksumKind:
+        return ChecksumKind.SHA256
 
 
 @dataclass(repr=False, eq=False)

--- a/src/glang/codegen/debug.py
+++ b/src/glang/codegen/debug.py
@@ -181,9 +181,9 @@ class DICompileUnit(DIScope):
     def __repr__(self) -> str:
         # TODO print glang version.
         # NOTE clang checks that the language is valid... so let's pretend we
-        # are C.
+        # are C++ (gdb prefixes all the structs with `struct` if we use C).
         return (
-            f"distinct !DICompileUnit(language: DW_LANG_C, file: !{self.file.id}, "
+            f"distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !{self.file.id}, "
             'producer: "glang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, '
             "splitDebugInlining: false, nameTableKind: None)"
         )

--- a/src/glang/codegen/debug.py
+++ b/src/glang/codegen/debug.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Metadata:
+    id: int
+
+
+@dataclass
+class MetadataFlag(Metadata):
+    behaviour: int
+    metadata: str
+    value: int
+
+    def __repr__(self) -> str:
+        return f'!{{i32 {self.behaviour}, !"{self.metadata}", i32 {self.value}}}'
+
+
+@dataclass
+class DIFile(Metadata):
+    file: Path
+
+    def __repr__(self) -> str:
+        # TODO checksum.
+        path = self.file.resolve(strict=True)
+        return f'!DIFile(filename: "{path.name}", directory: "{path.parent}")'
+
+
+@dataclass
+class DICompileUnit(Metadata):
+    file: DIFile
+
+    def __repr__(self) -> str:
+        # TODO print glang version.
+        # NOTE clang checks that the language is valid... so let's pretend we
+        # are C.
+        return (
+            f"distinct !DICompileUnit(language: DW_LANG_C, file: !{self.file.id}, "
+            'producer: "glang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, '
+            "splitDebugInlining: false, nameTableKind: None)"
+        )
+
+
+@dataclass
+class DISubroutineType(Metadata):
+    # TODO implementation.
+
+    def __repr__(self) -> str:
+        return f"!DISubroutineType(types: !{{null, null}})"
+
+
+@dataclass
+class DISubprogram(Metadata):
+    name: str
+    linkage_name: str
+    subroutine_type: DISubroutineType
+    file: DIFile
+    line: int
+    unit: DICompileUnit
+    is_definition: bool
+
+    def __repr__(self) -> str:
+        sp_flags = "spFlags: DISPFlagDefinition" if self.is_definition else ""
+        return (
+            f'distinct !DISubprogram(name: "{self.name}", linkageName: "{self.linkage_name}", '
+            f"scope: !{self.file.id}, file: !{self.file.id}, line: {self.line}, "
+            f"scopeLine: {self.line}, type: !{self.subroutine_type.id}, unit: !{self.unit.id}, "
+            f"{sp_flags})"
+        )

--- a/src/glang/codegen/debug.py
+++ b/src/glang/codegen/debug.py
@@ -99,7 +99,7 @@ class TypeKind(StrEnum):
     ASCII = "DW_ATE_ASCII"
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class Metadata:
     id: int
 
@@ -132,7 +132,7 @@ class Metadata:
         return f"!{self.__class__.__name__}({str.join(', ', contents)})"
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class MetadataFlag(Metadata):
     behaviour: int
     metadata: str
@@ -142,7 +142,7 @@ class MetadataFlag(Metadata):
         return f'!{{i32 {self.behaviour}, !"{self.metadata}", i32 {self.value}}}'
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class MetadataList(Metadata):
     children: Sequence[Metadata]
 
@@ -150,17 +150,17 @@ class MetadataList(Metadata):
         return "!{" + ", ".join(map(lambda c: f"!{c.id}", self.children)) + "}"
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DISubrange(Metadata):
     count: int
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DIScope(Metadata):
     pass
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DIFile(DIScope):
     # TODO checksum.
     _file: Path
@@ -174,7 +174,7 @@ class DIFile(DIScope):
         return str(self._file.resolve(strict=True).parent)
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DICompileUnit(DIScope):
     file: DIFile
 
@@ -189,14 +189,14 @@ class DICompileUnit(DIScope):
         )
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DILocation(Metadata):
     line: int
     column: int
     scope: DIScope
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DIType(DIScope):
     name: Optional[str]
     _size_in_bits: int
@@ -207,12 +207,12 @@ class DIType(DIScope):
         return self._size_in_bits
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DIBasicType(DIType):
     encoding: TypeKind
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DICompositeType(DIType):
     baseType: Optional[DIType]
     elements: Optional[MetadataList]
@@ -228,7 +228,7 @@ class DICompositeType(DIType):
             assert self.baseType is not None
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DIDerivedType(DIType):
     # scope: DIScope
     # file: DIFile
@@ -237,7 +237,7 @@ class DIDerivedType(DIType):
     offset: Optional[int]
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DISubroutineType(DIType):
     # TODO implementation.
 
@@ -245,7 +245,7 @@ class DISubroutineType(DIType):
         return f"!DISubroutineType(types: !{{null, null}})"
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DILocalVariable(Metadata):
     name: str
     arg: Optional[int]
@@ -255,7 +255,7 @@ class DILocalVariable(Metadata):
     type: DIType
 
 
-@dataclass(repr=False, eq=False, slots=True)
+@dataclass(repr=False, eq=False)
 class DISubprogram(DIScope):
     name: str
     linkage_name: str

--- a/src/glang/codegen/expressions.py
+++ b/src/glang/codegen/expressions.py
@@ -162,6 +162,7 @@ class FunctionCallExpression(StaticTypedExpression):
         # https://llvm.org/docs/LangRef.html#call-instruction
 
         ir = IROutput()
+        dbg = self.add_di_location(ctx, ir)
         conv_args: list[TypedExpression] = []
 
         for arg, arg_type in zip(self.args, self.signature.arguments, strict=True):
@@ -172,14 +173,12 @@ class FunctionCallExpression(StaticTypedExpression):
 
         args_ir = map(lambda arg: arg.ir_ref_with_type_annotation, conv_args)
 
-        call_expr = f"call {self.signature.ir_ref}({str.join(', ', args_ir)})"
-
-        dbg = self.add_di_location(ctx, ir)
+        call_expr = f"call {self.signature.ir_ref}({str.join(', ', args_ir)}), {dbg}"
 
         # We cannot assign `void` to a register.
         if not self.signature.return_type.definition.is_void:
             self.result_reg = ctx.next_reg()
-            call_expr = f"%{self.result_reg} = {call_expr}, {dbg}"
+            call_expr = f"%{self.result_reg} = {call_expr}"
 
         ir.lines.append(call_expr)
 

--- a/src/glang/codegen/generatable.py
+++ b/src/glang/codegen/generatable.py
@@ -59,7 +59,7 @@ class StackVariable(Variable):
         )
 
         metadata = self.type.to_di_type(ctx.metadata_gen)
-        ir.metadata.extend(metadata)
+        ir.metadata.update(metadata)
         assert isinstance(metadata[-1], DIType)
 
         di_local_variable = DILocalVariable(
@@ -71,12 +71,12 @@ class StackVariable(Variable):
             self._meta.start.line,
             metadata[-1],
         )
-        ir.metadata.append(di_local_variable)
+        ir.metadata.add(di_local_variable)
 
         di_location = DILocation(
             ctx.next_meta(), self._meta.start.line, self._meta.start.column, ctx.scope
         )
-        ir.metadata.append(di_location)
+        ir.metadata.add(di_location)
 
         ir.lines.append(
             f"call void @llvm.dbg.declare(metadata {self.ir_ref}, metadata !{di_local_variable.id},"

--- a/src/glang/codegen/generatable.py
+++ b/src/glang/codegen/generatable.py
@@ -2,7 +2,7 @@ from typing import Iterable, Iterator, Optional
 
 from ..parser.lexer_parser import Meta
 from .builtin_types import BoolType, CharArrayDefinition, VoidType
-from .debug import DIFile, DILocalVariable, DILocation
+from .debug import DIFile, DILocalVariable, DILocation, DIType
 from .interfaces import (
     Generatable,
     IRContext,
@@ -58,8 +58,9 @@ class StackVariable(Variable):
             f"%{self.ir_reg} = alloca {self.type.ir_type}, align {self.type.alignment}"
         )
 
-        di_types = self.type.to_di_type(ctx.metadata_gen)
-        ir.metadata.extend(di_types)
+        metadata = self.type.to_di_type(ctx.metadata_gen)
+        ir.metadata.extend(metadata)
+        assert isinstance(metadata[-1], DIType)
 
         di_local_variable = DILocalVariable(
             ctx.next_meta(),
@@ -68,7 +69,7 @@ class StackVariable(Variable):
             ctx.scope,
             self._di_file,
             self._meta.start.line,
-            di_types[-1],
+            metadata[-1],
         )
         ir.metadata.append(di_local_variable)
 

--- a/src/glang/codegen/generatable.py
+++ b/src/glang/codegen/generatable.py
@@ -1,5 +1,6 @@
 from typing import Iterable, Iterator, Optional
 
+from ..parser.lexer_parser import Meta
 from .builtin_types import BoolType, CharArrayDefinition, VoidType
 from .interfaces import Generatable, Type, TypedExpression, Variable
 from .type_conversions import assert_is_implicitly_convertible, do_implicit_conversion
@@ -104,8 +105,10 @@ class StaticVariable(Variable):
 
 
 class Scope(Generatable):
-    def __init__(self, scope_id: int, outer_scope: Optional["Scope"] = None) -> None:
-        super().__init__()
+    def __init__(
+        self, scope_id: int, meta: Meta, outer_scope: Optional["Scope"] = None
+    ) -> None:
+        super().__init__(meta)
 
         assert scope_id >= 0
         self.id = scope_id
@@ -211,8 +214,9 @@ class IfElseStatement(Generatable):
         condition: TypedExpression,
         if_scope: Scope,
         else_scope: Scope,
+        meta: Meta,
     ) -> None:
-        super().__init__()
+        super().__init__(meta)
 
         condition.assert_can_read_from()
         assert_is_implicitly_convertible(condition, BoolType(), "if condition")
@@ -276,8 +280,9 @@ class WhileStatement(Generatable):
         condition: TypedExpression,
         condition_generatable: list[Generatable],
         inner_scope: Scope,
+        meta: Meta,
     ) -> None:
-        super().__init__()
+        super().__init__(meta)
 
         condition.assert_can_read_from()
         assert_is_implicitly_convertible(condition, BoolType(), "while condition")
@@ -321,9 +326,12 @@ class WhileStatement(Generatable):
 
 class ReturnStatement(Generatable):
     def __init__(
-        self, return_type: Type, returned_expr: Optional[TypedExpression] = None
+        self,
+        return_type: Type,
+        meta: Meta,
+        returned_expr: Optional[TypedExpression] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(meta)
 
         if returned_expr is not None:
             returned_expr.assert_can_read_from()
@@ -363,8 +371,10 @@ class ReturnStatement(Generatable):
 
 
 class VariableInitialize(Generatable):
-    def __init__(self, variable: StackVariable, value: TypedExpression) -> None:
-        super().__init__()
+    def __init__(
+        self, variable: StackVariable, value: TypedExpression, meta: Meta
+    ) -> None:
+        super().__init__(meta)
 
         value.assert_can_read_from()
         assert_is_implicitly_convertible(value, variable.type, "variable assignment")
@@ -398,8 +408,8 @@ class VariableInitialize(Generatable):
 
 
 class Assignment(Generatable):
-    def __init__(self, dst: TypedExpression, src: TypedExpression) -> None:
-        super().__init__()
+    def __init__(self, dst: TypedExpression, src: TypedExpression, meta: Meta) -> None:
+        super().__init__(meta)
 
         if dst.result_type.storage_kind.is_reference():
             raise AssignmentToBorrowedReference(dst.format_for_output_to_user())

--- a/src/glang/codegen/interfaces.py
+++ b/src/glang/codegen/interfaces.py
@@ -227,7 +227,7 @@ class Generatable(ABC):
 
         return ir_output
 
-    def add_di_location(self, ctx: IRContext, ir: IROutput) -> DILocation:
+    def add_di_location(self, ctx: IRContext, ir: IROutput) -> str:
         assert self.meta is not None
 
         di_location = DILocation(
@@ -238,7 +238,7 @@ class Generatable(ABC):
         )
         ir.metadata.append(di_location)
 
-        return di_location
+        return f"!dbg !{di_location.id}"
 
 
 class TypedExpression(Generatable):
@@ -285,12 +285,12 @@ class TypedExpression(Generatable):
         # Converts a double indirection eg. address of reference into a reference
         assert self.has_address
 
-        di_location = self.add_di_location(ctx, ir)
+        dbg = self.add_di_location(ctx, ir)
 
         store_at = ctx.next_reg()
         ir.lines.append(
             f"%{store_at} = load ptr, {self.ir_ref_with_type_annotation}, "
-            f"align {self.result_type_as_if_borrowed.alignment}, !dbg !{di_location.id}"
+            f"align {self.result_type_as_if_borrowed.alignment}, {dbg}"
         )
         return store_at
 

--- a/src/glang/codegen/interfaces.py
+++ b/src/glang/codegen/interfaces.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Iterable, Iterator, Optional
 
+from ..parser.lexer_parser import Meta
 from .user_facing_errors import MutableVariableContainsAReference
 
 
@@ -177,6 +178,11 @@ class Variable(ABC):
 
 
 class Generatable(ABC):
+    def __init__(self, meta: Optional[Meta]) -> None:
+        super().__init__()
+
+        self.meta = meta
+
     def generate_ir(self, _: Iterator[int]) -> list[str]:
         return []
 
@@ -202,10 +208,9 @@ class Generatable(ABC):
 
 class TypedExpression(Generatable):
     def __init__(
-        self,
-        underlying_indirection_kind: Type.Kind,
+        self, underlying_indirection_kind: Type.Kind, meta: Optional[Meta]
     ) -> None:
-        super().__init__()
+        super().__init__(meta)
         self.underlying_indirection_kind = underlying_indirection_kind
         self.result_reg: Optional[int] = None
 
@@ -281,6 +286,7 @@ class StaticTypedExpression(TypedExpression):
         self,
         expr_type: Type,
         underlying_indirection_kind: Type.Kind,
+        meta: Optional[Meta],
         was_reference_type_at_any_point: bool = False,
     ) -> None:
         # It is the caller's responsibility to escape double indirections
@@ -290,7 +296,7 @@ class StaticTypedExpression(TypedExpression):
         self.underlying_type = expr_type
 
         self.was_reference_type_at_any_point = was_reference_type_at_any_point
-        super().__init__(underlying_indirection_kind)
+        super().__init__(underlying_indirection_kind, meta)
 
     @property
     def result_type(self) -> Type:

--- a/src/glang/codegen/interfaces.py
+++ b/src/glang/codegen/interfaces.py
@@ -141,11 +141,11 @@ class Type(ABC):
 @dataclass
 class IROutput:
     lines: list[str] = field(default_factory=list)
-    metadata: list[Metadata] = field(default_factory=list)
+    metadata: set[Metadata] = field(default_factory=set)
 
     def extend(self, other: "IROutput") -> None:
         self.lines.extend(other.lines)
-        self.metadata.extend(other.metadata)
+        self.metadata.update(other.metadata)
 
 
 @dataclass
@@ -247,7 +247,7 @@ class Generatable(ABC):
             self.meta.start.column,
             ctx.scope,
         )
-        ir.metadata.append(di_location)
+        ir.metadata.add(di_location)
 
         return f"!dbg !{di_location.id}"
 

--- a/src/glang/codegen/translation_unit.py
+++ b/src/glang/codegen/translation_unit.py
@@ -124,7 +124,7 @@ class Function:
             self._signature.mangled_name,
             di_subroutine_type,
             self._di_file,
-            0,  # TODO line number.
+            self._meta.start.line,
             self._di_unit,
             not self._signature.is_foreign,
         )

--- a/src/glang/codegen/translation_unit.py
+++ b/src/glang/codegen/translation_unit.py
@@ -13,13 +13,7 @@ from .builtin_types import (
     IntType,
     get_builtin_types,
 )
-from .debug import (
-    DICompileUnit,
-    DIFile,
-    DISubprogram,
-    DISubroutineType,
-    MetadataFlag,
-)
+from .debug import DICompileUnit, DIFile, DISubprogram, DISubroutineType, MetadataFlag
 from .expressions import FunctionCallExpression, FunctionParameter
 from .generatable import Scope, StackVariable, StaticVariable, VariableInitialize
 from .interfaces import IRContext, IROutput, SpecializationItem, Type, TypedExpression

--- a/src/glang/codegen/translation_unit.py
+++ b/src/glang/codegen/translation_unit.py
@@ -163,7 +163,7 @@ class Function:
                 *indent_ir(body_ir.lines),
                 "}",
             ],
-            [di_subroutine_type, di_subprogram, *body_ir.metadata],
+            {di_subroutine_type, di_subprogram, *body_ir.metadata},
         )
 
 
@@ -236,7 +236,7 @@ class Program:
         return di_file
 
     def generate_ir(self) -> str:
-        output = IROutput(metadata=[self.di_compile_unit, *self.di_files])
+        output = IROutput(metadata={self.di_compile_unit, *self.di_files})
 
         output.lines.append(f'target datalayout = "{target.get_datalayout()}"')
         output.lines.append(f'target triple = "{target.get_target_triple()}"')
@@ -270,7 +270,7 @@ class Program:
             next(self._metadata_gen), 1, "Debug Info Version", 3
         )
 
-        output.metadata.extend((dwarf_version_metadata, debug_info_version_metadata))
+        output.metadata.update((dwarf_version_metadata, debug_info_version_metadata))
 
         source = "\n".join(output.lines)
         source += "\n\n"

--- a/src/glang/codegen/translation_unit.py
+++ b/src/glang/codegen/translation_unit.py
@@ -18,7 +18,8 @@ from .debug import (
     DIFile,
     DISubprogram,
     DISubroutineType,
-    MetadataFlag,
+    ModuleFlags,
+    ModuleFlagsBehavior,
     Tag,
 )
 from .expressions import FunctionCallExpression, FunctionParameter
@@ -261,14 +262,11 @@ class Program:
         for func in self._fn_bodies:
             output.extend(func.generate_ir(self._metadata_gen))
 
-        # behaviour = 1 (Error)
-        # Emits an error if two values disagree, otherwise the resulting value
-        # is that of the operands.
-        dwarf_version_metadata = MetadataFlag(
-            next(self._metadata_gen), 1, "Dwarf Version", 4
+        dwarf_version_metadata = ModuleFlags(
+            next(self._metadata_gen), ModuleFlagsBehavior.Error, "Dwarf Version", 4
         )
-        debug_info_version_metadata = MetadataFlag(
-            next(self._metadata_gen), 1, "Debug Info Version", 3
+        debug_info_version_metadata = ModuleFlags(
+            next(self._metadata_gen), ModuleFlagsBehavior.Error, "Debug Info Version", 3
         )
 
         output.metadata.update((dwarf_version_metadata, debug_info_version_metadata))

--- a/src/glang/codegen/translation_unit.py
+++ b/src/glang/codegen/translation_unit.py
@@ -174,8 +174,8 @@ class Program:
 
         self._metadata_gen = count(0)
 
-        self.di_file = DIFile(next(self._metadata_gen), file)
-        self.di_compile_unit = DICompileUnit(next(self._metadata_gen), self.di_file)
+        self.di_files = [DIFile(next(self._metadata_gen), file)]
+        self.di_compile_unit = DICompileUnit(next(self._metadata_gen), self.di_files[0])
 
         for builtin_type in get_builtin_types():
             self.symbol_table.add_builtin_type(builtin_type)
@@ -215,8 +215,13 @@ class Program:
     def add_function_body(self, function: Function) -> None:
         self._fn_bodies.append(function)
 
+    def add_secondary_file(self, path: Path) -> DIFile:
+        di_file = DIFile(next(self._metadata_gen), path)
+        self.di_files.append(di_file)
+        return di_file
+
     def generate_ir(self) -> str:
-        output = IROutput([], [self.di_file, self.di_compile_unit])
+        output = IROutput(metadata=[self.di_compile_unit, *self.di_files])
 
         output.lines.append(f'target datalayout = "{target.get_datalayout()}"')
         output.lines.append(f'target triple = "{target.get_target_triple()}"')

--- a/src/glang/codegen/translation_unit.py
+++ b/src/glang/codegen/translation_unit.py
@@ -95,6 +95,7 @@ class Function:
         )
         self.top_level_scope.add_variable(fn_param_var)
 
+        # FIXME pass the true meta.
         fn_param_var_assignment = VariableInitialize(fn_param_var, fn_param, self._meta)
         self.top_level_scope.add_generatable(fn_param_var_assignment)
 

--- a/src/glang/codegen/type_conversions.py
+++ b/src/glang/codegen/type_conversions.py
@@ -7,7 +7,7 @@ from .user_facing_errors import OperandError, TypeCheckerError
 
 class RemoveIndirection(StaticTypedExpression):
     def __init__(self, ref: TypedExpression) -> None:
-        super().__init__(ref.result_type, Type.Kind.VALUE)
+        super().__init__(ref.result_type, Type.Kind.VALUE, ref.meta)
         self.ref = ref
 
     def generate_ir(self, reg_gen: Iterator[int]) -> list[str]:
@@ -38,7 +38,7 @@ class RemoveIndirection(StaticTypedExpression):
 
 class PromoteInteger(StaticTypedExpression):
     def __init__(self, src: TypedExpression, dest_type: Type) -> None:
-        super().__init__(dest_type, Type.Kind.VALUE)
+        super().__init__(dest_type, Type.Kind.VALUE, src.meta)
 
         src_definition = src.result_type.definition
 
@@ -86,7 +86,7 @@ class Reinterpret(StaticTypedExpression):
         assert src.has_address and not src.underlying_indirection_kind.is_reference()
         assert dest_type.storage_kind.is_reference()
 
-        super().__init__(dest_type, Type.Kind.VALUE)
+        super().__init__(dest_type, Type.Kind.VALUE, src.meta)
 
         self._src = src
 
@@ -257,7 +257,7 @@ def get_implicit_conversion_cost(
 ) -> Optional[int]:
     class Wrapper(StaticTypedExpression):
         def __init__(self, expr_type: Type) -> None:
-            super().__init__(expr_type, Type.Kind.VALUE)
+            super().__init__(expr_type, Type.Kind.VALUE, None)
 
         @property
         def ir_ref_without_type_annotation(self) -> str:

--- a/src/glang/codegen/type_conversions.py
+++ b/src/glang/codegen/type_conversions.py
@@ -22,13 +22,13 @@ class RemoveIndirection(StaticTypedExpression):
         return_type_ir = self.ref.result_type.ir_type
 
         ir = IROutput()
-        di_location = self.add_di_location(ctx, ir)
+        dbg = self.add_di_location(ctx, ir)
 
         # <result> = load [volatile] <ty>, ptr <pointer>[, align <alignment>]...
         ir.lines.append(
             f"%{self.result_reg} = load {return_type_ir}, "
             f"{self.ref.ir_ref_with_type_annotation}, "
-            f"align {self.result_type_as_if_borrowed.alignment}, !dbg !{di_location.id}"
+            f"align {self.result_type_as_if_borrowed.alignment}, {dbg}"
         )
 
         return ir
@@ -69,7 +69,7 @@ class PromoteInteger(StaticTypedExpression):
 
         self.result_reg = ctx.next_reg()
         ir = IROutput()
-        di_location = self.add_di_location(ctx, ir)
+        dbg = self.add_di_location(ctx, ir)
 
         instruction = "sext" if self.is_signed else "zext"
 
@@ -77,7 +77,7 @@ class PromoteInteger(StaticTypedExpression):
         ir.lines.append(
             f"%{self.result_reg} = {instruction} "
             f"{self.src.ir_ref_with_type_annotation} to {self.underlying_type.ir_type}, "
-            f"!dbg !{di_location.id}"
+            f"{dbg}"
         )
 
         return ir

--- a/src/glang/codegen/type_resolution.py
+++ b/src/glang/codegen/type_resolution.py
@@ -45,7 +45,6 @@ from .user_facing_errors import (
     PatternMatchDeductionFailure,
     RedeclarationWithIncorrectSpecializationCount,
     RedefinitionError,
-    SourceLocation,
     SpecializationFailed,
     SubstitutionFailure,
 )

--- a/src/glang/codegen/type_resolution.py
+++ b/src/glang/codegen/type_resolution.py
@@ -17,6 +17,7 @@ from .builtin_types import (
     StackArrayDefinition,
     StructDefinition,
 )
+from .debug import DIFile
 from .interfaces import (
     GenericArgument,
     GenericMapping,
@@ -845,6 +846,7 @@ class FunctionDeclaration:
     mapping: GenericMapping
     loc: Location
     meta: Meta
+    di_file: DIFile
     uuid: UUID
 
     @staticmethod
@@ -860,6 +862,7 @@ class FunctionDeclaration:
         return_type: UnresolvedType,
         location: Location,
         meta: Meta,
+        di_file: DIFile,
     ):
         explicitly_matched_generics = set().union(
             *(
@@ -897,6 +900,7 @@ class FunctionDeclaration:
             GenericMapping({}, []),
             location,
             meta,
+            di_file,
             uuid4(),
         )
 
@@ -936,6 +940,7 @@ class FunctionDeclaration:
             self.mapping + generics,
             self.loc,
             self.meta,
+            self.di_file,
             self.uuid,
         )
 

--- a/src/glang/codegen/type_resolution.py
+++ b/src/glang/codegen/type_resolution.py
@@ -6,6 +6,7 @@ from itertools import groupby
 from typing import Callable, Iterable, Optional
 from uuid import UUID, uuid4
 
+from ..parser.lexer_parser import Meta
 from .builtin_types import (
     AnonymousType,
     FunctionSignature,
@@ -43,6 +44,7 @@ from .user_facing_errors import (
     PatternMatchDeductionFailure,
     RedeclarationWithIncorrectSpecializationCount,
     RedefinitionError,
+    SourceLocation,
     SpecializationFailed,
     SubstitutionFailure,
 )
@@ -842,6 +844,7 @@ class FunctionDeclaration:
     signature: UnresolvedFunctionSignature
     mapping: GenericMapping
     loc: Location
+    meta: Meta
     uuid: UUID
 
     @staticmethod
@@ -856,6 +859,7 @@ class FunctionDeclaration:
         parameter_pack_argument_name: Optional[str],
         return_type: UnresolvedType,
         location: Location,
+        meta: Meta,
     ):
         explicitly_matched_generics = set().union(
             *(
@@ -892,6 +896,7 @@ class FunctionDeclaration:
             signature,
             GenericMapping({}, []),
             location,
+            meta,
             uuid4(),
         )
 
@@ -930,6 +935,7 @@ class FunctionDeclaration:
             self.signature.produce_specialized_copy(generics),
             self.mapping + generics,
             self.loc,
+            self.meta,
             self.uuid,
         )
 

--- a/src/glang/graphene_parser.py
+++ b/src/glang/graphene_parser.py
@@ -451,7 +451,7 @@ class ExpressionParser(lp.Interpreter):
         return self.parse(expr, FlattenedExpression)
 
     def HexConstant(self, node: lp.HexConstant) -> FlattenedExpression:
-        const_expr = cg.ConstantExpression(cg.UIntType(), node.value)
+        const_expr = cg.ConstantExpression(cg.UIntType(), node.value, node.meta)
         return FlattenedExpression([const_expr])
 
     def GenericIdentifierConstant(
@@ -463,18 +463,18 @@ class ExpressionParser(lp.Interpreter):
 
         mapped_value = self._generic_mapping.mapping[argument]
         assert isinstance(mapped_value, int)  # TODO: user facing error
-        const_expr = cg.ConstantExpression(cg.IntType(), str(mapped_value))
+        const_expr = cg.ConstantExpression(cg.IntType(), str(mapped_value), node.meta)
         return FlattenedExpression([const_expr])
 
     def IntConstant(self, node: lp.IntConstant) -> FlattenedExpression:
         # TODO: the parser has already decoded this, why are we undoing it?
-        const_expr = cg.ConstantExpression(cg.IntType(), str(node.value))
+        const_expr = cg.ConstantExpression(cg.IntType(), str(node.value), node.meta)
         return FlattenedExpression([const_expr])
 
     def BoolConstant(self, node: lp.BoolConstant) -> FlattenedExpression:
         # TODO: the parser has already decoded this, why are we undoing it?
         value = "true" if node.value else "false"
-        const_expr = cg.ConstantExpression(cg.BoolType(), value)
+        const_expr = cg.ConstantExpression(cg.BoolType(), value, node.meta)
         return FlattenedExpression([const_expr])
 
     def StringConstant(self, node: lp.StringConstant) -> FlattenedExpression:

--- a/src/glang/graphene_parser.py
+++ b/src/glang/graphene_parser.py
@@ -473,7 +473,7 @@ class ExpressionParser(lp.Interpreter):
         return FlattenedExpression([const_expr])
 
     def FloatConstant(self, node: lp.FloatConstant) -> FlattenedExpression:
-        const_expr = cg.ConstantExpression(cg.IEEEFloat(32), node.value)
+        const_expr = cg.ConstantExpression(cg.IEEEFloat(32), node.value, node.meta)
         return FlattenedExpression([const_expr])
 
     def IntConstant(self, node: lp.IntConstant) -> FlattenedExpression:

--- a/src/glang/graphene_parser.py
+++ b/src/glang/graphene_parser.py
@@ -519,7 +519,10 @@ class ExpressionParser(lp.Interpreter):
 
         flattened_expr = FlattenedExpression(rhs.subexpressions)
         call_expr = self._program.lookup_call_expression(
-            node.name, [], [rhs.expression()], node.meta  # Don't specialize operators
+            node.name,
+            [],  # Don't specialize operators
+            [rhs.expression()],
+            node.meta,
         )
         return flattened_expr.add_parent(call_expr)
 

--- a/tests/arrays/alignment_aarch64_linux.c3
+++ b/tests/arrays/alignment_aarch64_linux.c3
@@ -10,5 +10,5 @@ function main : () -> int = {
 
 /// @FOR aarch64_linux
 /// @COMPILE
-/// @GREP_IR [3 x i32], align 4
-/// @GREP_IR [4 x i32], align 4
+/// @GREP_IR [[]3 x i32[]], align 4
+/// @GREP_IR [[]4 x i32[]], align 4

--- a/tests/arrays/alignment_x86_64_linux.c3
+++ b/tests/arrays/alignment_x86_64_linux.c3
@@ -11,5 +11,5 @@ function main : () -> int = {
 
 /// @FOR x86_64_linux
 /// @COMPILE
-/// @GREP_IR [3 x i32], align 4
-/// @GREP_IR [4 x i32], align 16
+/// @GREP_IR [[]3 x i32[]], align 4
+/// @GREP_IR [[]4 x i32[]], align 16

--- a/tests/arrays/md_heap_array.c3
+++ b/tests/arrays/md_heap_array.c3
@@ -26,5 +26,5 @@ function main : () -> int = {
 }
 
 /// @COMPILE
-/// @GREP_IR getelementptr inbounds [2 x [2 x i32]]
+/// @GREP_IR getelementptr inbounds [[]2 x [[]2 x i32[]][]]
 /// @RUN

--- a/tests/debug/basic.c3
+++ b/tests/debug/basic.c3
@@ -9,7 +9,7 @@ function main : () -> int = {
 /// @GREP_IR !DIFile(directory: "*/lib/std", filename: "arithmetic.c3")
 /// @GREP_IR distinct !DISubprogram(name: "main", linkageName: "main", scope: !?, file: !?, line: 3, scopeLine: 3, type: !?, unit: !1, spFlags: DISPFlagDefinition)
 /// @GREP_IR distinct !DISubprogram(name: "+", linkageName: "__O43__SPECIAL___T_int__T_int_SPECIAL____T_int__T_int", *)
-/// @GREP_IR distinct !DICompileUnit(language: DW_LANG_C, file: !?, producer: "glang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+/// @GREP_IR distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !?, producer: "glang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
 /// @GREP_IR ret i32 %?, !dbg ![0-9]
 /// @GREP_IR !{i32 1, !"Dwarf Version", i32 4}
 /// @GREP_IR !{i32 1, !"Debug Info Version", i32 3}

--- a/tests/debug/basic.c3
+++ b/tests/debug/basic.c3
@@ -1,0 +1,13 @@
+@require_once "std/arithmetic.c3"
+
+function main : () -> int = {
+    return 1 + 1;
+}
+
+/// @COMPILE
+/// @GREP_IR !DIFile(filename: "basic.c3",
+/// @GREP_IR !DIFile(filename: "arithmetic.c3",
+/// @GREP_IR distinct !DISubprogram(name: "main", linkageName: "main"
+/// @GREP_IR distinct !DISubprogram(name: "+", linkageName: "__O43__SPECIAL___T_int__T_int_SPECIAL____T_int__T_int"
+/// @GREP_IR distinct !DICompileUnit(language: DW_LANG_C,
+/// @GREP_IR !dbg !

--- a/tests/debug/basic.c3
+++ b/tests/debug/basic.c3
@@ -11,3 +11,4 @@ function main : () -> int = {
 /// @GREP_IR distinct !DISubprogram(name: "+", linkageName: "__O43__SPECIAL___T_int__T_int_SPECIAL____T_int__T_int"
 /// @GREP_IR distinct !DICompileUnit(language: DW_LANG_C,
 /// @GREP_IR !dbg !
+/// @GREP_IR scopeLine: 3

--- a/tests/debug/basic.c3
+++ b/tests/debug/basic.c3
@@ -5,8 +5,8 @@ function main : () -> int = {
 }
 
 /// @COMPILE
-/// @GREP_IR !DIFile(directory: "*/tests/debug", filename: "basic.c3")
-/// @GREP_IR !DIFile(directory: "*/lib/std", filename: "arithmetic.c3")
+/// @GREP_IR !DIFile(checksum: "*", checksumkind: CSK_SHA256, directory: "*/tests/debug", filename: "basic.c3")
+/// @GREP_IR !DIFile(checksum: "*", checksumkind: CSK_SHA256, directory: "*/lib/std", filename: "arithmetic.c3")
 /// @GREP_IR distinct !DISubprogram(name: "main", linkageName: "main", scope: !?, file: !?, line: 3, scopeLine: 3, type: !?, unit: !1, spFlags: DISPFlagDefinition)
 /// @GREP_IR distinct !DISubprogram(name: "+", linkageName: "__O43__SPECIAL___T_int__T_int_SPECIAL____T_int__T_int", *)
 /// @GREP_IR distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !?, producer: "glang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)

--- a/tests/debug/basic.c3
+++ b/tests/debug/basic.c3
@@ -5,10 +5,12 @@ function main : () -> int = {
 }
 
 /// @COMPILE
-/// @GREP_IR !DIFile(filename: "basic.c3",
-/// @GREP_IR !DIFile(filename: "arithmetic.c3",
-/// @GREP_IR distinct !DISubprogram(name: "main", linkageName: "main"
-/// @GREP_IR distinct !DISubprogram(name: "+", linkageName: "__O43__SPECIAL___T_int__T_int_SPECIAL____T_int__T_int"
-/// @GREP_IR distinct !DICompileUnit(language: DW_LANG_C,
-/// @GREP_IR !dbg !
-/// @GREP_IR scopeLine: 3
+/// @GREP_IR !DIFile(directory: "*/tests/debug", filename: "basic.c3")
+/// @GREP_IR !DIFile(directory: "*/lib/std", filename: "arithmetic.c3")
+/// @GREP_IR distinct !DISubprogram(name: "main", linkageName: "main", scope: !?, file: !?, line: 3, scopeLine: 3, type: !?, unit: !1, spFlags: DISPFlagDefinition)
+/// @GREP_IR distinct !DISubprogram(name: "+", linkageName: "__O43__SPECIAL___T_int__T_int_SPECIAL____T_int__T_int", *)
+/// @GREP_IR distinct !DICompileUnit(language: DW_LANG_C, file: !?, producer: "glang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+/// @GREP_IR ret i32 %?, !dbg ![0-9]
+/// @GREP_IR !{i32 1, !"Dwarf Version", i32 4}
+/// @GREP_IR !{i32 1, !"Debug Info Version", i32 3}
+/// @GREP_IR declare void @llvm.dbg.declare(metadata, metadata, metadata)

--- a/tests/debug/variables.c3
+++ b/tests/debug/variables.c3
@@ -1,12 +1,12 @@
-typedef S : { ptr : S&, x : int }
+typedef [T] S : { ptr : S<T>&, x : T }
 
 function main : () -> int = {
-    mut s : S;
+    mut s : S<int>;
     return 0;
 }
 
 /// @COMPILE
-/// @GREP_IR !DICompositeType(elements: !?, size: 128, tag: DW_TAG_structure_type)
+/// @GREP_IR !DICompositeType(elements: !?, name: "S<int>", size: 128, tag: DW_TAG_structure_type)
 /// @GREP_IR !DIDerivedType(baseType: !?, size: 64, tag: DW_TAG_reference_type)
 /// @GREP_IR !DIDerivedType(baseType: !?, name: "ptr", offset: 0, size: 64, tag: DW_TAG_member)
 /// @GREP_IR !DIBasicType(encoding: DW_ATE_signed, name: "int", size: 32, tag: DW_TAG_base_type)

--- a/tests/debug/variables.c3
+++ b/tests/debug/variables.c3
@@ -1,0 +1,15 @@
+typedef S : { ptr : S&, x : int }
+
+function main : () -> int = {
+    mut s : S;
+    return 0;
+}
+
+/// @COMPILE
+/// @GREP_IR !DICompositeType(elements: !?, size: 128, tag: DW_TAG_structure_type)
+/// @GREP_IR !DIDerivedType(baseType: !?, size: 64, tag: DW_TAG_reference_type)
+/// @GREP_IR !DIDerivedType(baseType: !?, name: "ptr", offset: 0, size: 64, tag: DW_TAG_member)
+/// @GREP_IR !DIBasicType(encoding: DW_ATE_signed, name: "int", size: 32, tag: DW_TAG_base_type)
+/// @GREP_IR !DIDerivedType(baseType: !?, name: "x", offset: 64, size: 32, tag: DW_TAG_member)
+/// @GREP_IR !{!?, !?}
+/// @GREP_IR !DILocalVariable(file: !?, line: 4, name: "s", scope: !?, type: !?)

--- a/tests/debug/variables.c3
+++ b/tests/debug/variables.c3
@@ -1,4 +1,4 @@
-typedef [T] S : { ptr : S<T>&, x : T }
+typedef [T] S : { ptr : S<T>&, x : T, y : f32 }
 
 function main : () -> int = {
     mut s : S<int>;
@@ -6,10 +6,12 @@ function main : () -> int = {
 }
 
 /// @COMPILE
-/// @GREP_IR !DICompositeType(elements: !?, name: "S<int>", size: 128, tag: DW_TAG_structure_type)
+/// @GREP_IR !DICompositeType(elements: !??, name: "S<int>", size: 128, tag: DW_TAG_structure_type)
 /// @GREP_IR !DIDerivedType(baseType: !?, size: 64, tag: DW_TAG_reference_type)
 /// @GREP_IR !DIDerivedType(baseType: !?, name: "ptr", offset: 0, size: 64, tag: DW_TAG_member)
 /// @GREP_IR !DIBasicType(encoding: DW_ATE_signed, name: "int", size: 32, tag: DW_TAG_base_type)
 /// @GREP_IR !DIDerivedType(baseType: !?, name: "x", offset: 64, size: 32, tag: DW_TAG_member)
-/// @GREP_IR !{!?, !?}
+/// @GREP_IR !DIBasicType(encoding: DW_ATE_float, name: "f32", size: 32, tag: DW_TAG_base_type)
+/// @GREP_IR !DIDerivedType(baseType: !9, name: "y", offset: 96, size: 32, tag: DW_TAG_member)
+/// @GREP_IR !{!?, !?, !??}
 /// @GREP_IR !DILocalVariable(file: !?, line: 4, name: "s", scope: !?, type: !?)

--- a/tests/misc/string_constants.c3
+++ b/tests/misc/string_constants.c3
@@ -9,6 +9,6 @@ function main: () -> int = {
 }
 
 /// @COMPILE --use-crt
-/// @GREP_IR [11 x i8] c"άβ\c2\ad\e2\80\80γ"
+/// @GREP_IR [[]11 x i8[]] c"άβ\c2\ad\e2\80\80γ"
 /// @RUN; EXPECT OUT
 /// άβ­ γ

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -148,7 +148,6 @@ def run_test(file_path: Path) -> bool:
     # @GREP_IR
     for needle in config.grep_ir_strs:
         if not fnmatchcase(ir_output, f"*{needle}*"):
-            print(needle, ir_output)
             raise IRGrepFailure(needle)
 
     # @RUN

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,4 +1,4 @@
-import fnmatch
+from fnmatch import fnmatchcase
 import subprocess
 from argparse import ArgumentParser
 from concurrent.futures import ThreadPoolExecutor
@@ -107,7 +107,7 @@ def run_command(
         # - ? to match any single character
         # - [seq] to match any character in seq
         # - [!seq] to match any character not in seq
-        return all(map(fnmatch.fnmatchcase, actual_trimmed, expected_trimmed))
+        return all(map(fnmatchcase, actual_trimmed, expected_trimmed))
 
     if expected_output.status != status:
         raise TestCommandFailure("status", status, stdout, stderr, stage)
@@ -147,7 +147,8 @@ def run_test(file_path: Path) -> bool:
 
     # @GREP_IR
     for needle in config.grep_ir_strs:
-        if needle not in ir_output:
+        if not fnmatchcase(ir_output, f"*{needle}*"):
+            print(needle, ir_output)
             raise IRGrepFailure(needle)
 
     # @RUN

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,7 +1,7 @@
-from fnmatch import fnmatchcase
 import subprocess
 from argparse import ArgumentParser
 from concurrent.futures import ThreadPoolExecutor
+from fnmatch import fnmatchcase
 from importlib import resources
 from multiprocessing import cpu_count
 from os import getenv


### PR DESCRIPTION
I think you can take a look now - it's pretty functional.

The compiler now always emits LLVM-style debugging information (basically DWARF).
- The format is pretty straightforward, but it might help to look at some example IR before you review
- To get line number support, we need to pass the `Meta` from the parser to every single expression we codegen
- That's quite tedious unfortunately, but there's no other way
- The `generate_ir()` function now needs more inputs and has a second output, to handle the metadata
- To get type and variable support (`gdb` needs to know how to read variables off of memory), we need to serialize each type
- That's quite tricky and I don't really have a nice solution yet - maybe we should do it during type resolution to avoid cycles, etc but also this is strictly an IR thing so it doesn't feel right either