### PR TITLE
Testing: add `@FAILING` tag

### DIFF
--- a/tests/test_config_grammar.lark
+++ b/tests/test_config_grammar.lark
@@ -4,12 +4,13 @@
 %ignore " "
 %ignore "\n"
 
-start: (for_cmd)? compile_cmd (grep_ir_cmd)* (run_cmd)?
+start: (regressed)? (for_cmd)? compile_cmd (grep_ir_cmd)* (run_cmd)?
 
 ARG: /[-\w]+/  // Doesn't match ;
 
 expect_status: "EXPECT" INT
 expect_msg: "EXPECT" (/OUT/ | /ERR/) /([^@].*\n?)+/
+regressed: "@TEMPORARILY_REGRESSED"
 for_cmd: "@FOR" CNAME
 compile_cmd: "@COMPILE" ARG* [";" expect_status] [";" expect_msg]
 grep_ir_cmd: "@GREP_IR" /.+\n?/

--- a/tests/test_config_grammar.lark
+++ b/tests/test_config_grammar.lark
@@ -4,13 +4,13 @@
 %ignore " "
 %ignore "\n"
 
-start: (regressed)? (for_cmd)? compile_cmd (grep_ir_cmd)* (run_cmd)?
+start: (failing)? (for_cmd)? compile_cmd (grep_ir_cmd)* (run_cmd)?
 
 ARG: /[-\w]+/  // Doesn't match ;
 
 expect_status: "EXPECT" INT
 expect_msg: "EXPECT" (/OUT/ | /ERR/) /([^@].*\n?)+/
-regressed: "@TEMPORARILY_REGRESSED"
+failing: "@FAILING"
 for_cmd: "@FOR" CNAME
 compile_cmd: "@COMPILE" ARG* [";" expect_status] [";" expect_msg]
 grep_ir_cmd: "@GREP_IR" /.+\n?/

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -23,6 +23,7 @@ class ExpectedOutput:
 
 @dataclass
 class TestConfig:
+    temporarily_regressed: bool
     for_target: str | None
     compile_opts: ExpectedOutput | None
     compile_args: list[str]
@@ -41,7 +42,7 @@ class ConfigInterpreter(Interpreter):
     def __init__(self) -> None:
         super().__init__()
 
-        self.config = TestConfig(None, None, [], [], None, [])
+        self.config = TestConfig(False, None, None, [], [], None, [])
 
     @staticmethod
     def _format_msg(msg: str) -> list[str]:
@@ -77,6 +78,10 @@ class ConfigInterpreter(Interpreter):
             expected_output.status = 1
 
         return expected_output
+
+    @v_args(inline=True)
+    def regressed(self) -> None:
+        self.config.temporarily_regressed = True
 
     @v_args(inline=True)
     def for_cmd(self, target: str) -> None:

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -23,7 +23,7 @@ class ExpectedOutput:
 
 @dataclass
 class TestConfig:
-    temporarily_regressed: bool
+    expected_failing: bool
     for_target: str | None
     compile_opts: ExpectedOutput | None
     compile_args: list[str]
@@ -80,8 +80,8 @@ class ConfigInterpreter(Interpreter):
         return expected_output
 
     @v_args(inline=True)
-    def regressed(self) -> None:
-        self.config.temporarily_regressed = True
+    def failing(self) -> None:
+        self.config.expected_failing = True
 
     @v_args(inline=True)
     def for_cmd(self, target: str) -> None:


### PR DESCRIPTION
I've been working on function pointers, callables, and an over-loadable [] operator... Unfortunately this is becoming unwieldy and I'll have to regress the multidimensional array test to avoid touching the pattern matching logic in the same diff.

This PR adds the testing infrastructure to make this possible without completely deleting the test.