### PR TITLE
Add Map container and RB tree iterator

### DIFF
--- a/src/glang/lib/std/arithmetic.c3
+++ b/src/glang/lib/std/arithmetic.c3
@@ -9,6 +9,7 @@ typedef [U, V] AreCompatibleArithmeticTypes :
     >
 
 typedef [U, V] CommonArithmeticType: TypeIf<U, AreCompatibleArithmeticTypes<U, V>>
+typedef [U, V] CommonArithmeticType<U&, V&>: TypeIf<U, AreCompatibleArithmeticTypes<U, V>>
 
 typedef CommonArithmeticType<i8, i16>   : i16
 typedef CommonArithmeticType<i8, i32>   : i32
@@ -29,6 +30,7 @@ typedef CommonArithmeticType<f32, f128> : f128
 typedef CommonArithmeticType<f64, f128> : f128
 
 typedef [U, V] ArithmeticCompareResult : TypeIf<bool, AreCompatibleArithmeticTypes<U, V>>
+typedef [U, V] ArithmeticCompareResult<U&, V&> : TypeIf<bool, AreCompatibleArithmeticTypes<U, V>>
 typedef [T] RegisterHasTrivialAssignments<Override<T>> : TypeIf<TrueType, IsArithmetic<T>>
 
 @operator [T] + : (value: T) -> TypeIf<T, IsArithmetic<T>> = { return value; }

--- a/src/glang/lib/std/json.c3
+++ b/src/glang/lib/std/json.c3
@@ -1,10 +1,11 @@
 @require_once "std/arithmetic.c3"
+@require_once "std/iterators.c3"
 @require_once "std/logical.c3"
-@require_once "std/string.c3"
+@require_once "std/map.c3"
 @require_once "std/memory.c3"
+@require_once "std/string.c3"
 @require_once "std/vector.c3"
 @require_once "std/wrappers.c3"
-@require_once "std/iterators.c3"
 
 typedef StringViewIter : ContiguousContainerIter<View<u8>&, u8&>
 typedef VectorIter<JSON_Node> : ContiguousContainerIter<Vector<JSON_Node>&, JSON_Node mut&>
@@ -21,6 +22,7 @@ typedef JSON_Node : {
                     // 5: array, 6: object
     value    : Optional<StringView>,
     children : Vector<JSON_Node>,
+    map      : Map<JSON_Node, JSON_Node>,
 }
 
 function make<JSON_Node> : (node_type : int, allocator : Allocator mut&) -> JSON_Node = {
@@ -28,7 +30,16 @@ function make<JSON_Node> : (node_type : int, allocator : Allocator mut&) -> JSON
         node_type,
         make<Optional<StringView>>(),
         make<Vector<JSON_Node>>(&mut allocator),
+        make<Map<JSON_Node, JSON_Node>>(),
     };
