### PR TITLE
Implement Itanium C++ ABI name mangling

### DIFF
--- a/src/glang/codegen/builtin_types.py
+++ b/src/glang/codegen/builtin_types.py
@@ -145,7 +145,7 @@ class NamedType(Type):
             assert self.alias is not None
             return self.alias.ir_type
 
-        return f"%type.{self.ir_mangle}"
+        return f"%type._Z{self.ir_mangle}"
 
     def to_di_type(self, metadata_gen: Iterator[int]) -> list[Metadata]:
         metadata = super().to_di_type(metadata_gen)

--- a/src/glang/codegen/builtin_types.py
+++ b/src/glang/codegen/builtin_types.py
@@ -814,10 +814,6 @@ class FunctionSignature:
             else mangle_operator_name(self.name)
         )
 
-        if any(map(lambda c: c.isspace(), mangled_name)):
-            raise Exception(f"bad mangle : `{mangled_name}` from `{self.name}`")
-
-        # TODO make mangle_template_args() return the empty string.
         mangled_template_args = (
             mangle_template_args(self.specialization) if self.specialization else ""
         )

--- a/src/glang/codegen/mangling.py
+++ b/src/glang/codegen/mangling.py
@@ -87,7 +87,8 @@ def mangle_template_args(args: Iterable[SpecializationItem]) -> str:
 
 def mangle_operator_name(name: str) -> str:
     # **, @
-    # <operator-name> ::= pl  # +
+    # <operator-name> ::= co  # ~
+    #                 ::= pl  # +
     #                 ::= mi  # -
     #                 ::= ml  # *
     #                 ::= dv  # /
@@ -118,6 +119,8 @@ def mangle_operator_name(name: str) -> str:
     #                 ::= ix  # []
     #                 ::= v <digit> <source-name>	# vendor extended operator
     match name:
+        case "~":
+            return "co"
         case "+":
             return "pl"
         case "-":

--- a/src/glang/codegen/mangling.py
+++ b/src/glang/codegen/mangling.py
@@ -86,7 +86,6 @@ def mangle_template_args(args: Iterable[SpecializationItem]) -> str:
 
 
 def mangle_operator_name(name: str) -> str:
-    # **, @
     # <operator-name> ::= co  # ~
     #                 ::= pl  # +
     #                 ::= mi  # -

