### PR TITLE
Move clang driver functionality into Graphene

### DIFF
--- a/.github/workflows/graphene_tests.yml
+++ b/.github/workflows/graphene_tests.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       GRAPHENE_CLANG_CMD: clang-${{ matrix.llvm-version }}
       GRAPHENE_LLC_CMD: llc-${{ matrix.llvm-version }}
+      GRAPHENE_LLD_CMD: ld.lld-${{ matrix.llvm-version }}
       GRAPHENE_LLI_CMD: lli-${{ matrix.llvm-version }}
       GRAPHENE_LLVM_AR_CMD: llvm-ar-${{ matrix.llvm-version }}
       GRAPHENE_LLVM_MC_CMD: llvm-mc-${{ matrix.llvm-version }}

--- a/.github/workflows/graphene_tests.yml
+++ b/.github/workflows/graphene_tests.yml
@@ -16,7 +16,11 @@ jobs:
 
     env:
       GRAPHENE_CLANG_CMD: clang-${{ matrix.llvm-version }}
+      GRAPHENE_LLC_CMD: llc-${{ matrix.llvm-version }}
       GRAPHENE_LLI_CMD: lli-${{ matrix.llvm-version }}
+      GRAPHENE_LLVM_AR_CMD: llvm-ar-${{ matrix.llvm-version }}
+      GRAPHENE_LLVM_MC_CMD: llvm-mc-${{ matrix.llvm-version }}
+      GRAPHENE_OPT_CMD: opt-${{ matrix.llvm-version }}
 
     steps:
     - name: Checkout

--- a/src/glang/driver.py
+++ b/src/glang/driver.py
@@ -5,7 +5,7 @@ import sys
 from argparse import Action, ArgumentParser, Namespace
 from collections.abc import Sequence
 from dataclasses import dataclass
-from os import getenv, fdopen
+from os import fdopen, getenv
 from pathlib import Path
 from tempfile import TemporaryDirectory, mkstemp
 from typing import Any

--- a/src/glang/driver.py
+++ b/src/glang/driver.py
@@ -40,6 +40,21 @@ def run_checked(args: list[str | Path], stdin: bytes | None = None) -> bytes:
     return result.stdout
 
 
+class PrintHostTargetAction(Action):
+    def __call__(
+        self,
+        parser: ArgumentParser,
+        namespace: Namespace,
+        values: str | Sequence[Any] | None,
+        option_string: str | None = None,
+    ) -> None:
+        # Stop parsing and exit after printing the host's target. If we keep
+        # parsing, then the parser complains that `input`, a required position
+        # argument, is missing.
+        print(get_host_target())
+        parser.exit()
+
+
 class DriverArguments(Tap):
     inputs: list[Path]
     output: Path | None = None
@@ -90,21 +105,6 @@ class DriverArguments(Tap):
         self.add_argument("-I", "--include_path")
         self.add_argument("-O", "--optimize")
         self.add_argument("--print_host_target", nargs=0, action=PrintHostTargetAction)
-
-
-class PrintHostTargetAction(Action):
-    def __call__(
-        self,
-        parser: ArgumentParser,
-        namespace: Namespace,
-        values: str | Sequence[Any] | None,
-        option_string: str | None = None,
-    ) -> None:
-        # Stop parsing and exit after printing the host's target. If we keep
-        # parsing, then the parser complains that `input`, a required position
-        # argument, is missing.
-        print(get_host_target())
-        parser.exit()
 
 
 @dataclass(frozen=True)

--- a/src/glang/driver.py
+++ b/src/glang/driver.py
@@ -23,7 +23,7 @@ from glang.target import (
 global_tmp_dir = TemporaryDirectory()
 
 
-def run_checked(args: list[str | Path], stdin: bytes | None) -> bytes:
+def run_checked(args: list[str | Path], stdin: bytes | None = None) -> bytes:
     # Like the python one but actually output the stderr on fail
     result = subprocess.run(
         args,
@@ -146,9 +146,8 @@ class Assembly(Stage):
                 getenv("GRAPHENE_CLANG_CMD", "clang"),
                 "-E",
                 "-xassembler-with-cpp",
-                "-",
+                self.get_file(),
             ],
-            stdin=self.get_bytes(),
         )
         compiled = run_checked(
             [
@@ -239,7 +238,6 @@ def link_and_output(args: DriverArguments, objects: list[ELF_Binary]) -> None:
             "-o",
             binary_output,
         ],
-        stdin=None,
     )
 
 
@@ -252,7 +250,6 @@ def bundle_and_output(args: DriverArguments, objects: list[ELF_Binary]) -> None:
             lib_output,
             *(obj.get_file() for obj in objects),
         ],
-        stdin=None,
     )
 
 

--- a/src/glang/driver.py
+++ b/src/glang/driver.py
@@ -170,9 +170,6 @@ class LLVM_IR(Stage):
             ],
             stdin=self.get_bytes(),
         )
-        if args.emit_llvm_to_stdout:
-            print(result.decode("utf-8"))
-
         return ELF_Binary(result, self)
 
     def optimize(self, args: DriverArguments) -> "LLVM_IR":
@@ -207,6 +204,9 @@ class GrapheneSource(Stage):
             self.get_file(), args.include_path, debug_compiler=args.debug_compiler
         )
         ir_bytes = ir.encode("utf-8")
+
+        if args.emit_llvm_to_stdout:
+            print(ir_bytes.decode("utf-8"))
 
         if will_emit_llvm:
             if args.emit_everything or args.output is None:


### PR DESCRIPTION
This PR moves most of what clang was doing into graphene. Our new pipeline is:
1) Compile the graphene sources into LLVM
2) Optimize the LLVM
3) Compile the LLVM into an object
4) Compile our runtime.S into an object
5) Link with `ld.lld`

I suspect I'm missing some target-specific stuff in the `opt` step since clang is able turn on/off specific passes but I'm assuming this doesn't really make a difference.

Overall, this PR adds code but slightly reduces the number of conditional branches + adds support for compiling multiple sources into a static library (if for some reason you can find a graphene program that won't violate the ODR).

This is the first step in graphene translation units and allows us to support targets without a clang frontend but with a llvm backend (I can think of one :upside_down_face:). We still depend on clang for the c-macro expansion but this is not target-specific.