### PR TITLE
Use hatch v1.9.4 on CI

### DIFF
--- a/.github/workflows/graphene_tests.yml
+++ b/.github/workflows/graphene_tests.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         show-progress: false
     - name: Install hatch
-      run: python3 -m pip install hatch --user
+      run: python3 -m pip install hatch==1.9.4 --user
     - name: Install clang and lli
       run: |
         wget https://apt.llvm.org/llvm.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install hatch
-        run: python3 -m pip install hatch --user
+        run: python3 -m pip install hatch==1.9.4 --user
       - name: Run ruff
         run: |
           output=$(hatch fmt --linter --check)


### PR DESCRIPTION
Hatch updates keep breaking our CI checks...

v1.10 lets us pin stuff like the `ruff` version used, so perhaps that's gonna be more stable going forward, but right now it just updates and breaks the linting/formatting checks