--- a/src/glang/codegen/mangling.py
+++ b/src/glang/codegen/mangling.py
@@ -1,0 +1,187 @@
+from typing import Iterable
+
+from .interfaces import SpecializationItem, Type
+
+
+def mangle_int(size_in_bits: int, is_signed: bool) -> str:
+    # <builtin-type> ::= c  # char
+    #                ::= a  # signed char
+    #                ::= h  # unsigned char
+    #                ::= s  # short
+    #                ::= t  # unsigned short
+    #                ::= i  # int
+    #                ::= j  # unsigned int
+    #                ::= l  # long
+    #                ::= m  # unsigned long
+    #                ::= x  # long long, __int64
+    #                ::= y  # unsigned long long, __int64
+    #                ::= n  # __int128
+    #                ::= o  # unsigned __int128
+    match size_in_bits, is_signed:
+        case 8, True:
+            return "c"
+        case 8, False:
+            return "h"
+        case 16, True:
+            return "s"
+        case 16, False:
+            return "t"
+        case 32, True:
+            return "i"
+        case 32, False:
+            return "j"
+        case 64, True:
+            return "l"
+        case 64, False:
+            return "m"
+        case 128, True:
+            return "n"
+        case 128, False:
+            return "o"
+
+    raise AssertionError()
+
+
+def mangle_float(size_in_bits: int) -> str:
+    # <builtin-type> ::= DF <number> _  # _FloatN (N bits)
+    #                ::= f              # float
+    #                ::= d              # double
+    #                ::= g              # __float128
+    match size_in_bits:
+        case 16:
+            return "DF16_"
+        case 32:
+            return "f"
+        case 64:
+            return "d"
+        case 128:
+            return "g"
+
+    raise AssertionError()
+
+
+def mangle_source_name(identifier: str) -> str:
+    assert len(identifier) > 0
+
+    # <source-name> ::= <positive length number> <identifier>
+    return f"{len(identifier)}{identifier}"
+
+
+def mangle_template_arg(arg: SpecializationItem) -> str:
+    if isinstance(arg, Type):
+        # <template-arg> ::= <type>  # type or template
+        return arg.ir_mangle
+    else:
+        assert isinstance(arg, int)
+        # <template-arg> ::= <expr-primary>             # simple expressions
+        # <expr-primary> ::= L <type> <value number> E  # integer literal
+        # FIXME mangle as an int, even though we don't actually force a type.
+        # TODO negative numbers.
+        return f"Li{arg}E"
+
+
+def mangle_template_args(args: Iterable[SpecializationItem]) -> str:
+    # <template-args> ::= I <template-arg>+ E
+    return f"I{str.join('', map(mangle_template_arg, args))}E"
+
+
+def mangle_operator_name(name: str) -> str:
+    # **, @
+    # <operator-name> ::= pl  # +
+    #                 ::= mi  # -
+    #                 ::= ml  # *
+    #                 ::= dv  # /
+    #                 ::= rm  # %
+    #                 ::= an  # &
+    #                 ::= or  # |
+    #                 ::= eo  # ^
+    #                 ::= pL  # +=
+    #                 ::= mI  # -=
+    #                 ::= mL  # *=
+    #                 ::= dV  # /=
+    #                 ::= rM  # %=
+    #                 ::= aN  # &=
+    #                 ::= oR  # |=
+    #                 ::= eO  # ^=
+    #                 ::= ls  # <<
+    #                 ::= rs  # >>
+    #                 ::= lS  # <<=
+    #                 ::= rS  # >>=
+    #                 ::= eq  # ==
+    #                 ::= ne  # !=
+    #                 ::= lt  # <
+    #                 ::= gt  # >
+    #                 ::= le  # <=
+    #                 ::= ge  # >=
+    #                 ::= ss  # <=>
+    #                 ::= nt  # !
+    #                 ::= ix  # []
+    #                 ::= v <digit> <source-name>	# vendor extended operator
+    match name:
+        case "+":
+            return "pl"
+        case "-":
+            return "mi"
+        case "*":
+            return "ml"
+        case "/":
+            return "dv"
+        case "%":
+            return "rm"
+        case "&":
+            return "an"
+        case "|":
+            return "or"
+        case "^":
+            return "eo"
+        case "+=":
+            return "pL"
+        case "-=":
+            return "mI"
+        case "*=":
+            return "mL"
+        case "/=":
+            return "dV"
+        case "%=":
+            return "rM"
+        case "&=":
+            return "aN"
+        case "|=":
+            return "oR"
+        case "^=":
+            return "eO"
+        case "<<":
+            return "ls"
+        case ">>":
+            return "rs"
+        case "<<=":
+            return "lS"
+        case ">>=":
+            return "rS"
+        case "==":
+            return "eq"
+        case "!=":
+            return "ne"
+        case "<":
+            return "lt"
+        case ">":
+            return "gt"
+        case "<=":
+            return "le"
+        case ">=":
+            return "ge"
+        case "<=>":
+            return "ss"
+        case "!":
+            return "nt"
+        case "[]":
+            return "ix"
+        # Vendors who define builtin extended operators (e.g. __imag) shall
+        # encode them as a 'v' prefix followed by the operand count as a single
+        # decimal digit, and the name in <length,ID> form.
+        case "**":
+            return "v2" + mangle_source_name("power")
+        case "@":
+            return "v2" + mangle_source_name("matmul")
+
+    raise AssertionError(name)

--- a/tests/debug/basic.c3
+++ b/tests/debug/basic.c3
@@ -8,7 +8,7 @@ function main : () -> int = {
 /// @GREP_IR !DIFile(checksum: "*", checksumkind: CSK_SHA256, directory: "*/tests/debug", filename: "basic.c3")
 /// @GREP_IR !DIFile(checksum: "*", checksumkind: CSK_SHA256, directory: "*/lib/std", filename: "arithmetic.c3")
 /// @GREP_IR distinct !DISubprogram(name: "main", linkageName: "main", scope: !?, file: !?, line: 3, scopeLine: 3, type: !?, unit: !1, spFlags: DISPFlagDefinition)
-/// @GREP_IR distinct !DISubprogram(name: "+", linkageName: "__O43__SPECIAL___T_int__T_int_SPECIAL____T_int__T_int", *)
+/// @GREP_IR distinct !DISubprogram(name: "+", linkageName: "_ZplIiiEiii", *)
 /// @GREP_IR distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !?, producer: "glang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
 /// @GREP_IR ret i32 %?, !dbg ![0-9]
 /// @GREP_IR !{i32 1, !"Dwarf Version", i32 4}

--- a/tests/generic_types/basic_usage.c3
+++ b/tests/generic_types/basic_usage.c3
@@ -7,5 +7,5 @@ function main: () -> int = {
 }
 
 /// @COMPILE
-/// @GREP_IR %type.__T_my_struct__S__T_i32__T_i16__T_i8 = type {i32, i16, i8}
+/// @GREP_IR %type._Z9my_structIiscE = type {i32, i16, i8}
 /// @RUN


### PR DESCRIPTION
Based on https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling, which is what GCC and Clang use. 

Everything works (by inspection), but I'll add tests before merging.

I haven't implemented compression yet (and not sure it's worth it), but it's necessary if we want to be 100% compatible with other toolchains.