### PR TITLE
Improve the test runner and switch to `hatch test`

### DIFF
--- a/.github/workflows/graphene_tests.yml
+++ b/.github/workflows/graphene_tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         llvm-version: [17, 18]
-        python-version: [3.12]
+        python-version: [3.13]
         runner: [ubuntu-latest, buildjet-2vcpu-ubuntu-2204-arm]
 
     runs-on: ${{ matrix.runner }}
@@ -25,22 +25,22 @@ jobs:
       GRAPHENE_OPT_CMD: opt-${{ matrix.llvm-version }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        show-progress: false
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install hatch
-      run: pip install hatch==1.9.4
-    - name: Install clang and lli
-      run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh ${{ matrix.llvm-version }}
-        sudo apt-get install -y llvm-${{ matrix.llvm-version }}-runtime
-    - name: Fetch tags
-      run: git fetch --tags --force origin
-    - name: Run tests
-      run: hatch run dev:test
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install hatch
+        run: pip install hatch==1.13.0
+      - name: Install clang and lli
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{ matrix.llvm-version }}
+          sudo apt-get install -y llvm-${{ matrix.llvm-version }}-runtime
+      - name: Fetch tags
+        run: git fetch --tags --force origin
+      - name: Run tests
+        run: hatch test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: isort/isort-action@v1.1.1
         with:
-            requirements-files: requirements.txt
-            configuration: --check-only --diff --profile black
+          requirements-files: requirements.txt
+          configuration: --check-only --diff --profile black
 
   ruff:
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
         run: |
           python3 -m venv "${HOME}/venv"
           source "${HOME}/venv/bin/activate"
-          pip install hatch==1.9.4
+          pip install hatch==1.13.0
         shell: bash
       - name: Run ruff
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = ["interegular~=0.3", "lark==1.1.9"]
 [tool.hatch.envs.dev.scripts]
 bootstrap = "./bootstrap.sh"
 parser = "glang ./src/glang/parser/parser.c3 -o ./dist/parser -O3"
-test = "python tests/run_tests.py {args}"
 
 
 # Style environment. Does not depend on the project.
@@ -54,6 +53,14 @@ check = [
   "isort --check-only --diff --profile black .",
 ]
 fmt = ["isort --profile black .", "black ."]
+
+
+# Built-in hatch test environment.
+[tool.hatch.envs.hatch-test]
+dependencies = ["interegular~=0.3", "lark==1.1.9"]
+
+[tool.hatch.envs.hatch-test.scripts]
+run = "python tests/run_tests.py {args}"
 
 
 # Build configuration. Need a bunch of dependencies because the build process

--- a/src/glang/codegen/debug.py
+++ b/src/glang/codegen/debug.py
@@ -4,7 +4,6 @@ from enum import IntEnum, StrEnum
 from hashlib import file_digest
 from inspect import getmembers
 from pathlib import Path
-from typing import Optional
 
 
 class Tag(StrEnum):
@@ -228,7 +227,7 @@ class DILocation(Metadata):
 
 @dataclass(repr=False, eq=False)
 class DIType(DIScope):
-    name: Optional[str]
+    name: str | None
     _size_in_bits: int
     tag: Tag
 
@@ -244,8 +243,8 @@ class DIBasicType(DIType):
 
 @dataclass(repr=False, eq=False)
 class DICompositeType(DIType):
-    baseType: Optional[DIType]
-    elements: Optional[MetadataList]
+    baseType: DIType | None
+    elements: MetadataList | None
     # TODO
     # scope: DIScope
     # file: DIFile
@@ -264,7 +263,7 @@ class DIDerivedType(DIType):
     # file: DIFile
     # line: int
     baseType: DIType
-    offset: Optional[int]
+    offset: int | None
 
 
 @dataclass(repr=False, eq=False)
@@ -278,7 +277,7 @@ class DISubroutineType(DIType):
 @dataclass(repr=False, eq=False)
 class DILocalVariable(Metadata):
     name: str
-    arg: Optional[int]
+    arg: int | None
     scope: DIScope
     file: DIFile
     line: int

