### PR TITLE
lint.yml: make ruff errors fail the CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,9 +28,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - run: |
-          pip install hatch
-          hatch fmt --linter --check
+      - name: Install hatch
+        run: python3 -m pip install hatch --user
+      - name: Run ruff
+        run: |
+          output=$(hatch fmt --linter --check)
+          echo output >> $GITHUB_STEP_SUMMARY
+          echo output | grep "No errors fixed"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Run ruff
         run: |
           output=$(hatch fmt --linter --check)
-          echo output >> $GITHUB_STEP_SUMMARY
-          echo output | grep "No errors fixed"
+          echo "$output" >> $GITHUB_STEP_SUMMARY
+          echo "$output" | grep "No errors fixed"


### PR DESCRIPTION
Hatch doesn't pass `--exit-non-zero-on-fix` to ruff, so it always returns 0 and the CI always passes. This is a quick workaround.