### PR TITLE
Fix the CI lint stage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,11 +32,11 @@ jobs:
         run: |
           python3 -m venv "${HOME}/venv"
           source "${HOME}/venv/bin/activate"
-          python3 -m pip install hatch==1.9.4
+          pip install hatch==1.9.4
         shell: bash
       - name: Run ruff
         run: |
-          source "${HOME}/venv/bin/activate
+          source "${HOME}/venv/bin/activate"
           output=$(hatch fmt --linter --check)
           echo "$output" >> $GITHUB_STEP_SUMMARY
           echo "$output" | grep "No errors fixed"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: isort/isort-action@v1
+      - uses: isort/isort-action@v1.1.1
         with:
             requirements-files: requirements.txt
             configuration: --check-only --diff --profile black
@@ -29,9 +29,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install hatch
-        run: python3 -m pip install hatch==1.9.4 --user
+        run: |
+          python3 -m venv venv
+          source activate venv/bin/activate
+          python3 -m pip install hatch==1.9.4
       - name: Run ruff
         run: |
+          source activate venv/bin/activate
           output=$(hatch fmt --linter --check)
           echo "$output" >> $GITHUB_STEP_SUMMARY
           echo "$output" | grep "No errors fixed"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,10 +29,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install hatch
-        run: apt install hatch
+        run: |
+          python3 -m venv "${HOME}/venv"
+          source activate "${HOME}/venv/bin/activate"
+          python3 -m pip install hatch==1.9.4
+        shell: bash
       - name: Run ruff
         run: |
-          source activate venv/bin/activate
+          source activate "${HOME}/venv/bin/activate
           output=$(hatch fmt --linter --check)
           echo "$output" >> $GITHUB_STEP_SUMMARY
           echo "$output" | grep "No errors fixed"
+        shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,10 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install hatch
-        run: |
-          python3 -m venv venv
-          source activate venv/bin/activate
-          python3 -m pip install hatch==1.9.4
+        run: apt install hatch
       - name: Run ruff
         run: |
           source activate venv/bin/activate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,12 +31,12 @@ jobs:
       - name: Install hatch
         run: |
           python3 -m venv "${HOME}/venv"
-          source activate "${HOME}/venv/bin/activate"
+          source "${HOME}/venv/bin/activate"
           python3 -m pip install hatch==1.9.4
         shell: bash
       - name: Run ruff
         run: |
-          source activate "${HOME}/venv/bin/activate
+          source "${HOME}/venv/bin/activate
           output=$(hatch fmt --linter --check)
           echo "$output" >> $GITHUB_STEP_SUMMARY
           echo "$output" | grep "No errors fixed"


### PR DESCRIPTION
The `ubuntu-latest` image update to a version that prevent `pip --user` (and tells us to use `apt`). We can work around this by creating virtual environments.