### PR TITLE
Fix bootstrap broken by lark 1.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ glang = "glang.driver:main"
 # Development environment to be used with your IDE. Just set the venv path to
 # the output of `hatch env find dev`.
 [tool.hatch.envs.dev]
-dependencies = ["interegular~=0.3", "lark~=1.1"]
+dependencies = ["interegular~=0.3", "lark==1.1.9"]
 
 [tool.hatch.envs.dev.scripts]
 bootstrap = "./bootstrap.sh"
@@ -61,7 +61,7 @@ fmt = ["isort --profile black .", "black ."]
 [tool.hatch.build]
 # Exclude symlinks used for editable installs.
 exclude = ["src/glang/bin"]
-dependencies = ["lark~=1.1", "PyYAML~=6.0", "typed-argument-parser~=1.8"]
+dependencies = ["lark==1.1.9", "PyYAML~=6.0", "typed-argument-parser~=1.8"]
 
 [tool.hatch.build.targets.sdist]
 exclude = [".github", "docs", "tests"]


### PR DESCRIPTION
Lark 1.2.2 was release on August 13. This was marked as backwards compatible with lark 1.1 (hence pulled in by Hatch). Turns out it is not in fact backwards compatible and was breaking our bootstrap on a fresh checkout.

This PR reverts lark to the latest backwards compatible version.