### PR TITLE
Use unicode library everywhere

### DIFF
--- a/src/glang/lib/std/format.c3
+++ b/src/glang/lib/std/format.c3
@@ -2,22 +2,19 @@
 @require_once "string.c3"
 @require_once "type_traits.c3"
 @require_once "util.c3"
-
-function [IO] write : (io : IO mut&, char : UTF32Codepoint) -> TypeIf<void, IsStreamableTextIO<IO>> = {
-    io:write_char(char.codepoint);
-}
+@require_once "unicode.c3"
 
 function [IO, @Len] write : (io : IO mut&, string : u8[@Len]&) -> TypeIf<void, IsStreamableTextIO<IO>> = {
     io:write(sv(&string));
 }
 
 function [IO] write : (io : IO mut&, string : StringView) -> TypeIf<void, IsStreamableTextIO<IO>> = {
-    let buffer : Span<u8> = io:request_buffer(string:length());
+    let buffer : Span<u8> = io:request_buffer(string:length_bytes());
 
     // TODO: remove this assumption
     // TODO: maybe stream large strings directly
-    runtime_assert(buffer.length == string:length());
-    for index in range(string:length()) {
+    runtime_assert(buffer.length == string:length_bytes());
+    for index in range(string:length_bytes()) {
         buffer.data[index] = string.buffer.data[index];
     }
     io:consume_length(buffer.length);
@@ -26,7 +23,7 @@ function [IO] write : (io : IO mut&, string : StringView) -> TypeIf<void, IsStre
 function [IO] write : (io : IO mut&, number : isize) -> TypeIf<void, IsStreamableTextIO<IO>> = {
     let buffer : Span<u8> = io:request_buffer(21); // len(INT_64_MIN) == 21
     if number == 0 {
-        buffer.data[0] = "0"[0];
+        buffer.data[0] = ascii_char("0");
         io:consume_length(1);
 
         return;
@@ -36,7 +33,7 @@ function [IO] write : (io : IO mut&, number : isize) -> TypeIf<void, IsStreamabl
     mut current_number : isize = number;
     mut length : isize = 0;
     while current_number != 0 {
-        let next_digit: u8 = as_logical(__builtin_narrow<i8>(abs(current_number % 10) + as_arithmetic("0"[0])));
+        let next_digit: u8 = as_logical(__builtin_narrow<i8>(abs(current_number % 10) + as_arithmetic(ascii_char("0"))));
 
         buffer.data[length] = next_digit;
 
@@ -45,7 +42,7 @@ function [IO] write : (io : IO mut&, number : isize) -> TypeIf<void, IsStreamabl
     }
 
     if is_negative {
-        buffer.data[length] = "-"[0];
+        buffer.data[length] = ascii_char("-");
         length += 1;
     }
 
@@ -59,12 +56,28 @@ function [IO] write : (io : IO mut&, number : u32) -> TypeIf<void, IsStreamableT
     let buffer : Span<u8> = io:request_buffer(8); // 4 bytes
 
     if number == 0x00 {
-        buffer.data[0] = "0"[0];
+        buffer.data[0] = ascii_char("0");
+        io:consume_length(1);
         return;
     }
 
     let lookup_table : u8[16] = {
-        "0"[0], "1"[0], "2"[0], "3"[0], "4"[0], "5"[0], "6"[0], "7"[0], "8"[0], "9"[0], "A"[0], "B"[0], "C"[0], "D"[0], "E"[0], "F"[0]
+        ascii_char("0"),
+        ascii_char("1"),
+        ascii_char("2"),
+        ascii_char("3"),
+        ascii_char("4"),
+        ascii_char("5"),
+        ascii_char("6"),
+        ascii_char("7"),
+        ascii_char("8"),
+        ascii_char("9"),
+        ascii_char("A"),
+        ascii_char("B"),
+        ascii_char("C"),
+        ascii_char("D"),
+        ascii_char("E"),
+        ascii_char("F")
     };
 
     mut remaining_number : u32 = number;
@@ -89,7 +102,7 @@ function [IO] write : (io : IO mut&, value : bool) -> TypeIf<void, IsStreamableT
     }
 }
 
-function [IO] write_char : (io : IO mut&, char : u8) -> TypeIf<void, IsStreamableTextIO<IO>> = {
+function [IO] write_byte : (io : IO mut&, char : u8) -> TypeIf<void, IsStreamableTextIO<IO>> = {
     let buffer : Span<u8> = io:request_buffer(1);
     buffer.data[0] = char;
     io:consume_length(1);
@@ -119,10 +132,10 @@ function [Args...] printf : (args : Args...) -> void = {
 }
 
 function [IO] writef : (io : IO mut&, format_string : StringView) -> void = {
-    // if format_string:index_of("%"[0]) != -1 {
-    //     puts("writef format string has mismatched numbers of '%' specifiers and arguments");
-    //     runtime_assert(false);
-    // }
+    if index_of(format_string:get_iter(), char("%")) != -1 {
+        puts("writef format string has mismatched numbers of '%' specifiers and arguments");
+        runtime_assert(false);
+    }
     io:write(format_string);
 }
 
@@ -137,7 +150,7 @@ function [IO, NextArg, Args...] writef : (io : IO mut&, format_string : StringVi
 }
 
 function [IO, Arg] write_next_format_pair : (io : IO mut&, format_string : StringView, next_arg : Arg) -> StringView = {
-    let insertion_index : isize = index_of(format_string:get_iter(), "%"[0]);
+    let insertion_index : isize = index_of(format_string:get_iter(), char("%"));
     if (insertion_index == -1) {
         // TODO: this error looks kinda janky if something has already been printed
         puts("writef format string has mismatched numbers of '%' specifiers and arguments");

--- a/src/glang/lib/std/io.c3
+++ b/src/glang/lib/std/io.c3
@@ -112,7 +112,7 @@ function puts : (str : StringView) -> int = {
     // puts - put a string on standard output
     // https://pubs.opengroup.org/onlinepubs/9699919799/functions/puts.html
     let iov : iovec[2] = {
-        {&str.buffer.data, str:length()},
+        {&str.buffer.data, str:length_bytes()},
         {"\n", 1}
     };
 

--- a/src/glang/lib/std/json.c3
+++ b/src/glang/lib/std/json.c3
@@ -68,8 +68,8 @@ function is_json_whitespace : (token : u8) -> bool = {
     // JSON defines whitespace as one of { space, linefeed, carriage return,
     // horizontal tab }. If we use string literals instead of code points, then
     // our code doesn't care about the underlying encoding :).
-    return token == char(" ") or token == char("\n")
-           or token == char("\r") or token == char("\t");
+    return token == ascii_char(" ") or token == ascii_char("\n")
+           or token == ascii_char("\r") or token == ascii_char("\t");
 }
 
 function eat : (cursor : Cursor mut&, token : u8) -> bool = {
@@ -85,7 +85,7 @@ function eat : (cursor : Cursor mut&, token : u8) -> bool = {
 }
 
 function eat : (cursor : Cursor mut&, string : StringView) -> bool = {
-    for token in string:get_iter() {
+    for token in string.buffer:get_iter() {
         if !cursor:eat(token) {
             return false;
         }
@@ -110,7 +110,7 @@ function eat_whitespace : (cursor: Cursor mut&) -> void = {
 
 // TODO return ErrorOr<JSON_Node>.
 function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
-    if !cursor:eat(char("{")) {
+    if !cursor:eat(ascii_char("{")) {
         return make<Optional<JSON_Node>>();
     }
 
@@ -118,7 +118,7 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
 
     cursor:eat_whitespace();
 
-    if cursor:eat(char("}")) {
+    if cursor:eat(ascii_char("}")) {
         // Empty object.
         return make<Optional<JSON_Node>>(node);
     }
@@ -138,7 +138,7 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
 
         cursor:eat_whitespace();
 
-        if !cursor:eat(char(":")) {
+        if !cursor:eat(ascii_char(":")) {
             node.map:clear();
             return make<Optional<JSON_Node>>();
         }
@@ -152,12 +152,12 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
 
         node.map:insert(string_view, value_node:data());
 
-        if cursor:eat(char("}")) {
+        if cursor:eat(ascii_char("}")) {
             // We're done.
             return make<Optional<JSON_Node>>(node);
         }
 
-        if !cursor:eat(char(",")) {
+        if !cursor:eat(ascii_char(",")) {
             node.map:clear();
             return make<Optional<JSON_Node>>();
         }
@@ -169,7 +169,7 @@ function parse_object : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
 }
 
 function parse_array : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
-    if !cursor:eat(char("[")) {
+    if !cursor:eat(ascii_char("[")) {
         return make<Optional<JSON_Node>>();
     }
 
@@ -177,7 +177,7 @@ function parse_array : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
 
     cursor:eat_whitespace();
 
-    if cursor:eat(char("]")) {
+    if cursor:eat(ascii_char("]")) {
         // Empty array.
         return make<Optional<JSON_Node>>(node);
     }
@@ -191,12 +191,12 @@ function parse_array : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
 
         node.children:push_back(value_node:data());
 
-        if cursor:eat(char("]")) {
+        if cursor:eat(ascii_char("]")) {
             // We're done.
             return make<Optional<JSON_Node>>(node);
         }
 
-        if !cursor:eat(char(",")) {
+        if !cursor:eat(ascii_char(",")) {
             node.children:deallocate();
             return make<Optional<JSON_Node>>();
         }
@@ -214,15 +214,15 @@ function parse_value : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
 
     let next_token : u8 = optional_next_token:data();
 
-    if next_token == char("\"") {
+    if next_token == ascii_char("\"") {
         return cursor:parse_string();
     }
 
-    if next_token == char("{") {
+    if next_token == ascii_char("{") {
         return cursor:parse_object();
     }
 
-    if next_token == char("[") {
+    if next_token == ascii_char("[") {
         return cursor:parse_array();
     }
 
@@ -262,7 +262,7 @@ function is_control_character : (char : u8) -> bool = {
 }
 
 function parse_string : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
-    if !cursor:eat(char("\"")) {
+    if !cursor:eat(ascii_char("\"")) {
         return make<Optional<JSON_Node>>();
     }
 
@@ -271,7 +271,7 @@ function parse_string : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
     mut string : Vector<u8> = make<Vector<u8>>(&mut cursor.allocator);
 
     while cursor:has_next() {
-        if !in_escape_seq and cursor:eat(char("\"")) {
+        if !in_escape_seq and cursor:eat(ascii_char("\"")) {
             mut node : JSON_Node = make<JSON_Node>(/* string */ 3, &mut cursor.allocator);
 
             node.value = make<Optional<StringView>>(
@@ -293,30 +293,30 @@ function parse_string : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
         if in_escape_seq {
             in_escape_seq = false;
 
-            if char == char("\\") {
-                string:push_back(char("\\"));
+            if char == ascii_char("\\") {
+                string:push_back(ascii_char("\\"));
             }
-            if char == char("/") {
-                string:push_back(char("/"));
+            if char == ascii_char("/") {
+                string:push_back(ascii_char("/"));
             }
-            if char == char("b") {
-                string:push_back(char("\b"));
+            if char == ascii_char("b") {
+                string:push_back(ascii_char("\b"));
             }
-            if char == char("f") {
-                string:push_back(char("\f"));
+            if char == ascii_char("f") {
+                string:push_back(ascii_char("\f"));
             }
-            if char == char("n") {
-                string:push_back(char("\n"));
+            if char == ascii_char("n") {
+                string:push_back(ascii_char("\n"));
             }
-            if char == char("r") {
-                string:push_back(char("\r"));
+            if char == ascii_char("r") {
+                string:push_back(ascii_char("\r"));
             }
-            if char == char("t") {
-                string:push_back(char("\t"));
+            if char == ascii_char("t") {
+                string:push_back(ascii_char("\t"));
             }
         }
         else {
-            if char == char("\\") {
+            if char == ascii_char("\\") {
                 in_escape_seq = true;
             }
             else {
@@ -337,9 +337,9 @@ function parse_number : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
     mut is_valid : bool = false;
 
     // This is optional, so discard the return value.
-    cursor:eat(char("-"));
+    cursor:eat(ascii_char("-"));
 
-    if !cursor:eat(char("0")) {
+    if !cursor:eat(ascii_char("0")) {
         while is_digit_helper(cursor:peak()) {
             is_valid = true;
             cursor:next();
@@ -367,7 +367,7 @@ function parse_number : (cursor : Cursor mut&) -> Optional<JSON_Node> = {
 // TODO this and write below should be the only public functions.
 function json_parse : (source : StringView, allocator : Allocator mut&) -> Optional<JSON_Node> = {
     // FIXME memory safety, memory leaks.
-    mut cursor : Cursor = { source:get_iter(), &mut allocator };
+    mut cursor : Cursor = { source.buffer:get_iter(), &mut allocator };
 
     let result : Optional<JSON_Node> = cursor:parse_element();
 
@@ -407,11 +407,11 @@ function [IO] write : (io : IO mut&, node : JSON_Node) -> TypeIf<void, IsStreama
         // Allowed to fail.
         if node.value:has_value() {
             let string : StringView = node.value:data();
-            let buffer : Span<u8> = io:request_buffer(string:length() + 2);
+            let buffer : Span<u8> = io:request_buffer(string:length_bytes() + 2);
 
-            buffer.data[0] = char("\"");
-            buffer.data[buffer.length - 1] = char("\"");
-            for i in range(string:length()) {
+            buffer.data[0] = ascii_char("\"");
+            buffer.data[buffer.length - 1] = ascii_char("\"");
+            for i in range(string:length_bytes()) {
                 // FIXME we need to escape the strings we print here.
                 buffer.data[i + 1] = string.buffer.data[i];
             }

--- a/src/glang/lib/std/string.c3
+++ b/src/glang/lib/std/string.c3
@@ -1,18 +1,12 @@
-@require_once "arithmetic.c3"
-@require_once "assert.c3"
-@require_once "iterators.c3"
-@require_once "util.c3"
-@require_once "wrappers.c3"
-@require_once "span.c3"
+@require_once "std/arithmetic.c3"
+@require_once "std/assert.c3"
+@require_once "std/iterators.c3"
+@require_once "std/span.c3"
+@require_once "std/util.c3"
+@require_once "std/wrappers.c3"
 
 typedef CString : { data : u8[&] }
 typedef StringView     : { buffer : View<u8> }
-typedef UTF32Codepoint : { codepoint : u8 /* TODO: unicode support */ }
-
-function decode_utf8 : (char : u8) -> UTF32Codepoint = {
-    // TODO: this just supports ascii atm
-    return {char};
-}
 
 // StringView
 function [@Len] sv : (string : u8[@Len]&) -> StringView = {
@@ -24,16 +18,11 @@ function make<StringView> : (buffer : View<u8>) -> StringView = {
 }
 
 function make<StringView> : (cstr : CString) -> StringView = {
-    return { make<View<u8>>(&cstr.data, cstr:length()) };
+    return { make<View<u8>>(&cstr.data, cstr:length_bytes()) };
 }
 
-function length : (sv : StringView&) -> isize = {
+function length_bytes : (sv : StringView&) -> isize = {
     return sv.buffer:length();
-}
-
-// TODO: return `UTF32Codepoint` here
-function get_iter : (sv : StringView&) -> ContiguousContainerIter<View<u8>, u8&> = {
-    return sv.buffer:get_iter();
 }
 
 @operator == : (lhs : StringView, rhs : StringView) -> bool = {
@@ -73,16 +62,16 @@ function slice_between : (sv : StringView&, start : isize, end : isize) -> Strin
 }
 
 // CString
-function length : (str: CString&) -> isize = {
+function length_bytes : (str: CString&) -> isize = {
     mut len : isize = 0;
-    while str.data[len] != char("\0") {
+    while str.data[len] != ascii_char("\0") {
         len = len + 1;
     }
     return len;
 }
 
 function [@Len] make<CString> : (literal : u8[@Len]&) -> CString = {
-    runtime_assert(literal[@Len - 1] == char("\0"));
+    runtime_assert(literal[@Len - 1] == ascii_char("\0"));
     return {&literal};
 }
 
@@ -90,16 +79,16 @@ function [@Len] make<CString> : (literal : u8[@Len]&) -> CString = {
 // String utilities
 function ascii_is_white_space : (char : u8) -> bool = {
     // TODO: all other white spaces
-    return char == char("\n") or char == char(" ");
+    return char == ascii_char("\n") or char == ascii_char(" ");
 }
 
 function ascii_is_digit : (char : u8) -> bool = {
-    return as_arithmetic(char) >= as_arithmetic(char("0")) and as_arithmetic(char) <= as_arithmetic(char("9"));
+    return as_arithmetic(char) >= as_arithmetic(ascii_char("0")) and as_arithmetic(char) <= as_arithmetic(ascii_char("9"));
 }
 
 function ascii_is_alpha : (char : u8) -> bool = {
     let lower : i8 = as_arithmetic(ascii_to_lower(char));
-    return lower >= as_arithmetic(char("a")) and lower <= as_arithmetic(char("z"));
+    return lower >= as_arithmetic(ascii_char("a")) and lower <= as_arithmetic(ascii_char("z"));
 }
 
 function ascii_is_alphanumeric : (char : u8) -> bool = {
@@ -107,39 +96,38 @@ function ascii_is_alphanumeric : (char : u8) -> bool = {
 }
 
 function ascii_to_lower : (char : u8) -> u8 = {
-    // TODO: support char literals
-    if as_arithmetic(char) >= as_arithmetic(char("A")) and as_arithmetic(char) <= as_arithmetic(char("Z")) {
+    if as_arithmetic(char) >= as_arithmetic(ascii_char("A")) and as_arithmetic(char) <= as_arithmetic(ascii_char("Z")) {
         return char | __builtin_narrow<u8>(0x20);
     }
     return char;
 }
 
 function ascii_to_upper : (char : u8) -> u8 = {
-    // TODO: support char literals
-    if as_arithmetic(char) >= as_arithmetic(char("a")) or as_arithmetic(char) <= as_arithmetic(char("z")) {
+    if as_arithmetic(char) >= as_arithmetic(ascii_char("a")) or as_arithmetic(char) <= as_arithmetic(ascii_char("z")) {
         return char ^ __builtin_narrow<u8>(0x20);
     }
     return char;
 }
 
 function ascii_is_matched_pair : (lhs : u8, rhs : u8) -> bool = {
-    if lhs == char("(") and rhs == char(")") {
+    if lhs == ascii_char("(") and rhs == ascii_char(")") {
         return true;
     }
-    if lhs == char("[") and rhs == char("]") {
+    if lhs == ascii_char("[") and rhs == ascii_char("]") {
         return true;
     }
-    if lhs == char("<") and rhs == char(">") {
+    if lhs == ascii_char("<") and rhs == ascii_char(">") {
         return true;
     }
-    if lhs == char("{") and rhs == char("}") {
+    if lhs == ascii_char("{") and rhs == ascii_char("}") {
         return true;
     }
     return false;
 }
 
-function char : (literal : u8[1]&) -> u8 = {
-    // TODO: add char literals
+function [@Len] ascii_char : (literal : u8[@Len]&) -> u8 = {
+    // TODO: static_assert
+    runtime_assert(@Len == 1);
     return literal[0];
 }
 
@@ -149,7 +137,7 @@ function[Int] unstringify : (view : StringView) -> TypeIf<Int, IsIntegral<Int>> 
     for char in view:get_iter() {
         runtime_assert(ascii_is_digit(char));
         result *= 10;
-        result += as_arithmetic(char) - as_arithmetic(char("0"));
+        result += as_arithmetic(char) - as_arithmetic(ascii_char("0"));
     }
 
     return result;

--- a/src/glang/lib/std/unicode.c3
+++ b/src/glang/lib/std/unicode.c3
@@ -32,6 +32,12 @@ function make<UnicodeScalar> : (char: StringView) -> UnicodeScalar = {
     return scalar;
 }
 
+function [@Len] char : (char: u8[@Len]&) -> UnicodeScalar = {
+    // TODO: static_assert here
+    runtime_assert(@Len != 0 and @Len <= 4);
+    return make<UnicodeScalar>(sv(&char));
+}
+
 // TODO parsing fix from: https://github.com/DaveDuck321/GrapheneLang/pull/164
 // typedef HasSpaceship<UnicodeScalar> : TrueType
 //
@@ -45,6 +51,10 @@ function make<UnicodeScalar> : (char: StringView) -> UnicodeScalar = {
 
 @operator != : (self : UnicodeScalar, other : UnicodeScalar) -> bool = {
     return self.value != other.value;
+}
+
+function get_iter : (string: StringView&) -> UTF8DecodeIter = {
+    return make<UTF8DecodeIter>(string);
 }
 
 function make<UTF8DecodeIter> : ( string: StringView ) -> UTF8DecodeIter = {

--- a/src/glang/parser/file_info.c3
+++ b/src/glang/parser/file_info.c3
@@ -17,9 +17,9 @@ typedef FilePosition : {
 function generate_position_lookup_table : (program : StringView, allocator: Allocator mut&) -> PositionLookupTable = {
     mut new_lines : Vector<isize> = make<Vector<isize>>(&mut allocator);
 
-    for current_offset in range(program:length()) {
-        if program.buffer.data[current_offset] == "\n"[0] {
-            new_lines:push_back(current_offset);
+    for current_offset_bytes in range(program:length_bytes()) {
+        if program.buffer.data[current_offset_bytes] == ascii_char("\n") {
+            new_lines:push_back(current_offset_bytes);
         }
     }
     return {new_lines};

--- a/src/glang/parser/parser.c3
+++ b/src/glang/parser/parser.c3
@@ -21,12 +21,25 @@ function slice : (cursor : Cursor&, length : isize) -> ProgramSlice = {
     return {cursor.position, cursor.position + length};
 }
 
+// XXX: Hackfix
+typedef ParserChar : {
+    char: u8,
+}
+
+function [IO] write : (io : IO mut&, char : ParserChar) -> TypeIf<void, IsStreamableTextIO<IO>> = {
+    io:write_byte(char.char);
+}
+
+function decode_utf8 : (char : u8) -> ParserChar = {
+    return { char };
+}
+
 function ascii_is_text_token_start_char : (char : u8) -> bool = {
-    return ascii_is_alpha(char) or char == "_"[0];
+    return ascii_is_alpha(char) or char == ascii_char("_");
 }
 
 function ascii_is_text_token_char : (char : u8) -> bool = {
-    return ascii_is_alphanumeric(char) or char == "_"[0];
+    return ascii_is_alphanumeric(char) or char == ascii_char("_");
 }
 
 function get_char : (cursor : Cursor&) -> u8 = {
@@ -34,8 +47,8 @@ function get_char : (cursor : Cursor&) -> u8 = {
 }
 
 function get_char_at_offset : (cursor : Cursor&, offset : isize) -> u8 = {
-    if cursor.position + offset >= cursor.program:length() {
-        return "\0"[0];
+    if cursor.position + offset >= cursor.program:length_bytes() {
+        return ascii_char("\0");
     }
     // TODO: allow direct indexing into a stringview
     return cursor.program.buffer.data[cursor.position + offset];
@@ -50,7 +63,7 @@ function [@Len] is_next : (cursor : Cursor&, token : u8[@Len]&) -> bool = {
 }
 
 function is_next : (cursor : Cursor&, token : StringView) -> bool = {
-    for i in range(token:length()) {
+    for i in range(token:length_bytes()) {
         if cursor:get_char_at_offset(i) != token.buffer.data[i] {
             return false;
         }
@@ -58,7 +71,7 @@ function is_next : (cursor : Cursor&, token : StringView) -> bool = {
 
     if ascii_is_text_token_start_char(token.buffer.data[0]) {
         // Avoid matching a substring in a larger text token
-        return !ascii_is_text_token_char(cursor:get_char_at_offset(token:length()));
+        return !ascii_is_text_token_char(cursor:get_char_at_offset(token:length_bytes()));
     }
     return true;
 }
@@ -77,7 +90,7 @@ function try_skip_next_and_surrounding_white_space : (cursor : Cursor mut&, toke
 function try_skip_next_operator : (cursor : Cursor mut&, operator: StringView) -> bool = {
     // The small lookahead exists so we don't capture the operator part of an assignment
     cursor:try_skip_white_space();
-    if cursor:get_char_at_offset(operator:length()) == "="[0] {
+    if cursor:get_char_at_offset(operator:length_bytes()) == ascii_char("=") {
         return false;
     }
     if cursor:is_next("<<=") or cursor:is_next(">>=") or cursor:is_next("**=") {
@@ -94,7 +107,7 @@ function try_skip_next : (cursor : Cursor mut&, string : StringView) -> bool = {
     if !cursor:is_next(string) {
         return false;
     }
-    cursor.position += string:length();
+    cursor.position += string:length_bytes();
     return true;
 }
 
@@ -215,12 +228,12 @@ function get_next_hex_token : (cursor : Cursor mut&) -> ProgramSlice = {
     while !cursor:is_end_of_token() {
         let next_char : u8 = ascii_to_lower(cursor:get_char());
         if ascii_is_digit(next_char) |
-          (next_char == "a"[0]) |
-          (next_char == "b"[0]) |
-          (next_char == "c"[0]) |
-          (next_char == "d"[0]) |
-          (next_char == "e"[0]) |
-          (next_char == "f"[0]) {
+          (next_char == ascii_char("a")) |
+          (next_char == ascii_char("b")) |
+          (next_char == ascii_char("c")) |
+          (next_char == ascii_char("d")) |
+          (next_char == ascii_char("e")) |
+          (next_char == ascii_char("f")) {
             cursor.position += 1;
             token.end_offset += 1;
         } else {
@@ -243,10 +256,10 @@ function get_next_bool_token : (cursor : Cursor mut&) -> ProgramSlice = {
 
     let start_offset : isize = cursor.position;
     if cursor:try_skip_next_and_surrounding_white_space(true_str) {
-        return {start_offset, start_offset + true_str:length()};
+        return {start_offset, start_offset + true_str:length_bytes()};
     } else {
         runtime_assert(cursor:try_skip_next_and_surrounding_white_space(false_str));
-        return {start_offset, start_offset + false_str:length()};
+        return {start_offset, start_offset + false_str:length_bytes()};
     }
 }
 
@@ -277,7 +290,7 @@ function get_next_numeric_token : (cursor : Cursor mut&) -> NumericToken = {
             cursor.position += 1;
             token.end_offset += 1;
 
-            if cursor:get_char() == char(".") {
+            if cursor:get_char() == ascii_char(".") {
                 if has_seen_decimal_point {
                     syntax_error(&mut cursor, sv("cannot have two decimal points in a floating point constant"));
                 }
@@ -290,7 +303,7 @@ function get_next_numeric_token : (cursor : Cursor mut&) -> NumericToken = {
                 token.end_offset += 1;
             }
 
-            if ascii_to_upper(cursor:get_char()) == char("E") {
+            if ascii_to_upper(cursor:get_char()) == ascii_char("E") {
                 if has_seen_exponent {
                     syntax_error(&mut cursor, sv("cannot have two exponents in a floating point constant"));
                 }
@@ -299,7 +312,7 @@ function get_next_numeric_token : (cursor : Cursor mut&) -> NumericToken = {
                 cursor.position += 1;
                 token.end_offset += 1;
 
-                if cursor:get_char() == char("-") or cursor:get_char() == char("+") {
+                if cursor:get_char() == ascii_char("-") or cursor:get_char() == ascii_char("+") {
                     cursor.position += 1;
                     token.end_offset += 1;
                 }
@@ -439,7 +452,7 @@ function parse_comma_separated_named_members : (cursor : Cursor mut&, matched_pa
 
     mut is_missing_comma : bool = false;
     while !cursor:try_skip_next_and_surrounding_white_space(matched_pair) {
-        if cursor:get_char() == "\0"[0] {
+        if cursor:get_char() == ascii_char("\0") {
             syntax_error_at_position(&mut cursor, start_offset, sv("unterminated list, expected '%'"), matched_pair);
         }
         if is_missing_comma {
@@ -469,7 +482,7 @@ function parse_generic_definition_list : (cursor : Cursor mut&) -> Vector<Generi
 
     mut is_missing_comma : bool = false;
     while !cursor:try_skip_next_and_surrounding_white_space("]") {
-        if cursor:get_char() == "\0"[0] {
+        if cursor:get_char() == ascii_char("\0") {
             syntax_error_at_position(&mut cursor, start_offset, sv("unterminated list, expected ']'"));
         }
         if is_missing_comma {
@@ -479,7 +492,7 @@ function parse_generic_definition_list : (cursor : Cursor mut&) -> Vector<Generi
         // TODO: this is a little ugly, should be refactored
         mut type : int;
         mut name : ProgramSlice;
-        if cursor:get_char() == "@"[0] {
+        if cursor:get_char() == ascii_char("@") {
             type = /* generic numeric */ 1;
             name = cursor:get_next_at_identifier();
         } else {
@@ -540,7 +553,7 @@ function parse_compile_time_constant_list : (cursor : Cursor mut&) -> Vector<Com
 
     mut is_missing_comma : bool = false;
     while !cursor:try_skip_next_and_surrounding_white_space("]") {
-        if cursor:get_char() == "\0"[0] {
+        if cursor:get_char() == ascii_char("\0") {
             syntax_error_at_position(&mut cursor, start_offset, sv("unterminated list, expected ']'"));
         }
         if is_missing_comma {
@@ -573,7 +586,7 @@ function parse_specialization_list : (cursor : Cursor mut&) -> Vector<Specializa
 
     mut specializations : Vector<Specialization> = make<Vector<Specialization>>(&mut cursor.allocator);
     while !cursor:try_skip_next_and_surrounding_white_space(">") {
-        if cursor:get_char() == "\0"[0] {
+        if cursor:get_char() == ascii_char("\0") {
             syntax_error_at_position(&mut cursor, start_offset, sv("unterminated list, expected '>'"));
         }
         if is_missing_comma {
@@ -723,7 +736,7 @@ function parse_list_of_expressions : (cursor : Cursor mut&, end : StringView) ->
     mut is_missing_comma : bool = false;
     while !cursor:try_skip_next_and_surrounding_white_space(end) {
         // TODO: I've done this logic like 5 times, function pointers would eliminate this
-        if cursor:get_char() == "\0"[0] {
+        if cursor:get_char() == ascii_char("\0") {
             syntax_error_at_position(&mut cursor, start_offset, sv("unterminated list, expected '%'"), end);
         }
         if is_missing_comma {
@@ -742,7 +755,7 @@ function parse_list_of_named_expressions : (cursor : Cursor mut&, end : StringVi
     let start_offset : isize = cursor.position;
     mut is_missing_comma : bool = false;
     while !cursor:try_skip_next_and_surrounding_white_space(end) {
-        if cursor:get_char() == "\0"[0] {
+        if cursor:get_char() == ascii_char("\0") {
             syntax_error_at_position(&mut cursor, start_offset, sv("unterminated list, expected '%'"), end);
         }
         if is_missing_comma {
@@ -849,11 +862,11 @@ function is_likely_the_start_of_a_specialized_function : (cursor : Cursor mut&) 
     mut brackets_stack : Vector<u8> = make<Vector<u8>>(&mut cursor.allocator);
     mut lookahead : Cursor = cursor;
     while !lookahead:is_next("\0") {
-        if is_one_of(lookahead:get_char(), "<"[0], "("[0], "{"[0], "["[0]) {
+        if is_one_of(lookahead:get_char(), ascii_char("<"), ascii_char("("), ascii_char("{"), ascii_char("[")) {
             brackets_stack:push_back(lookahead:get_char());
         }
 
-        if is_one_of(lookahead:get_char(), ">"[0], ")"[0], "}"[0], "]"[0]) {
+        if is_one_of(lookahead:get_char(), ascii_char(">"), ascii_char(")"), ascii_char("}"), ascii_char("]")) {
             if !ascii_is_matched_pair(brackets_stack:pop_back(), lookahead:get_char()) {
                 brackets_stack:deallocate();
                 return false;
@@ -974,7 +987,7 @@ function parse_non_operator_expression_prefix : (cursor : Cursor mut&) -> Expres
 function parse_maybe_unary_or_borrow_expression : (cursor : Cursor mut&) -> Expression = {
     let start_offset : isize = cursor.position;
 
-    if is_one_of(cursor:get_char(), "!"[0], "-"[0], "+"[0], "~"[0]) {
+    if is_one_of(cursor:get_char(), ascii_char("!"), ascii_char("-"), ascii_char("+"), ascii_char("~")) {
         let name : ProgramSlice = cursor:slice(1);
         cursor.position += 1;
         cursor:try_skip_white_space();
@@ -1248,7 +1261,7 @@ function parse_scope : (cursor : Cursor mut&) -> Scope = {
 
     mut lines : Vector<Line> = make<Vector<Line>>(&mut cursor.allocator);
     while !cursor:try_skip_next("}") {
-        if cursor:get_char() == "\0"[0] {
+        if cursor:get_char() == ascii_char("\0") {
             syntax_error(&mut cursor, sv("unterminated scope, expected '}'"));
         }
         lines:push_back(cursor:parse_line());

--- a/src/glang/parser/syntax_tree.c3
+++ b/src/glang/parser/syntax_tree.c3
@@ -336,11 +336,11 @@ function write_json_value : (stream : JSON_Stream mut&, slice : ProgramSlice&) -
 }
 
 function write_escaped : (stream : JSON_Stream mut&, text : StringView) -> void = {
-    for char in text:get_iter() {
-        if is_one_of(char, "\""[0], "\\"[0]) {
-            stream.file:write_char("\\"[0]);
+    for char in text.buffer:get_iter() {
+        if is_one_of(char, ascii_char("\""), ascii_char("\\")) {
+            stream.file:write_byte(ascii_char("\\"));
         }
-        stream.file:write_char(char);
+        stream.file:write_byte(char);
     }
 }
 


### PR DESCRIPTION
Our current parsers are mostly correct on utf8 streams but we will occasionally do something like `char: u8 = next_char()`.

I'm trying to rework the library so that its more ergonomic to always do the correct thing... Note: with the correct string helpers we will rarely need to actually decode the utf8 stream -- everything can be a byte-by-byte compare.