### PR TITLE
LLVM 18 support

### DIFF
--- a/.github/workflows/graphene_tests.yml
+++ b/.github/workflows/graphene_tests.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        llvm-version: [16, 17]
+        llvm-version: [17, 18]
         runner: [ubuntu-latest, buildjet-2vcpu-ubuntu-2204-arm]
 
     runs-on: ${{ matrix.runner }}

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -172,6 +172,7 @@ def run_test(file_path: Path) -> bool:
                 *lli_runtime_options,
                 "--extra-object",
                 RUNTIME_OBJ_PATH,
+                "--lljit-platform=Inactive",
                 "-",
                 *config.run_args,
             ],


### PR DESCRIPTION
Fix the following error in tests that do _not_ run with `--use-crt`:

```
lli: Native platforms require a process symbols JITDylib
```

by disabling JIT platform support.

Not 100% sure on what we lose, but I think the "native" platform just calls `dlopen()` and `dlclose()` on each SO.

See https://reviews.llvm.org/D144276 and https://reviews.llvm.org/D99416.