+}
+
+@operator < : (left : JSON_Node&, right : JSON_Node&) -> bool = {
+    return ref_to_addr(&left) < ref_to_addr(&right);
+}
+
+@operator == : (left : JSON_Node&, right : JSON_Node&) -> bool = {
+    return ref_to_addr(&left) == ref_to_addr(&right);
 }
 
 function has_next : (cursor : Cursor mut&) -> bool = {
@@ -50,7 +61,6 @@ function next : (cursor : Cursor mut&) -> Optional<u8> = {
     return make<Optional<u8>>();
 }
 
-function position : (cursor : Cursor mut&) -> isize = { return (&cursor):position();}
 function position : (cursor : Cursor&) -> isize = {
     // Looking into the iterator like this is sorta cursed
     return cursor.iter.current_index;
@@ -131,8 +141,6 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
             return make<Optional<JSON_Node>>();
         }
 
-        node.children:push_back(string_node:data());
-
         cursor:eat_whitespace();
 
         if !cursor:eat(char(":")) {
@@ -147,7 +155,7 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
             return make<Optional<JSON_Node>>();
         }
 
-        node.children:push_back(value_node:data());
+        node.map:insert(string_node:data(), value_node:data());
 
         if cursor:eat(char("}")) {
             // We're done.
@@ -448,22 +456,15 @@ function [IO] write : (io : IO mut&, node : JSON_Node) -> TypeIf<StringView, IsS
         // FIXME we should be using a buffer here.
         io:write(sv("{"));
 
-        mut iter : VectorIter<JSON_Node> = node.children:get_iter();
-        mut flag : bool = true;
+        mut iter : MapIter<JSON_Node, JSON_Node> = node.map:get_citer();
 
         // XXX we have to borrow the iterator, otherwise it is not updated
         // in place by the implicit call to get_next().
         for element in &mut iter {
-            io:write(element);
-
-            if flag {
-                io:write(sv(": "));
-            } else {
-                if iter:has_next() {
-                    io:write(sv(", "));
-                }
+            io:writef(sv("%: %"), element.key, element.value);
+            if iter:has_next() {
+                io:write(sv(", "));
             }
-            flag ^= true;
         }
 
         return io:write(sv("}"));

--- a/src/glang/lib/std/json.c3
+++ b/src/glang/lib/std/json.c3
@@ -451,12 +451,12 @@ function [IO] write : (io : IO mut&, node : JSON_Node) -> TypeIf<void, IsStreama
         // FIXME we should be using a buffer here.
         io:write(sv("{"));
 
-        mut iter : MapIter<JSON_Node, JSON_Node> = node.map:get_citer();
+        mut iter : MapIter<StringView, JSON_Node> = node.map:get_citer();
 
         // XXX we have to borrow the iterator, otherwise it is not updated
         // in place by the implicit call to get_next().
         for element in &mut iter {
-            io:writef(sv("%: %"), element.key, element.value);
+            io:writef(sv("\"%\": %"), element.key, element.value);
             if iter:has_next() {
                 io:write(sv(", "));
             }

--- a/src/glang/lib/std/json.c3
+++ b/src/glang/lib/std/json.c3
@@ -412,6 +412,7 @@ function [IO] write : (io : IO mut&, node : JSON_Node) -> TypeIf<void, IsStreama
             buffer.data[0] = char("\"");
             buffer.data[buffer.length - 1] = char("\"");
             for i in range(string:length()) {
+                // FIXME we need to escape the strings we print here.
                 buffer.data[i + 1] = string.buffer.data[i];
             }
 
@@ -454,6 +455,7 @@ function [IO] write : (io : IO mut&, node : JSON_Node) -> TypeIf<void, IsStreama
         // XXX we have to borrow the iterator, otherwise it is not updated
         // in place by the implicit call to get_next().
         for element in &mut iter {
+            // FIXME we need to escape the strings we print here.
             io:writef(sv("\"%\": %"), element.key, element.value);
             if iter:has_next() {
                 io:write(sv(", "));

--- a/src/glang/lib/std/json.c3
+++ b/src/glang/lib/std/json.c3
@@ -12,7 +12,7 @@ typedef VectorIter<JSON_Node> : ContiguousContainerIter<Vector<JSON_Node>&, JSON
 
 typedef Cursor : {
     iter      : StringViewIter,
-    allocator : Allocator,  // FIXME use global allocator.
+    allocator : Allocator mut&,  // FIXME use global allocator.
     // TODO when we get RAII working, add a max_depth field to prevent crashes
     // when the input is too nested.
 }
@@ -30,7 +30,7 @@ function make<JSON_Node> : (node_type : int, allocator : Allocator mut&) -> JSON
         node_type,
         make<Optional<StringView>>(),
         make<Vector<JSON_Node>>(&mut allocator),
-        make<Map<StringView, JSON_Node>>(),
+        make<Map<StringView, JSON_Node>>(&mut allocator),
     };
 }
 
@@ -129,7 +129,7 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
         let string_node : Optional<JSON_Node> = cursor:parse_string();
 
         if !string_node:has_value() {
-            node.children:deallocate();
+            node.map:clear();
             return make<Optional<JSON_Node>>();
         }
 
@@ -139,14 +139,14 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
         cursor:eat_whitespace();
 
         if !cursor:eat(char(":")) {
-            node.children:deallocate();
+            node.map:clear();
             return make<Optional<JSON_Node>>();
         }
 
         let value_node : Optional<JSON_Node> = cursor:parse_element();
 
         if !value_node:has_value() {
-            node.children:deallocate();
+            node.map:clear();
             return make<Optional<JSON_Node>>();
         }
 
@@ -158,7 +158,7 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
         }
 
         if !cursor:eat(char(",")) {
-            node.children:deallocate();
+            node.map:clear();
             return make<Optional<JSON_Node>>();
         }
     }
@@ -365,11 +365,9 @@ function parse_number : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
 }
 
 // TODO this and write below should be the only public functions.
-function json_parse : (source : StringView) -> Optional<JSON_Node> = {
+function json_parse : (source : StringView, allocator : Allocator mut&) -> Optional<JSON_Node> = {
     // FIXME memory safety, memory leaks.
-    mut cursor : Cursor = {
-        source:get_iter(), initialize_allocator()
-    };
+    mut cursor : Cursor = { source:get_iter(), &mut allocator };
 
     let result : Optional<JSON_Node> = cursor:parse_element();
 

--- a/src/glang/lib/std/json.c3
+++ b/src/glang/lib/std/json.c3
@@ -23,9 +23,7 @@ typedef JSON_Node : {
     children : Vector<JSON_Node>,
 }
 
-// TODO something like new<JSON_Node> would be nice, but we don't support
-// function specializations.
-function new_json_node : (node_type : int, allocator : Allocator mut&) -> JSON_Node = {
+function make<JSON_Node> : (node_type : int, allocator : Allocator mut&) -> JSON_Node = {
     return {
         node_type,
         make<Optional<StringView>>(),
@@ -114,7 +112,7 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
         return make<Optional<JSON_Node>>();
     }
 
-    mut node : JSON_Node = new_json_node(/* object */ 6, &mut cursor.allocator);
+    mut node : JSON_Node = make<JSON_Node>(/* object */ 6, &mut cursor.allocator);
 
     cursor:eat_whitespace();
 
@@ -172,7 +170,7 @@ function parse_array : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
         return make<Optional<JSON_Node>>();
     }
 
-    mut node : JSON_Node = new_json_node(/* array */ 5, &mut cursor.allocator);
+    mut node : JSON_Node = make<JSON_Node>(/* array */ 5, &mut cursor.allocator);
 
     cursor:eat_whitespace();
 
@@ -226,15 +224,15 @@ function parse_value : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
     }
 
     if cursor:eat(sv("null")) {
-        return make<Optional<JSON_Node>>(new_json_node(/* null */ 0, &mut cursor.allocator));
+        return make<Optional<JSON_Node>>(make<JSON_Node>(/* null */ 0, &mut cursor.allocator));
     }
 
     if cursor:eat(sv("true")) {
-        return make<Optional<JSON_Node>>(new_json_node(/* true */ 1, &mut cursor.allocator));
+        return make<Optional<JSON_Node>>(make<JSON_Node>(/* true */ 1, &mut cursor.allocator));
     }
 
     if cursor:eat(sv("false")) {
-        return make<Optional<JSON_Node>>(new_json_node(/* false */ 2, &mut cursor.allocator));
+        return make<Optional<JSON_Node>>(make<JSON_Node>(/* false */ 2, &mut cursor.allocator));
     }
 
     // Numbers don't have a prefix character, so just try and parse them.
@@ -271,7 +269,7 @@ function parse_string : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
 
     while cursor:has_next() {
         if !in_escape_seq and cursor:eat(char("\"")) {
-            mut node : JSON_Node = new_json_node(/* string */ 3, &mut cursor.allocator);
+            mut node : JSON_Node = make<JSON_Node>(/* string */ 3, &mut cursor.allocator);
 
             // TODO: https://github.com/DaveDuck321/GrapheneLang/issues/124
             let value: StringView = {(&string):view()};
@@ -357,7 +355,7 @@ function parse_number : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
         return make<Optional<JSON_Node>>();
     }
 
-    mut node : JSON_Node = new_json_node(/* string */ 4, &mut cursor.allocator);
+    mut node : JSON_Node = make<JSON_Node>(/* string */ 4, &mut cursor.allocator);
     node.value = make<Optional<StringView>>((&cursor):slice_between(start_pos, end_pos));
 
     return make<Optional<JSON_Node>>(node);

--- a/src/glang/lib/std/json.c3
+++ b/src/glang/lib/std/json.c3
@@ -271,9 +271,9 @@ function parse_string : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
         if !in_escape_seq and cursor:eat(char("\"")) {
             mut node : JSON_Node = make<JSON_Node>(/* string */ 3, &mut cursor.allocator);
 
-            // TODO: https://github.com/DaveDuck321/GrapheneLang/issues/124
-            let value: StringView = {(&string):view()};
-            node.value = make<Optional<StringView>>(value);
+            node.value = make<Optional<StringView>>(
+                make<StringView>(string:view())
+            );
 
             return make<Optional<JSON_Node>>(node);
         }

--- a/src/glang/lib/std/json.c3
+++ b/src/glang/lib/std/json.c3
@@ -22,7 +22,7 @@ typedef JSON_Node : {
                     // 5: array, 6: object
     value    : Optional<StringView>,
     children : Vector<JSON_Node>,
-    map      : Map<JSON_Node, JSON_Node>,
+    map      : Map<StringView, JSON_Node>,
 }
 
 function make<JSON_Node> : (node_type : int, allocator : Allocator mut&) -> JSON_Node = {
@@ -30,16 +30,8 @@ function make<JSON_Node> : (node_type : int, allocator : Allocator mut&) -> JSON
         node_type,
         make<Optional<StringView>>(),
         make<Vector<JSON_Node>>(&mut allocator),
-        make<Map<JSON_Node, JSON_Node>>(),
+        make<Map<StringView, JSON_Node>>(),
     };
-}
-
-@operator < : (left : JSON_Node&, right : JSON_Node&) -> bool = {
-    return ref_to_addr(&left) < ref_to_addr(&right);
-}
-
-@operator == : (left : JSON_Node&, right : JSON_Node&) -> bool = {
-    return ref_to_addr(&left) == ref_to_addr(&right);
 }
 
 function has_next : (cursor : Cursor mut&) -> bool = {
@@ -141,6 +133,9 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
             return make<Optional<JSON_Node>>();
         }
 
+        runtime_assert(string_node:data().value:has_value());
+        let string_view : StringView = string_node:data().value:data();
+
         cursor:eat_whitespace();
 
         if !cursor:eat(char(":")) {
@@ -155,7 +150,7 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
             return make<Optional<JSON_Node>>();
         }
 
-        node.map:insert(string_node:data(), value_node:data());
+        node.map:insert(string_view, value_node:data());
 
         if cursor:eat(char("}")) {
             // We're done.

--- a/src/glang/lib/std/logical.c3
+++ b/src/glang/lib/std/logical.c3
@@ -65,3 +65,8 @@ typedef [T] RegisterHasTrivialAssignments<Override<T>> : TypeIf<TrueType, IsLogi
 @operator [U, V] != : (lhs: U, rhs: V) -> LogicalCompareResult<U, V> = {
     return !(lhs == rhs);
 }
+
+// TODO just for string comparisons to work; come up with something better.
+@operator < : (lhs: u8, rhs: u8) -> bool = {
+    return __builtin_is_less_than(lhs, rhs);
+}

--- a/src/glang/lib/std/map.c3
+++ b/src/glang/lib/std/map.c3
@@ -9,27 +9,29 @@ typedef [K, V] MapNode : {
     value : V
 }
 
+typedef [K, V] MapIter : RB_Iter<MapNode<K, V>>
+
 // FIXME <=> is untested and broken :(
 typedef [K, V] HasSpaceship<MapNode<K, V>> : HasSpaceship<K>
 
-@operator [K1, K2, V] == : (left : MapNode<K1, V>, right : MapNode<K2, V>) -> bool = {
-    return left.key == right.key;
+@operator [K1, K2, V] == : (left : MapNode<K1, V>&, right : MapNode<K2, V>&) -> bool = {
+    return &left.key == &right.key;
 }
 
-@operator [K1, K2, V] != : (left : MapNode<K1, V>, right : MapNode<K2, V>) -> bool = {
-    return left.key != right.key;
+@operator [K1, K2, V] != : (left : MapNode<K1, V>&, right : MapNode<K2, V>&) -> bool = {
+    return &left.key != &right.key;
 }
 
-@operator [K1, K2, V] < : (left : MapNode<K1, V>, right : MapNode<K2, V>) -> bool = {
-    return left.key < right.key;
+@operator [K1, K2, V] < : (left : MapNode<K1, V>&, right : MapNode<K2, V>&) -> bool = {
+    return &left.key < &right.key;
 }
 
-@operator [K, V] != : (left : K, right : MapNode<K, V>) -> bool = {
-    return left != right.key;
+@operator [K, V] != : (left : K&, right : MapNode<K, V>&) -> bool = {
+    return &left != &right.key;
 }
 
-@operator [K, V] < : (left : K, right : MapNode<K, V>) -> bool = {
-    return left < right.key;
+@operator [K, V] < : (left : K&, right : MapNode<K, V>&) -> bool = {
+    return &left < &right.key;
 }
 
 typedef [K, V] Map : {
@@ -95,6 +97,6 @@ function [K, V, C] contains : (self : Map<K, V>&, key : C) -> bool = {
     return result:has_value();
 }
 
-function [K, V] get_citer : (map : Map<K, V> mut&) -> RB_Iter<MapNode<K, V>> = {
+function [K, V] get_citer : (map : Map<K, V> mut&) -> MapIter<K, V> = {
     return map.tree:get_citer();
 }

--- a/src/glang/lib/std/map.c3
+++ b/src/glang/lib/std/map.c3
@@ -1,0 +1,96 @@
+@require_once "arithmetic.c3"
+@require_once "iterators.c3"
+@require_once "rb_tree.c3"
+@require_once "type_traits.c3"
+@require_once "wrappers.c3"
+
+typedef [K, V] MapNode : {
+    key   : K,
+    value : V
+}
+
+// FIXME <=> is untested and broken :(
+typedef [K, V] HasSpaceship<MapNode<K, V>> : HasSpaceship<K>
+
+@operator [K1, K2, V] == : (left : MapNode<K1, V>, right : MapNode<K2, V>) -> bool = {
+    return left.key == right.key;
+}
+
+@operator [K1, K2, V] != : (left : MapNode<K1, V>, right : MapNode<K2, V>) -> bool = {
+    return left.key != right.key;
+}
+
+@operator [K1, K2, V] < : (left : MapNode<K1, V>, right : MapNode<K2, V>) -> bool = {
+    return left.key < right.key;
+}
+
+@operator [K, V] != : (left : K, right : MapNode<K, V>) -> bool = {
+    return left != right.key;
+}
+
+@operator [K, V] < : (left : K, right : MapNode<K, V>) -> bool = {
+    return left < right.key;
+}
+
+typedef [K, V] Map : {
+    tree   : RB_Tree<MapNode<K, V>>,
+    length : isize
+}
+
+function [K, V] make<Map<K, V>> : () -> Map<K, V> = {
+    return {
+        .tree = make<RB_Tree<MapNode<K, V>>>(),
+        .length = 0,
+    };
+}
+
+function [K, V, C] at : (self : Map<K, V>&, key : C) -> Optional<V> = {
+    let result : Optional<MapNode<K, V>> = self.tree:search(key);
+
+    if result:has_value() {
+        return make<Optional<V>>(result:data().value);
+    }
+
+    return make<Optional<V>>();
+}
+
+function [K, V] empty : (self : Map<K, V>&) -> bool = {
+    return self.length == 0;
+}
+
+function [K, V] size : (self : Map<K, V>&) -> isize = {
+    return self.length;
+}
+
+function [K, V] clear : (self : Map<K, V> mut&) -> void = {
+    mut min : Optional<MapNode<K, V>> = self.tree:minimum();
+    while min:has_value() {
+        self:erase(min:data());
+        min = self.tree:minimum();
+    }
+}
+
+function [K, V] insert : (self : Map<K, V> mut&, key : K, value : V) -> void = {
+    let node : MapNode<K, V> = {
+        .key = key,
+        .value = value
+    };
+
+    self.tree:insert(node);
+    self.length += 1;
+}
+
+function [K, V, C] erase : (self : Map<K, V> mut&, key : C) -> bool = {
+    let deleted : bool = self.tree:delete(key);
+
+    if deleted {
+        self.length -= 1;
+    }
+
+    return deleted;
+}
+
+function [K, V, C] contains : (self : Map<K, V>&, key : C) -> bool = {
+    let result : Optional<V> = self:at(key);
+    return result:has_value();
+}

--- a/src/glang/lib/std/map.c3
+++ b/src/glang/lib/std/map.c3
@@ -39,9 +39,9 @@ typedef [K, V] Map : {
     length : isize
 }
 
-function [K, V] make<Map<K, V>> : () -> Map<K, V> = {
+function [K, V] make<Map<K, V>> : (allocator : Allocator mut&) -> Map<K, V> = {
     return {
-        .tree = make<RB_Tree<MapNode<K, V>>>(),
+        .tree = make<RB_Tree<MapNode<K, V>>>(&mut allocator),
         .length = 0,
     };
 }

--- a/src/glang/lib/std/map.c3
+++ b/src/glang/lib/std/map.c3
@@ -94,3 +94,7 @@ function [K, V, C] contains : (self : Map<K, V>&, key : C) -> bool = {
     let result : Optional<V> = self:at(key);
     return result:has_value();
 }
+
+function [K, V] get_citer : (map : Map<K, V> mut&) -> RB_Iter<MapNode<K, V>> = {
+    return map.tree:get_citer();
+}

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -114,7 +114,7 @@ function [K] which_child_am_i : (
 }
 
 function [K] which_child_am_i : (node : RB_Node<K> mut&) -> bool = {
-    return which_child_am_i(make(&mut node), &mut node.parent:data());
+    return which_child_am_i(make<Optional<RB_Node<K> mut&>>(&mut node), &mut node.parent:data());
 }
 
 function [K] is_red : (node_opt : Optional<RB_Node<K> mut&>&) -> bool = {
@@ -235,7 +235,7 @@ function [K] insert : (self : RB_Tree<K> mut&, key : K) -> void = {
     while u_ptr:data():has_value() {
         let u : RB_Node<K> mut& = &mut u_ptr:data():data();
 
-        if key == u.key {
+        if &key == &u.key {
             // Key already exists. Overwrite it with the new key (if the tree is
             // used to implement a map, then the associated value could be
             // different) and return early, as the red-black tree is already
@@ -247,7 +247,7 @@ function [K] insert : (self : RB_Tree<K> mut&, key : K) -> void = {
         // Keep track of the parent node.
         p_opt:store(&mut u_ptr:data():data());
 
-        u_ptr = {&mut u:get_child(left_if(key < u.key))};
+        u_ptr = {&mut u:get_child(left_if(&key < &u.key))};
     }
 
     u_ptr:data():store(&mut self:new<RB_Node<K>>(key, p_opt));
@@ -260,8 +260,8 @@ function [K, Comparable] search_impl : (
 ) -> Optional<RB_Node<K> mut&> = {
     mut u : Optional<RB_Node<K> mut&> = self.root;
 
-    while u:has_value() and key != u:data().key {
-        u = u:data():get_child(left_if(key < u:data().key));
+    while u:has_value() and &key != &u:data().key {
+        u = u:data():get_child(left_if(&key < &u:data().key));
     }
 
     return u;

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -38,6 +38,10 @@ typedef [K] RB_Tree : {
     allocator : Allocator,  // FIXME use global allocator.
 }
 
+typedef [K] RB_Iter: {
+    node : Optional<RB_Node<K> mut&>
+}
+
 @operator [K] == : (left : RB_Node<K>&, right : RB_Node<K>&) -> bool = {
     return ref_to_addr(&left) == ref_to_addr(&right);
 }
@@ -520,4 +524,24 @@ function [K] successor : (node : RB_Node<K> mut&) -> Optional<RB_Node<K> mut&> =
     }
 
     return parent;
+}
+
+function [K] get_citer : (tree : RB_Tree<K> mut&) -> RB_Iter<K> = {
+    if tree.root:has_value() {
+        return { make<Optional<RB_Node<K> mut&>>(&mut tree.root:data():minimum()) };
+    }
+    else {
+        return { make<Optional<RB_Node<K> mut&>>() };
+    }
+}
+
+@implicit [K] has_next : (self : RB_Iter<K> mut&) -> bool = {
+    return self.node:has_value();
+}
+
+@implicit [K] get_next : (self : RB_Iter<K> mut&) -> K& = {
+    runtime_assert(self.node:has_value());
+    let node : RB_Node<K> mut& = &mut self.node:data();
+    self.node = node:successor();
+    return &node.key;
 }

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -303,6 +303,14 @@ function [K] minmax : (node : RB_Node<K> mut&, direction : bool) -> RB_Node<K> m
     return &mut u:data();
 }
 
+function [K] minimum : (node : RB_Node<K> mut&) -> RB_Node<K> mut& = {
+    return &mut node:minmax(LEFT());
+}
+
+function [K] maximum : (node : RB_Node<K> mut&) -> RB_Node<K> mut& = {
+    return &mut node:minmax(RIGHT());
+}
+
 function [K] minmax : (tree : RB_Tree<K> mut&, direction : bool) -> Optional<K> = {
     if tree.root:has_value() {
         return make(tree.root:data():minmax(direction).key);
@@ -482,4 +490,34 @@ function [K, Comparable] delete : (self : RB_Tree<K> mut&, key : Comparable) -> 
     }
 
     return false;
+}
+
+function [K] predecessor : (node : RB_Node<K> mut&) -> Optional<RB_Node<K> mut&> = {
+    if node.left:has_value() {
+        return make<Optional<RB_Node<K> mut&>>(&mut node.left:data():maximum());
+    }
+
+    mut current : Optional<RB_Node<K> mut&> = make<Optional<RB_Node<K> mut&>>(&mut node);
+    mut parent  : Optional<RB_Node<K> mut&> = node.parent;
+    while parent:has_value() and parent:data().right != current {
+        current = parent;
+        parent = parent:data().parent;
+    }
+
+    return parent;
+}
+
+function [K] successor : (node : RB_Node<K> mut&) -> Optional<RB_Node<K> mut&> = {
+    if node.right:has_value() {
+        return make<Optional<RB_Node<K> mut&>>(&mut node.right:data():minimum());
+    }
+
+    mut current : Optional<RB_Node<K> mut&> = make<Optional<RB_Node<K> mut&>>(&mut node);
+    mut parent  : Optional<RB_Node<K> mut&> = node.parent;
+    while parent:has_value() and parent:data().left != current {
+        current = parent;
+        parent = parent:data().parent;
+    }
+
+    return parent;
 }

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -35,7 +35,7 @@ typedef [K] RB_Node : {
 
 typedef [K] RB_Tree : {
     root : Optional<RB_Node<K> mut&>,
-    allocator : Allocator,  // FIXME use global allocator.
+    allocator : Allocator mut&,  // FIXME use global allocator.
 }
 
 typedef [K] RB_Iter: {
@@ -82,10 +82,10 @@ function [K] new<RB_Node<K>> : (
     return &mut node;
 }
 
-function [K] make<RB_Tree<K>> : () -> RB_Tree<K> = {
+function [K] make<RB_Tree<K>> : (allocator : Allocator mut&) -> RB_Tree<K> = {
     return {
         .root = make<Optional<RB_Node<K> mut&>>(),
-        .allocator = initialize_allocator(),
+        .allocator = &mut allocator,
     };
 }
 
@@ -272,7 +272,7 @@ function [K, Comparable] search : (
     mut result : Optional<RB_Node<K> mut&> = self:search_impl(key);
 
     if result:has_value() {
-        return make(result:data().key);
+        return make<Optional<K>>(result:data().key);
     }
 
     return make<Optional<K>>();
@@ -316,7 +316,7 @@ function [K] maximum : (node : RB_Node<K> mut&) -> RB_Node<K> mut& = {
 
 function [K] minmax : (tree : RB_Tree<K> mut&, direction : bool) -> Optional<K> = {
     if tree.root:has_value() {
-        return make(tree.root:data():minmax(direction).key);
+        return make<Optional<K>>(tree.root:data():minmax(direction).key);
     }
     return make<Optional<K>>();
 }
@@ -358,7 +358,7 @@ function [K] fix_after_delete_impl : (
         // was black, then now it is double black; if it was red, then now it is
         // red-and-black.
         w.colour = RED();
-        return make(&mut x_parent);
+        return make<Optional<RB_Node<K> mut&>>(&mut x_parent);
     }
 
     // Case 3: w is black with red close and black distant child.
@@ -455,11 +455,11 @@ function [K] delete_impl : (self : RB_Tree<K> mut&, u : RB_Node<K> mut&) -> void
             x.parent:store(&mut v);
         }
         else {
-            x_parent = make(&mut v);
+            x_parent = make<Optional<RB_Node<K> mut&>>(&mut v);
         }
 
         // Replace u with v.
-        self:replace_node_with(&mut u, make(&mut v));
+        self:replace_node_with(&mut u, make<Optional<RB_Node<K> mut&>>(&mut v));
         v.left = u.left;
         v.left:data().parent:store(&mut v);
         v.colour = u.colour;

--- a/src/glang/lib/std/rb_tree.c3
+++ b/src/glang/lib/std/rb_tree.c3
@@ -252,7 +252,7 @@ function [K] insert : (self : RB_Tree<K> mut&, key : K) -> void = {
 }
 
 function [K, Comparable] search_impl : (
-    self : RB_Tree<K> mut&, key : Comparable
+    self : RB_Tree<K>&, key : Comparable
 ) -> Optional<RB_Node<K> mut&> = {
     mut u : Optional<RB_Node<K> mut&> = self.root;
 
@@ -264,7 +264,7 @@ function [K, Comparable] search_impl : (
 }
 
 function [K, Comparable] search : (
-    self : RB_Tree<K> mut&, key : Comparable
+    self : RB_Tree<K>&, key : Comparable
 ) -> Optional<K> = {
     mut result : Optional<RB_Node<K> mut&> = self:search_impl(key);
 
@@ -472,7 +472,7 @@ function [K] delete_impl : (self : RB_Tree<K> mut&, u : RB_Node<K> mut&) -> void
     }
 }
 
-function [K] delete : (self : RB_Tree<K> mut&, key : K) -> bool = {
+function [K, Comparable] delete : (self : RB_Tree<K> mut&, key : Comparable) -> bool = {
     mut node : Optional<RB_Node<K> mut&> = self:search_impl(key);
 
     // Do nothing if the key is not in the tree.

--- a/src/glang/lib/std/span.c3
+++ b/src/glang/lib/std/span.c3
@@ -95,30 +95,27 @@ function [T] get : (span : _SpanImpl<T>&, index : isize)
 
 @operator [T] < : (lhs : _SpanImpl<T>, rhs : _SpanImpl<T>) -> bool = {
     // Use lexicographic ordering:
-    // - Given two sequences of the same lenght, the order of the two sequences
+    // - Given two sequences of the same length, the order of the two sequences
     //   depends on the order of the symbols in the first place where the two
     //   sequences differ.
     // - If the sequences have different lengths, the shortest sequence is
     //   padded with symbols that compare less than all other symbols until the
-    //   two sequences have the same lenght.
-    if lhs.length == rhs.length {
-        for i in range(lhs.length) {
-            if lhs:get(i) != rhs:get(i) {
-                // We've found the first place where they differ.
-                return lhs:get(i) < rhs:get(i);
-            }
+    //   two sequences have the same length.
+    let common_length : isize = min(lhs.length, rhs.length);
+    for i in range(common_length) {
+        if lhs:get(i) != rhs:get(i) {
+            // We've found the first place where they differ.
+            return lhs:get(i) < rhs:get(i);
         }
+    }
 
-        // Spans are equal.
+    // Spans are equal.
+    if lhs.length == rhs.length {
         return false;
     }
 
-    let common_length : isize = min(lhs.length, rhs.length);
-    if lhs:slice_to(common_length) == rhs:slice_to(common_length) {
-        return lhs.length < rhs.length;
-    }
-
-    return lhs:slice_to(common_length) < rhs:slice_to(common_length);
+    // The shortest sequence compares less.
+    return lhs.length < rhs.length;
 }
 
 function [T] slice_to : (span : Span<T>&, end : isize) -> Span<T> = {

--- a/src/glang/lib/std/span.c3
+++ b/src/glang/lib/std/span.c3
@@ -93,6 +93,34 @@ function [T] get : (span : _SpanImpl<T>&, index : isize)
     return true;
 }
 
+@operator [T] < : (lhs : _SpanImpl<T>, rhs : _SpanImpl<T>) -> bool = {
+    // Use lexicographic ordering:
+    // - Given two sequences of the same lenght, the order of the two sequences
+    //   depends on the order of the symbols in the first place where the two
+    //   sequences differ.
+    // - If the sequences have different lengths, the shortest sequence is
+    //   padded with symbols that compare less than all other symbols until the
+    //   two sequences have the same lenght.
+    if lhs.length == rhs.length {
+        for i in range(lhs.length) {
+            if lhs:get(i) != rhs:get(i) {
+                // We've found the first place where they differ.
+                return lhs:get(i) < rhs:get(i);
+            }
+        }
+
+        // Spans are equal.
+        return false;
+    }
+
+    let common_length : isize = min(lhs.length, rhs.length);
+    if lhs:slice_to(common_length) == rhs:slice_to(common_length) {
+        return lhs.length < rhs.length;
+    }
+
+    return lhs:slice_to(common_length) < rhs:slice_to(common_length);
+}
+
 function [T] slice_to : (span : Span<T>&, end : isize) -> Span<T> = {
     return make<Span<T>>(&mut span.data, min(end, span.length));
 }

--- a/src/glang/lib/std/string.c3
+++ b/src/glang/lib/std/string.c3
@@ -44,6 +44,14 @@ function get_iter : (sv : StringView&) -> ContiguousContainerIter<View<u8>&, u8&
     return lhs.buffer == rhs.buffer;
 }
 
+@operator != : (lhs : StringView, rhs : StringView) -> bool = {
+    return !(lhs == rhs);
+}
+
+@operator != : (lhs : StringView&, rhs : StringView&) -> bool = {
+    return !(&lhs == &rhs);
+}
+
 @operator < : (lhs : StringView, rhs : StringView) -> bool = {
     return lhs.buffer < rhs.buffer;
 }

--- a/src/glang/lib/std/string.c3
+++ b/src/glang/lib/std/string.c3
@@ -40,6 +40,18 @@ function get_iter : (sv : StringView&) -> ContiguousContainerIter<View<u8>&, u8&
     return lhs.buffer == rhs.buffer;
 }
 
+@operator == : (lhs : StringView&, rhs : StringView&) -> bool = {
+    return lhs.buffer == rhs.buffer;
+}
+
+@operator < : (lhs : StringView, rhs : StringView) -> bool = {
+    return lhs.buffer < rhs.buffer;
+}
+
+@operator < : (lhs : StringView&, rhs : StringView&) -> bool = {
+    return lhs.buffer < rhs.buffer;
+}
+
 function slice_to : (sv : StringView&, end : isize) -> StringView = {
     return { sv.buffer:slice_to(end) };
 }

--- a/src/glang/lib/std/vector.c3
+++ b/src/glang/lib/std/vector.c3
@@ -66,17 +66,7 @@ function [T] get : (self : Vector<T>&, index : isize) -> T mut& = {
     return &mut self.memory.data[index];
 }
 
-function [T] get : (self : Vector<T> mut&, index : isize) -> T mut& = {
-    runtime_assert(index >= 0 and index < self.length);
-    return &mut self.memory.data[index];
-}
-
 function [T] length : (self : Vector<T>&) -> isize = {
-    return self.length;
-}
-
-function [T] length : (self : Vector<T> mut&) -> isize = {
-    // TODO: I really don't like this way of supporting UFCS
     return self.length;
 }
 
@@ -84,23 +74,9 @@ function [T] capacity : (self : Vector<T>&) -> isize = {
     return self.memory.length;
 }
 
-function [T] capacity : (self : Vector<T> mut&) -> isize = {
-    return self.memory.length;
-}
-
-function [T] data : (self : Vector<T> mut&) -> Span<T> = {
-    return (&self.memory):slice_to(self.length);
-}
-
 function [T] data : (self : Vector<T>&) -> Span<T> = {
     // TODO: we can extract the mutable data from a constant vector... Do I like this?
     return self.memory:slice_to(self.length);
-}
-
-function [T] view : (self : Vector<T> mut&) -> View<T> = {
-    // TODO: take value types as const reference
-    let data : Span<T> = self:data();
-    return data:to_view();
 }
 
 function [T] view : (self : Vector<T>&) -> View<T> = {
@@ -109,17 +85,8 @@ function [T] view : (self : Vector<T>&) -> View<T> = {
     return data:to_view();
 }
 
-function [T] get_iter : (vec : Vector<T> mut&) -> ContiguousContainerIter<Vector<T>&, T mut&> = {
-    return (&vec):get_iter();
-}
-
 function [T] get_iter : (vec : Vector<T>&) -> ContiguousContainerIter<Vector<T>&, T mut&> = {
     return { .container = &vec, .current_index = 0 };
-}
-
-// TODO: remove this... maybe use const value semantics?
-function [T] get_citer : (vec : Vector<T> mut&) -> ContiguousContainerIter<Vector<T>&, T&> = {
-    return (&vec):get_iter();
 }
 
 function [T] get_citer : (vec : Vector<T>&) -> ContiguousContainerIter<Vector<T>&, T&> = {

--- a/src/glang/target.py
+++ b/src/glang/target.py
@@ -1,10 +1,10 @@
 import platform
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from sys import exit as sys_exit
 from sys import stderr
-from typing import Iterator
 
 import yaml
 

--- a/tests/json/array_comma_after_close.c3
+++ b/tests/json/array_comma_after_close.c3
@@ -1,9 +1,11 @@
 @require_once "std/json.c3"
 @require_once "std/string.c3"
+@require_once "std/memory.c3"
 
 function main : () -> int = {
+    mut allocator : Allocator = initialize_allocator();
     let input : StringView = sv("[\"\"],");
-    let result : Optional<JSON_Node> = json_parse(input);
+    let result : Optional<JSON_Node> = json_parse(input, &mut allocator);
 
     // Should be rejected.
     if result:has_value() {

--- a/tests/json/array_extra_comma.c3
+++ b/tests/json/array_extra_comma.c3
@@ -1,9 +1,11 @@
 @require_once "std/json.c3"
 @require_once "std/string.c3"
+@require_once "std/memory.c3"
 
 function main : () -> int = {
+    mut allocator : Allocator = initialize_allocator();
     let input : StringView = sv("[\"\",]");
-    let result : Optional<JSON_Node> = json_parse(input);
+    let result : Optional<JSON_Node> = json_parse(input, &mut allocator);
 
     // Should be rejected.
     if result:has_value() {

--- a/tests/json/echo.c3
+++ b/tests/json/echo.c3
@@ -9,6 +9,8 @@ function main : () -> int = {
 
     // Should be accepted.
     if result:has_value() {
+        // Note that the order of the keys in the dictionary isn't necessarily
+        // preserved.
         print(result:data());
         return 0;
     }
@@ -18,4 +20,4 @@ function main : () -> int = {
 
 /// @COMPILE
 /// @RUN; EXPECT OUT
-/// {"name": "program", "children": [[]{"name": "require_once", "children": [[]{"name": "ESCAPED_STRING", "value": "std/format.c3"}[]]}[]]}
+/// {"children": [[]{"children": [[]{"name": "ESCAPED_STRING", "value": "std/format.c3"}[]], "name": "require_once"}[]], "name": "program"}

--- a/tests/json/echo.c3
+++ b/tests/json/echo.c3
@@ -1,11 +1,12 @@
 @require_once "std/json.c3"
 @require_once "std/string.c3"
 @require_once "std/format.c3"
-
+@require_once "std/memory.c3"
 
 function main : () -> int = {
+    mut allocator : Allocator = initialize_allocator();
     let input : StringView = sv("{\"name\":\"program\",\"children\":[{\"name\":\"require_once\",\"children\":[{\"name\":\"ESCAPED_STRING\",\"value\":\"\\\"std/format.c3\\\"\"}]}]}");
-    let result : Optional<JSON_Node> = json_parse(input);
+    let result : Optional<JSON_Node> = json_parse(input, &mut allocator);
 
     // Should be accepted.
     if result:has_value() {

--- a/tests/json/object_empty_key.c3
+++ b/tests/json/object_empty_key.c3
@@ -1,9 +1,11 @@
 @require_once "std/json.c3"
 @require_once "std/string.c3"
+@require_once "std/memory.c3"
 
 function main : () -> int = {
+    mut allocator : Allocator = initialize_allocator();
     let input : StringView = sv("{\"\":0}");
-    let result : Optional<JSON_Node> = json_parse(input);
+    let result : Optional<JSON_Node> = json_parse(input, &mut allocator);
 
     // Should be accepted.
     if result:has_value() {

--- a/tests/json/string_allowed_escapes.c3
+++ b/tests/json/string_allowed_escapes.c3
@@ -1,9 +1,11 @@
 @require_once "std/json.c3"
 @require_once "std/string.c3"
+@require_once "std/memory.c3"
 
 function main : () -> int = {
+    mut allocator : Allocator = initialize_allocator();
     let input : StringView = sv("[\"\\\"\\\\\\/\\b\\f\\n\\r\\t\"]"); // ["\"\\\/\b\f\n\r\t"]
-    let result : Optional<JSON_Node> = json_parse(input);
+    let result : Optional<JSON_Node> = json_parse(input, &mut allocator);
 
     // Should be accepted.
     if result:has_value() {

--- a/tests/json/string_incomplete_escape.c3
+++ b/tests/json/string_incomplete_escape.c3
@@ -1,9 +1,11 @@
 @require_once "std/json.c3"
 @require_once "std/string.c3"
+@require_once "std/memory.c3"
 
 function main : () -> int = {
+    mut allocator : Allocator = initialize_allocator();
     let input : StringView = sv("[\"\\\"]"); // ["\"]
-    let result : Optional<JSON_Node> = json_parse(input);
+    let result : Optional<JSON_Node> = json_parse(input, &mut allocator);
 
     // Should be rejected.
     if result:has_value() {

--- a/tests/json/string_unescaped_tab.c3
+++ b/tests/json/string_unescaped_tab.c3
@@ -1,9 +1,11 @@
 @require_once "std/json.c3"
 @require_once "std/string.c3"
+@require_once "std/memory.c3"
 
 function main : () -> int = {
+    mut allocator : Allocator = initialize_allocator();
     let input : StringView = sv("[\"a\ta\"],");
-    let result : Optional<JSON_Node> = json_parse(input);
+    let result : Optional<JSON_Node> = json_parse(input, &mut allocator);
 
     // Should be rejected.
     if result:has_value() {

--- a/tests/regressions/di_struct_offset.c3
+++ b/tests/regressions/di_struct_offset.c3
@@ -1,0 +1,12 @@
+typedef S : { x : i32, y : i64 }
+
+function main : () -> int = {
+    let s : S = {1, 2};
+
+    return 0;
+}
+
+/// @FOR x86_64_linux
+/// @COMPILE
+/// @GREP_IR !DIDerivedType(baseType: !?, name: "x", offset: 0, size: 32, tag: DW_TAG_member)
+/// @GREP_IR !DIDerivedType(baseType: !?, name: "y", offset: 64, size: 64, tag: DW_TAG_member)

--- a/tests/stdlib/map.c3
+++ b/tests/stdlib/map.c3
@@ -28,6 +28,10 @@ function main : () -> int = {
     print(map:at(1));
     print(map:at(0));
 
+    for i in map:get_citer() {
+        printf(sv("% = %"), i.key, i.value);
+    }
+
     runtime_assert(map:erase(0));
     runtime_assert(!map:erase(4));
 
@@ -58,6 +62,10 @@ function main : () -> int = {
 /// 2
 /// 1
 /// 0
+/// 0 = 0
+/// 1 = 1
+/// 2 = 2
+/// 3 = 3
 /// <empty>
 /// <empty>
 /// <empty>

--- a/tests/stdlib/map.c3
+++ b/tests/stdlib/map.c3
@@ -1,0 +1,65 @@
+@require_once "std/map.c3"
+@require_once "std/format.c3"
+@require_once "std/assert.c3"
+@require_once "std/string.c3"
+
+function main : () -> int = {
+    mut map : Map<int, StringView> = make<Map<int, StringView>>();
+
+    runtime_assert(map:empty() == true);
+    runtime_assert(map:size() == 0);
+
+    map:insert(0, sv("0"));
+    map:insert(1, sv("1"));
+    map:insert(2, sv("2"));
+    map:insert(3, sv("3"));
+
+    runtime_assert(map:contains(0));
+    runtime_assert(map:contains(1));
+    runtime_assert(map:contains(2));
+    runtime_assert(map:contains(3));
+
+    runtime_assert(map:empty() == false);
+    runtime_assert(map:size() == 4);
+
+    print(map:at(4));
+    print(map:at(3));
+    print(map:at(2));
+    print(map:at(1));
+    print(map:at(0));
+
+    runtime_assert(map:erase(0));
+    runtime_assert(!map:erase(4));
+
+    runtime_assert(!map:contains(0));
+    runtime_assert(!map:contains(4));
+
+    runtime_assert(map:empty() == false);
+    runtime_assert(map:size() == 3);
+
+    map:clear();
+
+    runtime_assert(map:empty() == true);
+    runtime_assert(map:size() == 0);
+
+    print(map:at(4));
+    print(map:at(3));
+    print(map:at(2));
+    print(map:at(1));
+    print(map:at(0));
+
+    return 0;
+}
+
+/// @COMPILE
+/// @RUN; EXPECT OUT
+/// <empty>
+/// 3
+/// 2
+/// 1
+/// 0
+/// <empty>
+/// <empty>
+/// <empty>
+/// <empty>
+/// <empty>

--- a/tests/stdlib/map.c3
+++ b/tests/stdlib/map.c3
@@ -4,7 +4,8 @@
 @require_once "std/string.c3"
 
 function main : () -> int = {
-    mut map : Map<int, StringView> = make<Map<int, StringView>>();
+    mut allocator : Allocator = initialize_allocator();
+    mut map : Map<int, StringView> = make<Map<int, StringView>>(&mut allocator);
 
     runtime_assert(map:empty() == true);
     runtime_assert(map:size() == 0);

--- a/tests/stdlib/rb_tree/basic.c3
+++ b/tests/stdlib/rb_tree/basic.c3
@@ -3,7 +3,8 @@
 @require_once "std/assert.c3"
 
 function main : () -> int = {
-    mut tree : RB_Tree<int> = make<RB_Tree<int>>();
+    mut allocator : Allocator = initialize_allocator();
+    mut tree : RB_Tree<int> = make<RB_Tree<int>>(&mut allocator);
 
     tree:insert(0);
     tree:insert(1);

--- a/tests/stdlib/rb_tree/extended.c3
+++ b/tests/stdlib/rb_tree/extended.c3
@@ -79,7 +79,8 @@ function [K] is_valid_rb_tree : (tree : RB_Tree<K> mut&) -> bool = {
 }
 
 function main : () -> int = {
-    mut tree : RB_Tree<int> = make<RB_Tree<int>>();
+    mut allocator : Allocator = initialize_allocator();
+    mut tree : RB_Tree<int> = make<RB_Tree<int>>(&mut allocator);
     mut n : int = 1000;
 
     for i in range(n) {

--- a/tests/stdlib/rb_tree/minmax.c3
+++ b/tests/stdlib/rb_tree/minmax.c3
@@ -2,7 +2,8 @@
 @require_once "std/iterators.c3"
 
 function main : () -> int = {
-    mut tree : RB_Tree<int> = make<RB_Tree<int>>();
+    mut allocator : Allocator = initialize_allocator();
+    mut tree : RB_Tree<int> = make<RB_Tree<int>>(&mut allocator);
     mut res : Optional<int>;
 
     for i in range(-10, 11) {

--- a/tests/stdlib/rb_tree/traversal.c3
+++ b/tests/stdlib/rb_tree/traversal.c3
@@ -3,7 +3,8 @@
 @require_once "std/format.c3"
 
 function main : () -> int = {
-    mut tree : RB_Tree<int> = make<RB_Tree<int>>();
+    mut allocator : Allocator = initialize_allocator();
+    mut tree : RB_Tree<int> = make<RB_Tree<int>>(&mut allocator);
 
     for i in range(-10, 11) {
         tree:insert(i);

--- a/tests/stdlib/rb_tree/traversal.c3
+++ b/tests/stdlib/rb_tree/traversal.c3
@@ -1,5 +1,6 @@
 @require_once "std/rb_tree.c3"
 @require_once "std/iterators.c3"
+@require_once "std/format.c3"
 
 function main : () -> int = {
     mut tree : RB_Tree<int> = make<RB_Tree<int>>();
@@ -55,8 +56,33 @@ function main : () -> int = {
         return 10;
     }
 
+    for i in tree:get_citer() {
+        print(i);
+    }
+
     return 0;
 }
 
 /// @COMPILE
-/// @RUN
+/// @RUN; EXPECT OUT
+/// -10
+/// -9
+/// -8
+/// -7
+/// -6
+/// -5
+/// -4
+/// -3
+/// -2
+/// -1
+/// 0
+/// 1
+/// 2
+/// 3
+/// 4
+/// 5
+/// 6
+/// 7
+/// 8
+/// 9
+/// 10

--- a/tests/stdlib/rb_tree/traversal.c3
+++ b/tests/stdlib/rb_tree/traversal.c3
@@ -1,0 +1,62 @@
+@require_once "std/rb_tree.c3"
+@require_once "std/iterators.c3"
+
+function main : () -> int = {
+    mut tree : RB_Tree<int> = make<RB_Tree<int>>();
+
+    for i in range(-10, 11) {
+        tree:insert(i);
+    }
+
+    let min : Optional<RB_Node<int> mut&> = tree:search_impl(-10);
+    if !min:has_value() or min:data().key != -10 {
+        return 1;
+    }
+
+    let max : Optional<RB_Node<int> mut&> = tree:search_impl(10);
+    if !max:has_value() or max:data().key != 10 {
+        return 2;
+    }
+
+    let min_predecessor : Optional<RB_Node<int> mut&> = min:data():predecessor();
+    if min_predecessor:has_value() {
+        return 3;
+    }
+
+    let max_successor : Optional<RB_Node<int> mut&> = max:data():successor();
+    if max_successor:has_value() {
+        return 4;
+    }
+
+    let nine : Optional<RB_Node<int> mut&> = max:data():predecessor();
+    if !nine:has_value() or nine:data().key != 9 {
+        return 5;
+    }
+
+    let eight : Optional<RB_Node<int> mut&> = nine:data():predecessor();
+    if !eight:has_value() or eight:data().key != 8 {
+        return 6;
+    }
+
+    let seven : Optional<RB_Node<int> mut&> = eight:data():predecessor();
+    if !seven:has_value() or seven:data().key != 7 {
+        return 7;
+    }
+
+    if seven:data():successor() != eight {
+        return 8;
+    }
+
+    if eight:data():successor() != nine {
+        return 9;
+    }
+
+    if nine:data():successor() != max {
+        return 10;
+    }
+
+    return 0;
+}
+
+/// @COMPILE
+/// @RUN


### PR DESCRIPTION
The goal was to use `Map` in the JSON library, but there's a bunch of stuff in this PR:

- Add `Map`, based on `RB_Tree`
- Fixed the debug information generated for struct members
- Add RB tree `predecessor()` and `successor()` functions
- Add RB tree and Map iterators
- Change some comparisons to take their arguments by references (the only straightforward way to compare two `JSON_Node`s is by looking at their address... but to pass them by reference means that we have to pass everything else by reference too, even `int`s)