### PR TITLE
Disable production of all libcalls

### DIFF
--- a/src/glang/driver.py
+++ b/src/glang/driver.py
@@ -229,15 +229,7 @@ class LLVM_IR(Stage):
 
     def optimize(self, args: DriverArguments) -> LLVM_IR:
         # The C library can provide these common definitions, but we do not.
-        extra_args = (
-            []
-            if args.use_crt
-            else [
-                "--disable-builtin=memcpy",
-                "--disable-builtin=memset",
-                "--disable-builtin=memmove",
-            ]
-        )
+        extra_args = [] if args.use_crt else ["--disable-simplify-libcalls"]
         optimized_ir = run_checked(
             [
                 getenv("GRAPHENE_OPT_CMD", "opt"),


### PR DESCRIPTION
I updated LLVM and it broke my tests by inserting a `strlen` :crying_cat_face:

This seems more future-proof than listing them all.