### PR TITLE
Fix RPM build

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,11 +6,11 @@ function checkout() {
     # Pass commit in $1. Output directory is returned.
     rpm_dir="GrapheneLang-${1/\//-}"
     if [ -d "$rpm_dir" ]; then
-        echo "$rpm_dir"
+        realpath "$rpm_dir"
     else
         dir="$(mktemp -d)"
         git archive "$1" --worktree-attributes ":(exclude)tests/" | tar -x -C "$dir"
-        echo "$dir"
+        realpath "$dir"
     fi
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,10 @@ fmt = ["isort --profile black .", "black ."]
 # Exclude symlinks used for editable installs.
 exclude = ["src/glang/bin"]
 dependencies = [
-  "hatch~=1.7.0",
-  "lark~=1.1.7",
-  "PyYAML~=6.0.0",
-  "typed-argument-parser>=1.8.1,<1.10.0",
+  "hatch~=1.7",
+  "lark~=1.1",
+  "PyYAML~=6.0",
+  "typed-argument-parser~=1.8",
 ]
 
 [tool.hatch.build.targets.sdist]
@@ -81,3 +81,7 @@ exclude = [".github", "docs", "tests"]
 [tool.hatch.build.targets.wheel]
 packages = ["src/glang"]
 hooks.custom.path = "hatch_build.py"
+
+[tool.ruff]
+# hatch sets this to 120 by default. 88 is what black uses.
+line-length = 88


### PR DESCRIPTION
- Relax dependency requirements to allow newer minor versions; required when packaging for a distro
- Use absolute paths in `bootstrap.sh` instead of relative paths, as we set the working directory with `env -C`

If we don't need anything else for the quick bootstrap PR, then we can make 0.4.0 release.