### PR TITLE
Allow automatic integer literal sizing based on context

### DIFF
--- a/src/glang/codegen/__init__.py
+++ b/src/glang/codegen/__init__.py
@@ -16,6 +16,7 @@ from glang.codegen.expressions import (
     NamedInitializerList,
     StructMemberAccess,
     UnnamedInitializerList,
+    UnsizedConstantExpression,
     VariableReference,
 )
 from glang.codegen.generatable import (
@@ -93,6 +94,7 @@ __all__ = [
     "TypedExpression",
     "UIntType",
     "UnnamedInitializerList",
+    "UnsizedConstantExpression",
     "UnresolvedFunctionSignature",
     "UnresolvedGenericType",
     "UnresolvedHeapArrayType",

--- a/src/glang/codegen/user_facing_errors.py
+++ b/src/glang/codegen/user_facing_errors.py
@@ -196,7 +196,11 @@ class InvalidEscapeSequence(GrapheneError):
         super().__init__(f"Error: \\{escaped_char} is not a valid escape sequence")
 
 
-class InvalidIntSize(GrapheneError):
+class InvalidLiteralError(GrapheneError):
+    pass
+
+
+class InvalidIntSize(InvalidLiteralError):
     def __init__(
         self,
         type_name: str,
@@ -210,7 +214,7 @@ class InvalidIntSize(GrapheneError):
         )
 
 
-class InvalidFloatLiteralTooLarge(GrapheneError):
+class InvalidFloatLiteralTooLarge(InvalidLiteralError):
     def __init__(
         self,
         type_name: str,
@@ -237,7 +241,7 @@ class InvalidFloatLiteralTooLarge(GrapheneError):
         )
 
 
-class InvalidFloatLiteralPrecision(GrapheneError):
+class InvalidFloatLiteralPrecision(InvalidLiteralError):
     def __init__(
         self,
         type_name: str,

--- a/src/glang/graphene_parser.py
+++ b/src/glang/graphene_parser.py
@@ -462,7 +462,9 @@ class ExpressionParser(lp.Interpreter):
         return self.parse(expr, FlattenedExpression)
 
     def HexConstant(self, node: lp.HexConstant) -> FlattenedExpression:
-        const_expr = cg.ConstantExpression(cg.UIntType(), node.value, node.meta)
+        const_expr = cg.UnsizedConstantExpression(
+            cg.UnsizedConstantExpression.Kind.UNSIGNED, node.value, node.meta
+        )
         return FlattenedExpression([const_expr])
 
     def GenericIdentifierConstant(
@@ -474,16 +476,22 @@ class ExpressionParser(lp.Interpreter):
 
         mapped_value = self._generic_mapping.mapping[argument]
         assert isinstance(mapped_value, int)  # TODO: user facing error
-        const_expr = cg.ConstantExpression(cg.IntType(), str(mapped_value), node.meta)
+        const_expr = cg.UnsizedConstantExpression(
+            cg.UnsizedConstantExpression.Kind.SIGNED, str(mapped_value), node.meta
+        )
         return FlattenedExpression([const_expr])
 
     def FloatConstant(self, node: lp.FloatConstant) -> FlattenedExpression:
-        const_expr = cg.ConstantExpression(cg.IEEEFloat(32), node.value, node.meta)
+        const_expr = cg.UnsizedConstantExpression(
+            cg.UnsizedConstantExpression.Kind.FLOAT, node.value, node.meta
+        )
         return FlattenedExpression([const_expr])
 
     def IntConstant(self, node: lp.IntConstant) -> FlattenedExpression:
         # TODO: the parser has already decoded this, why are we undoing it?
-        const_expr = cg.ConstantExpression(cg.IntType(), str(node.value), node.meta)
+        const_expr = cg.UnsizedConstantExpression(
+            cg.UnsizedConstantExpression.Kind.SIGNED, str(node.value), node.meta
+        )
         return FlattenedExpression([const_expr])
 
     def BoolConstant(self, node: lp.BoolConstant) -> FlattenedExpression:

--- a/src/glang/lib/std/unicode.c3
+++ b/src/glang/lib/std/unicode.c3
@@ -222,19 +222,23 @@ function unsafe_decode_utf8_bytes : (bytes: u8[1]) -> UnicodeScalar = {
 }
 
 function unsafe_decode_utf8_bytes : (bytes: u8[2]) -> UnicodeScalar = {
-    return { ((bytes[0] & 0x1f) << 6) | (bytes[1] & 0x3f) };
+    return { (as_u32(bytes[0] & 0x1f) << 6) | as_u32(bytes[1] & 0x3f) };
 }
 
 function unsafe_decode_utf8_bytes : (bytes: u8[3]) -> UnicodeScalar = {
-    return { ((bytes[0] & 0x0f) << 12) | ((bytes[1] & 0x3f) << 6) | (bytes[2] & 0x3f) };
+    return {
+        (as_u32(bytes[0] & 0x0f) << 12) |
+        (as_u32(bytes[1] & 0x3f) << 6)  |
+        as_u32(bytes[2] & 0x3f)
+    };
 }
 
 function unsafe_decode_utf8_bytes : (bytes: u8[4]) -> UnicodeScalar = {
     return {
-        ((bytes[0] & 0x07) << 18) |
-        ((bytes[1] & 0x3f) << 12) |
-        ((bytes[2] & 0x3f) << 6)  |
-        (bytes[3] & 0x3f)
+        (as_u32(bytes[0] & 0x07) << 18) |
+        (as_u32(bytes[1] & 0x3f) << 12) |
+        (as_u32(bytes[2] & 0x3f) << 6)  |
+        as_u32(bytes[3] & 0x3f)
     };
 }
 

--- a/tests/generic_functions/partial_specialization_conflicting_types.c3
+++ b/tests/generic_functions/partial_specialization_conflicting_types.c3
@@ -19,7 +19,7 @@ function main : () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 14, in 'function main: () -> int'
-/// Error: overload resolution for function call 'test_fn<bool, bool>(int)' failed
+/// Error: overload resolution for function call 'test_fn<bool, bool>(Literal<7>)' failed
 /// Available overloads:
 /// - function [[]Ret, Val[]] test_fn<Ret, Val> : (Val) -> TypeIf<Ret, AreEquivalent<Ret, bool>>
 /// - function [[]Ret, Val[]] test_fn<Ret, Val> : (Val) -> TypeIf<Ret, AreEquivalent<Ret, int>>

--- a/tests/misc/ambiguous_function_call.c3
+++ b/tests/misc/ambiguous_function_call.c3
@@ -7,6 +7,6 @@ function main: () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 5, in 'function main: () -> int'
-/// Error: function call 'a(int, int)' is ambiguous. Equally good candidates are:
+/// Error: function call 'a(Literal<0>, Literal<0>)' is ambiguous. Equally good candidates are:
 /// - function a : (i32, i64) -> int      (File '*.c3', line 1)
 /// - function a : (i64, i32) -> int      (File '*.c3', line 2)

--- a/tests/stdlib/unicode/exhaustive_encode.c3
+++ b/tests/stdlib/unicode/exhaustive_encode.c3
@@ -19,7 +19,7 @@ function try_encode_and_decode : (original_scalar: UnicodeScalar) -> void = {
 // This makes no attempt to verify incorrect utf-8 encodings are correctly handled
 function main : () -> int = {
     // U+0000..U+D7FF
-    for char in range(as_arithmetic(0x0000), as_arithmetic(0xD7FF) + 1)
+    for char in range(as_arithmetic(as_u32(0x0000)), as_arithmetic(as_u32(0xD7FF)) + 1)
     {
         try_encode_and_decode({as_logical(char)});
     }
@@ -27,20 +27,19 @@ function main : () -> int = {
     // U+D800–U+DFFF is reserved for the surrogate area
 
     // U+E000..U+FFFF
-    for char in range(as_arithmetic(0xE000), as_arithmetic(0xFFFF) + 1)
+    for char in range(as_arithmetic(as_u32(0xE000)), as_arithmetic(as_u32(0xFFFF)) + 1)
     {
         try_encode_and_decode({as_logical(char)});
     }
 
     // U+10000..U+10FFFF
-    for char in range(as_arithmetic(0x10000), as_arithmetic(0x10FFFF) + 1)
+    for char in range(as_arithmetic(as_u32(0x10000)), as_arithmetic(as_u32(0x10FFFF)) + 1)
     {
         try_encode_and_decode({as_logical(char)});
     }
 
     return 0;
 }
-
 
 /// @COMPILE
 /// @RUN

--- a/tests/structs/init_list_invalid_assignment_with_names.c3
+++ b/tests/structs/init_list_invalid_assignment_with_names.c3
@@ -6,4 +6,4 @@ function main: () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> int'
-/// Error: initializer list of the form '{a: int, b: u8[[]3[]]&, c: bool}' cannot be converted to 'int'
+/// Error: initializer list of the form '{a: Literal<2>, b: u8[[]3[]]&, c: bool}' cannot be converted to 'int'

--- a/tests/structs/init_list_invalid_assignment_without_names.c3
+++ b/tests/structs/init_list_invalid_assignment_without_names.c3
@@ -6,4 +6,4 @@ function main: () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> int'
-/// Error: initializer list of the form '{int, u8[[]3[]]&, bool}' cannot be converted to 'int'
+/// Error: initializer list of the form '{Literal<2>, u8[[]3[]]&, bool}' cannot be converted to 'int'

--- a/tests/structs/init_list_unexpected.c3
+++ b/tests/structs/init_list_unexpected.c3
@@ -7,4 +7,4 @@ function main: () -> i32 = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 2, in 'function main: () -> i32'
-/// Error: initializer list of the form '{int, int}' cannot be converted to 'bool'
+/// Error: initializer list of the form '{Literal<1>, Literal<2>}' cannot be converted to 'bool'

--- a/tests/structs/init_list_with_wrong_name.c3
+++ b/tests/structs/init_list_with_wrong_name.c3
@@ -8,4 +8,4 @@ function main: () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 4, in 'function main: () -> int'
-/// Error: initializer list of the form '{b: int}' cannot be converted to 'typedef my_struct : {a: int}'
+/// Error: initializer list of the form '{b: Literal<2>}' cannot be converted to 'typedef my_struct : {a: int}'

--- a/tests/structs/initializer_list_function_call_no_overloaded.c3
+++ b/tests/structs/initializer_list_function_call_no_overloaded.c3
@@ -15,7 +15,7 @@ function main : () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 13, in 'function main: () -> int'
-/// Error: overload resolution for function call 'get_x({int})' failed
+/// Error: overload resolution for function call 'get_x({Literal<11>})' failed
 /// Available overloads:
 /// - function get_x : (MyStruct1) -> int
 /// - function get_x : (MyStruct2) -> int

--- a/tests/structs/pattern_match_init_list_fail.c3
+++ b/tests/structs/pattern_match_init_list_fail.c3
@@ -9,6 +9,6 @@ function main : () -> int = {
 
 /// @COMPILE; EXPECT ERR
 /// File '*.c3', line 7, in 'function main: () -> int'
-/// Error: overload resolution for function call 'test({b: int, a: int})' failed
+/// Error: overload resolution for function call 'test({b: Literal<50>, a: Literal<100>})' failed
 /// Available overloads:
 /// - function [[]U, V[]] test<U, V> : ({ a: U, b: V }) -> U


### PR DESCRIPTION
This PR adds automatic integer literal size deduction (cool right). The change is relatively easy (and reuses most of the work from initializer lists) but I have also convinced myself that this is evil and we should not merge this PR.

The rules:
- The size of an integral literal is determined based on its usage.
- If no type can be deduced eg. `function [T] fn; fn(<literal>)`, the literal is deduced as `int`
- If there are multiple options we prefer selecting the smallest integral size.
- Integral template arguments act in the same way as literals

Examples:
```
let a : i8 = 7; // Just works now

function foo : ( param: i8 );
function foo : ( param: i128 );
foo(1);                           // Deduces the first overload
```

Where is breaks down:
```
let a : int = 127 + 1; // UB!!???!!
```
Reasoning: the compiler sees the expression `add(Literal<127>, Literal<1>)`, it deduces that `add(i8, i8)` is the smallest integral size that would satisfy this expression -- the overflow causes UB.

There's not much we can do to fix this imo. Deducing int or larger might seem to work but a) doesn't give us the motivating automatic narrow and b) faces the same problem at `INT_MAX`.

I'm opening this PR anyway to show that this is possible. I think a better approach is just to allow integral prefixes.