--- a/src/glang/codegen/type_resolution.py
+++ b/src/glang/codegen/type_resolution.py
@@ -804,9 +804,8 @@ class UnresolvedFunctionSignature:
         if self.parameter_pack_argument_name is None:
             if len(self.arguments) != len(target_args):
                 return None
-        else:
-            if len(self.arguments) >= len(target_args):
-                return None
+        elif len(self.arguments) >= len(target_args):
+            return None
 
         # Match the (non-packed) arguments
         for target_arg, unresolved_arg in zip(
@@ -1181,9 +1180,9 @@ class SymbolTable:
         # Find the cheapest valid candidate (doing overload resolution if cost is the same)
         all_candidates.sort(key=lambda item: item[0])
         for _, candidates in groupby(all_candidates, key=lambda item: item[0]):
-            resolved_candidates: list[tuple[FunctionSignature, FunctionDeclaration]] = (
-                []
-            )
+            resolved_candidates: list[
+                tuple[FunctionSignature, FunctionDeclaration]
+            ] = []
             for _, candidate in candidates:
                 try:
                     resolved = self.resolve_function(candidate)

--- a/src/glang/codegen/type_resolution.py
+++ b/src/glang/codegen/type_resolution.py
@@ -1180,9 +1180,9 @@ class SymbolTable:
         # Find the cheapest valid candidate (doing overload resolution if cost is the same)
         all_candidates.sort(key=lambda item: item[0])
         for _, candidates in groupby(all_candidates, key=lambda item: item[0]):
-            resolved_candidates: list[
-                tuple[FunctionSignature, FunctionDeclaration]
-            ] = []
+            resolved_candidates: list[tuple[FunctionSignature, FunctionDeclaration]] = (
+                []
+            )
             for _, candidate in candidates:
                 try:
                     resolved = self.resolve_function(candidate)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -216,7 +216,8 @@ def run_test_print_result(test_path: Path) -> TestStatus:
 
     config = parse_file(test_path)
     if config is None:
-        print(f"SKIPPED '{test_name}' (not a test)")
+        with io_lock:
+            print(f"SKIPPED '{test_name}' (not a test)")
         return TestStatus.SKIPPED_NOT_A_TEST
 
     if config.for_target is not None and config.for_target != HOST_TARGET:

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -121,11 +121,15 @@ class ConfigInterpreter(Interpreter):
         self.config.grep_ir_strs.append(token.strip())
 
 
-def parse_file(path: Path) -> TestConfig:
+def parse_file(path: Path) -> TestConfig | None:
     with path.open(encoding="utf-8") as file:
         lines = [
             line.removeprefix("///").strip() for line in file if line.startswith("///")
         ]
+
+    if not lines:
+        # This is not a test file.
+        return None
 
     tree = lark.parse("\n".join(lines))
     interpreter = ConfigInterpreter()

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,9 +1,11 @@
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
+from sys import exit as sys_exit
 from typing import Any, TypeGuard
 
 from lark import Lark, Token, Tree, v_args
+from lark.exceptions import LarkError
 from lark.visitors import Interpreter
 
 
@@ -131,7 +133,11 @@ def parse_file(path: Path) -> TestConfig | None:
         # This is not a test file.
         return None
 
-    tree = lark.parse("\n".join(lines))
+    try:
+        tree = lark.parse("\n".join(lines))
+    except LarkError as exc:
+        # Print the path and the error message instead of the stack trace.
+        sys_exit(f"Failed to parse test file '{path}'\n{exc}")
     interpreter = ConfigInterpreter()
     interpreter.visit(tree)
 


### PR DESCRIPTION
The test runner now accepts a list of paths, and like `pytest`, these can be either a test file or directory to search for tests. If no paths are provided, then it searches the `tests/` directory instead (the existing behaviour).

I've also (finally) fixed that bug where the test config parser would crash if the file was not a test.

This and some project changes let us use `hatch test [args...]` to launch the test runner, instead of `hatch run dev:test [args...]` that we have to do today.